### PR TITLE
Add Dockerfile for product builds

### DIFF
--- a/images/cluster-ingress-operator/Dockerfile
+++ b/images/cluster-ingress-operator/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:7
+
+RUN yum install -y golang make
+
+ENV GOPATH /go
+RUN mkdir $GOPATH
+
+COPY . $GOPATH/src/github.com/openshift/cluster-ingress-operator
+
+RUN cd $GOPATH/src/github.com/openshift/cluster-ingress-operator \
+    && make build \
+    && cp $GOPATH/src/github.com/openshift/cluster-ingress-operator/cluster-ingress-operator /usr/bin/
+
+RUN yum remove -y golang make
+
+ENTRYPOINT ["/usr/bin/cluster-ingress-operator"]
+
+USER 1001
+
+LABEL io.k8s.display-name="OpenShift cluster-ingress-operator" \
+      io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of cluster ingress components." \
+      maintainer="Dan Mace <dmace@redhat.com>"


### PR DESCRIPTION
/cc @openshift/sig-network-edge 

1. Product builds require the Dockerfile in this location
2. Turns out the product builds don't yet support multistage all the way up and down the stack yet; once they do we can replace this Dockerfile with the multistage contents
3. After this merges, we can go ahead and switch CI to point to this file