### PR TITLE
Add operator manifest

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -52,13 +52,24 @@ To run the operator, first deploy the custom resource definitions:
 $ oc create -f deploy/crd.yaml
 ```
 
-Then, use the operator-sdk to launch the operator:
+#### Running with Operator SDK
+
+Use the operator-sdk to launch the operator:
 
 ```
 $ operator-sdk up local namespace default --kubeconfig=$KUBECONFIG
 ```
 
 If you're using the `openshift/release` tooling, `KUBECONFIG` will be something like `$RELEASE_REPO/cluster/test-deploy/gcp-dev/admin.kubeconfig`.
+
+#### Running a Containerized Operator
+
+```
+oc create -f deploy/cluster-ingress-operator.yaml
+```
+
+*In order to run as a container you will need to upload the Cluster Ingress Operator image to your registry*
+
 
 To test the default `ClusterIngress` manifest:
 

--- a/deploy/cluster-ingress-operator.yaml
+++ b/deploy/cluster-ingress-operator.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-ingress-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-ingress-operator
+  template:
+    metadata:
+      labels:
+        name: cluster-ingress-operator
+    spec:
+      containers:
+        - name: cluster-ingress-operator
+          image: openshift/cluster-ingress-operator
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - cluster-ingress-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "cluster-ingress-operator"
+      serviceAccountName: cluster-ingress-operator


### PR DESCRIPTION
This manifest is needed in order to run the
Cluster Ingress Operator as a container inside
OpenShift.

Also added running information to the documentation.