### PR TITLE
Simplify running integration tests

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -81,19 +81,10 @@ $ oc create -f deploy/cr.yaml
 
 ### Integration tests
 
-Integration tests are still very immature. To run them, use the GCP test cluster instructions, create the ClusterIngress custom resource definition:
+Integration tests are still very immature. To run them, use the GCP test cluster instructions and then run the tests with:
 
 ```
-$ oc apply -f deploy/crd.yaml
-```
-
-Then run the tests using the following as a guide:
-
-```
-KUBECONFIG=/some/admin.kubeconfig \
-CLUSTER_NAME=your_gcp_cluster_name \
-WATCH_NAMESPACE=default \
-go test -v -tags integration ./test/integration
+KUBECONFIG=/path/to/admin.kubeconfig CLUSTER_NAME=your_gcp_cluster_name make test-integration
 ```
 
 **Important**: Note that the resources and namespaces used for the test are currently fixed and the tests will clean up after themselves, including deleting the `openshift-cluster-ingress-router` namespace. Don't run these tests in a cluster where data loss is a concern.

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ $(GOBINDATA_BIN):
 test:
 	go test ./...
 
+test-integration:
+	go test -v -tags integration ./test/integration
+
 clean:
 	go clean
 	rm -f $(BIN)
 
-.PHONY: all build generate test clean
+.PHONY: all build generate test test-integration clean


### PR DESCRIPTION
- CRD is created as part of the test
- WATCH_NAMESPACE env is now optional

Command to run integration tests:
```
KUBECONFIG=<admin.kubeconfig> CLUSTER_NAME=<gcp-cluster-name> make test-integration
```