### PR TITLE
Add Namespace for Cluster Ingress Operator

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+    name: openshift-cluster-ingress-operator


### PR DESCRIPTION
The Cluster Ingress Operator Service Account needs a namespace
for isolating permissions.