### PR TITLE
Set deployment order

### DIFF
--- a/deploy/01_namespace.yaml
+++ b/deploy/01_namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+    name: openshift-cluster-ingress-operator

--- a/deploy/02_crd.yaml
+++ b/deploy/02_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusteringresses.ingress.openshift.io
+spec:
+  group: ingress.openshift.io
+  names:
+    kind: ClusterIngress
+    listKind: ClusterIngressList
+    plural: clusteringresses
+    singular: clusteringress
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/03_rbac.yaml
+++ b/deploy/03_rbac.yaml
@@ -1,0 +1,60 @@
+# Account for the operator itself. It should require namespace scoped
+# permissions.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: cluster-ingress-operator
+  namespace: openshift-cluster-ingress-operator
+
+---
+
+# Role for the operator itself.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-ingress-operator
+  namespace: openshift-cluster-ingress-operator
+rules:
+- apiGroups:
+  - ingress.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+
+---
+
+# Binds the operator role to its Service Account.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-ingress-operator:cluster-ingress-operator
+subjects:
+- kind: ServiceAccount
+  name: cluster-ingress-operator
+  namespace: openshift-cluster-ingress-operator
+roleRef:
+  kind: Role
+  name: cluster-ingress-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/04_cluster-ingress-operator.yaml
+++ b/deploy/04_cluster-ingress-operator.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-ingress-operator
+  namespace: openshift-cluster-ingress-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-ingress-operator
+  template:
+    metadata:
+      labels:
+        name: cluster-ingress-operator
+    spec:
+      containers:
+        - name: cluster-ingress-operator
+          image: openshift/cluster-ingress-operator
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - cluster-ingress-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "cluster-ingress-operator"
+      serviceAccountName: cluster-ingress-operator

--- a/deploy/05_cr.yaml
+++ b/deploy/05_cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: "ingress.openshift.io/v1alpha1"
+kind: "ClusterIngress"
+metadata:
+  name: "default"
+spec:
+  ingressDomain: cluster.local
+  highAvailability:
+    type: Cloud


### PR DESCRIPTION
In order to deploy a cluster ingress operator some
resource have to be deployed in a specific order.
The point of this patch is to allow user to issue a
oc create -f deploy/.