### PR TITLE
Makefile: Fix handling of GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ BIN=$(lastword $(subst /, ,$(MAIN_PACKAGE)))
 BINDATA=pkg/manifests/bindata.go
 TEST_BINDATA=test/manifests/bindata.go
 
-GOBINDATA_BIN=$(GOPATH)/bin/go-bindata
+vpath bin/go-bindata $(GOPATH)
+GOBINDATA_BIN=bin/go-bindata
 
 ENVVAR=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 GOOS=linux


### PR DESCRIPTION
Instead of interpolating `GOPATH` directly into the pathname for `go-bindata`, treat it as a search path.

Before this commit, if `GOPATH` had more than one entry, make would fail with the following error message:

    Makefile:20: *** target pattern contains no `%'.  Stop.