### PR TITLE
Add examples directory

### DIFF
--- a/examples/cr.yaml
+++ b/examples/cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: "ingress.openshift.io/v1alpha1"
+kind: "ClusterIngress"
+metadata:
+  name: "default"
+spec:
+  ingressDomain: cluster.local
+  highAvailability:
+    type: Cloud


### PR DESCRIPTION
Some manifests are needed to manage an test the Cluster Ingress Operator, this patch adds the
custom resource creation example.