### PR TITLE
release-local.sh: Fix cp command for manifests

### DIFF
--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -23,7 +23,7 @@ if [[ "${TEMP_COMMIT}" == "true" ]]; then
   git reset --soft HEAD~1
 fi
 
-cp -R manifests/ $MANIFESTS
+cp -R manifests/* $MANIFESTS
 cat manifests/02-deployment.yaml | sed "s~openshift/origin-cluster-ingress-operator:latest~$REPO:$REV~" > "$MANIFESTS/02-deployment.yaml"
 
 echo "Pushed $REPO:$REV"


### PR DESCRIPTION
Fix the `cp` command in `release-local.sh` to copy the manifest files directly into the temporary directory rather than copying the `manifests/` directory as a subdirectory of the temporary directory.  This change causes the subsequent `sed` command to overwrite the `02-deployment.yaml` file.

Before this commit, the `cp` command in `release-local.sh` was copying the `manifests/` directory under the temporary directory, and the subsequent `sed` command was creating a second `02-deployment.yaml` file in the temporary directory, as shown below:

    /tmp/tmp.8gU85s0EC2
    ├── 02-deployment.yaml
    └── manifests
        ├── 00-cluster-role.yaml
        ├── 00-custom-resource-definition.yaml
        ├── 00-namespace.yaml
        ├── 01-cluster-role-binding.yaml
        ├── 01-role-binding.yaml
        ├── 01-role.yaml
        ├── 01-service-account.yaml
        ├── 02-deployment.yaml
        └── image-references

Having this file hierarchy was causing the following error:

    $ oc apply -f /tmp/tmp.8gU85s0EC2
    Error from server (NotFound): error when creating "/tmp/tmp.8gU85s0EC2/02-deployment.yaml": namespaces "openshift-ingress-operator" not found

After this change, the file hierarchy looks as follows:

    /tmp/tmp.zkXMmjzrHV
    ├── 00-cluster-role.yaml
    ├── 00-custom-resource-definition.yaml
    ├── 00-namespace.yaml
    ├── 01-cluster-role-binding.yaml
    ├── 01-role-binding.yaml
    ├── 01-role.yaml
    ├── 01-service-account.yaml
    ├── 02-deployment.yaml
    └── image-references

...and the `oc apply` command succeeds.