### PR TITLE
Add baseline end-to-end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ test: verify
 release-local:
 	MANIFESTS=$(shell mktemp -d) hack/release-local.sh
 
+.PHONY: test-e2e
+test-e2e:
+	KUBERNETES_CONFIG="$(KUBECONFIG)" go test -v -tags e2e ./...
+
 .PHONY: test-integration
 test-integration:
 	hack/test-integration.sh

--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -52,6 +52,12 @@ rules:
   verbs:
   - create
   - get
+
+- apiGroups:
+  - operatorstatus.openshift.io
+  resources:
+  - clusteroperators/status
+  verbs:
   - update
 
 # Mirrored from assets/router/cluster-role.yaml

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,0 +1,68 @@
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+	osv1 "github.com/openshift/cluster-version-operator/pkg/apis/operatorstatus.openshift.io/v1"
+
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestOperatorAvailable(t *testing.T) {
+	co := &osv1.ClusterOperator{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterOperator",
+			APIVersion: "operatorstatus.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-ingress",
+			Namespace: "openshift-ingress-operator",
+		},
+	}
+	err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		if err := sdk.Get(co); err != nil {
+			return false, nil
+		}
+
+		for _, cond := range co.Status.Conditions {
+			if cond.Type == osv1.OperatorAvailable &&
+				cond.Status == osv1.ConditionTrue {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("did not get expected available condition: %v", err)
+	}
+}
+
+func TestDefaultClusterIngressExists(t *testing.T) {
+	ci := &ingressv1alpha1.ClusterIngress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterIngress",
+			APIVersion: "ingress.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-ingress-operator",
+		},
+	}
+	err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		if err := sdk.Get(ci); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("failed to get default ClusterIngress: %v", err)
+	}
+}


### PR DESCRIPTION
#### Add baseline end-to-end tests

Add baseline end-to-end tests for cluster-ingress-operator.

This commit is related to NE-96.

https://jira.coreos.com/browse/NE-96

* `Makefile` (`test-e2e`): Add target.
* `test/e2e/operator_test.go`: Add tests.

#### Fix RBAC for clusteroperator status subresource

Give the operator permission to update the clusteroperator's `status` subresource.

* `manifests/00-cluster-role.yaml`: Allow the operator to update the clusteroperator's `status` subresource.

This change is a followup https://github.com/openshift/cluster-ingress-operator/pull/65.