### PR TITLE
Fix RBAC for clusteroperator status subresource

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -52,6 +52,12 @@ rules:
   verbs:
   - create
   - get
+
+- apiGroups:
+  - operatorstatus.openshift.io
+  resources:
+  - clusteroperators/status
+  verbs:
   - update
 
 # Mirrored from assets/router/cluster-role.yaml


### PR DESCRIPTION
Give the operator permission to update the clusteroperator's `status` subresource.

* `manifests/00-cluster-role.yaml`: Allow the operator to update the clusteroperator's `status` subresource.

This PR is a followup https://github.com/openshift/cluster-ingress-operator/pull/65.