### PR TITLE
Add UserDefinedClusterIngressHA

### DIFF
--- a/pkg/apis/ingress/v1alpha1/clusteringress_types.go
+++ b/pkg/apis/ingress/v1alpha1/clusteringress_types.go
@@ -60,6 +60,11 @@ const (
 	// CloudClusterIngressHA is a type of HA implemented by fronting
 	// the cluster ingress implementation with a Service Load Balancer.
 	CloudClusterIngressHA ClusterIngressHAType = "Cloud"
+	// UserDefinedClusterIngressHA configures the ingress implementation
+	// pods to use host networking, exposing ports 80 and 443 as endpoints
+	// on the host nodes.  Implementing HA for these endpoints is left to
+	// the user.
+	UserDefinedClusterIngressHA ClusterIngressHAType = "UserDefined"
 )
 
 type ClusterIngressHighAvailability struct {


### PR DESCRIPTION
Add a high-availability strategy that exposes ports 80 and 443 as endpoints on the host network and leaves implementation of high-availability up to the user.

* `pkg/apis/ingress/v1alpha1/clusteringress_types.go`: Define `UserDefinedClusterIngressHA`.
* `pkg/manifests/manifests.go` (`RouterDeployment`): If HA type is `UserDefinedClusterIngressHA`, use host network, and configure probes to use localhost (defaulting to the node IP address could cause problems if it is not routable or is blocked by a firewall).
* `pkg/manifests/manifests_test.go`: Test with `nil`, `CloudClusterIngressHA`, and `UserDefinedClusterIngressHA`.

This PR resolves [NE-116](https://jira.coreos.com/browse/NE-116).

---

@ironcladlou

Should I add handling of updates, so the operator deletes any service LB if one exists and the HA strategy us "UserDefined", or do we want to leave that as part of the outstanding work to handle updates?