### PR TITLE
Consume cluster ID from config.openshift.io

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -48,6 +48,7 @@ rules:
   - config.openshift.io
   resources:
   - ingresses
+  - clusterversions
   verbs:
   - get
 

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -19,7 +19,6 @@ const (
 )
 
 type InstallConfig struct {
-	ClusterID  string                `json:"clusterID"`
 	BaseDomain string                `json:"baseDomain"`
 	Platform   InstallConfigPlatform `json:"platform"`
 }


### PR DESCRIPTION
Consume cluster ID from its stable location in config.openshift.io. The previous
field on the install configmap is deprecated.

Blocks https://github.com/openshift/installer/pull/783.