### PR TITLE
Fix selector for internal router service, so that it is correctly populated

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -220,7 +220,7 @@ func (f *Factory) RouterServiceInternal(cr *ingressv1alpha1.ClusterIngress) (*co
 	if s.Spec.Selector == nil {
 		s.Spec.Selector = map[string]string{}
 	}
-	s.Spec.Selector["router"] = name
+	s.Spec.Selector["router"] = "router-" + cr.Name
 
 	return s, nil
 }


### PR DESCRIPTION
Noticed this while fixing up the router tests in origin - the service selector for the internal service adds an extra selector which causes issues. PTAL Thx

/cc @openshift/sig-network-edge 
