### PR TITLE
docs/readme: Add Bugzilla issue reporting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ The operator tries to be useful out of the box by creating a working default dep
 ## How to help
 
 See [HACKING.md](HACKING.md) for development topics.
+
+
+## Reporting issues
+
+Bugs are tracked in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&version=4.0.0&component=Routing).


### PR DESCRIPTION
Bugs are tracked in Bugzilla. GitHub issues are disabled for the repository, so make a note in the README to redirect users to Bugzilla.