### PR TITLE
Restrict operator to masters

### DIFF
--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists 
       strategy:
         type: Recreate
       serviceAccountName: ingress-operator


### PR DESCRIPTION
An operator deployed by the CVO should run on the master.