### PR TITLE
Put router-ca configmap in openshift-config-managed iff needed

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - namespaces
   - secrets
   - serviceaccounts

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -37,6 +37,11 @@ const (
 	// all states. TODO: Make this generic and not tied to the "default" ingress.
 	ClusterIngressFinalizer = "ingress.openshift.io/default-cluster-ingress"
 
+	// GlobalMachineSpecifiedConfigNamespace is the location for global
+	// config.  In particular, the operator will put the configmap with the
+	// CA certificate in this namespace.
+	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
+
 	// caCertSecretName is the name of the secret that holds the CA certificate
 	// that the operator will use to create default certificates for
 	// clusteringresses.
@@ -468,7 +473,7 @@ func (r *reconciler) ensureRouterCACertificate() (*crypto.CA, error) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      caCertConfigMapName,
-			Namespace: r.Namespace,
+			Namespace: GlobalMachineSpecifiedConfigNamespace,
 		},
 	}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: cm.Namespace, Name: cm.Name}, cm)

--- a/pkg/operator/controller/controller_test.go
+++ b/pkg/operator/controller/controller_test.go
@@ -1,0 +1,50 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestShouldPublishRouterCA(t *testing.T) {
+	var (
+		empty = ""
+		x     = "x"
+		y     = "y"
+	)
+	testCases := []struct {
+		description string
+		input       []*string
+		output      bool
+	}{
+		{"no ingresses", []*string{}, false},
+		{"all using no default certificates", []*string{&empty, &empty, &empty}, false},
+		{"all using generated default certificates", []*string{nil, nil, nil}, true},
+		{"all using custom default certificates", []*string{&x, &x, &y}, false},
+		{"mix of custom default certificate and no default certificate", []*string{&x, &x, &empty}, false},
+		{"mix of custom default certificate and generated default certificate", []*string{&x, &x, nil}, true},
+		{"mix of no default certificate and generated default certificate", []*string{&empty, &empty, nil}, true},
+	}
+	for _, tc := range testCases {
+		ingresses := []ingressv1alpha1.ClusterIngress{}
+		for i := range tc.input {
+			ingress := ingressv1alpha1.ClusterIngress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("router-%d", i),
+				},
+				Spec: ingressv1alpha1.ClusterIngressSpec{
+					Replicas:                 1,
+					DefaultCertificateSecret: tc.input[i],
+				},
+			}
+			ingresses = append(ingresses, ingress)
+		}
+		if e, a := tc.output, shouldPublishRouterCA(ingresses); e != a {
+			t.Errorf("%q: expected %t, got %t", tc.description, e, a)
+		}
+
+	}
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -284,6 +284,21 @@ func TestClusterIngressUpdate(t *testing.T) {
 		t.Fatalf("failed to get default router deployment: %v", err)
 	}
 
+	// Wait for the CA certificate configmap to exist.
+	configmap := &corev1.ConfigMap{}
+	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ingresscontroller.GlobalMachineSpecifiedConfigNamespace, Name: "router-ca"}, configmap); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("failed to get CA certificate configmap, will retry: %v", err)
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get CA certificate configmap: %v", err)
+	}
+
 	originalSecret := ci.Spec.DefaultCertificateSecret
 	expectedSecretName := fmt.Sprintf("router-certs-%s", ci.Name)
 	if originalSecret != nil {
@@ -319,10 +334,38 @@ func TestClusterIngressUpdate(t *testing.T) {
 		t.Fatalf("failed to get updated router deployment %s/%s: %v", deployment.Namespace, deployment.Name, err)
 	}
 
+	// Wait for the CA certificate configmap to be deleted.
+	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ingresscontroller.GlobalMachineSpecifiedConfigNamespace, Name: "router-ca"}, configmap); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			t.Logf("failed to get CA certificate configmap, will retry: %v", err)
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe clean-up of CA certificate configmap: %v", err)
+	}
+
 	ci.Spec.DefaultCertificateSecret = originalSecret
 	err = cl.Update(context.TODO(), ci)
 	if err != nil {
 		t.Errorf("failed to reset ClusterIngress: %v", err)
+	}
+
+	// Wait for the CA certificate configmap to be recreated.
+	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ingresscontroller.GlobalMachineSpecifiedConfigNamespace, Name: "router-ca"}, configmap); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("failed to get CA certificate configmap, will retry: %v", err)
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to get recreated CA certificate configmap: %v", err)
 	}
 
 	err = cl.Delete(context.TODO(), secret)
@@ -579,7 +622,7 @@ func TestRouterCACertificate(t *testing.T) {
 	var certData []byte
 	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 		cm := &corev1.ConfigMap{}
-		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-config-managed", Name: "router-ca"}, cm)
+		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ingresscontroller.GlobalMachineSpecifiedConfigNamespace, Name: "router-ca"}, cm)
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -579,7 +579,7 @@ func TestRouterCACertificate(t *testing.T) {
 	var certData []byte
 	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 		cm := &corev1.ConfigMap{}
-		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: "router-ca"}, cm)
+		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-config-managed", Name: "router-ca"}, cm)
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
## Put `router-ca` configmap in `openshift-config-managed`

* `manifests/00-cluster-role.yaml`: Grant the operator create, get, list, watch, and delete access to configmaps.
* `pkg/operator/controller/controller.go` (`globalMachineSpecifiedConfigNamespace`): New constant for the `openshift-config-managed` namespace.
(`ensureRouterCACertificate`): Create the `router-ca` configmap in `openshift-config-managed`.
* `test/e2e/operator_test.go` (`TestRouterCACertificate`): Get the `router-ca` configmap from the `openshift-config-managed` namespace.

## Avoid shadowing the `errors` package

* `pkg/operator/controller/controller.go` (`reconcile`): Rename `errors` variable to `errs` to avoid shadowing the `errors` package.

## Delete unnecessary caching of the CA certificate

* `pkg/operator/controller/controller.go` (`CACert`): Delete.
(`Config`): Delete CACert.
(`ensureRouterCACertificate`): Delete caching.

## Delete `router-ca` configmap if it is not needed

If there exists no clusteringress that uses the generated default certificate, delete the configmap for the CA certificate.

This change makes it straightforward for other components to incorporate cluster-ingress-operator's CA certificate into their trust bundles exactly when some router has a default certificate signed by the CA certificate: The `router-ca` configmap will exist in the `openshift-config-managed` namespace iff the certificate CA should be trusted.

This is a follow-up to #109.

Related to [NE-139](https://jira.coreos.com/browse/NE-139).

* `pkg/operator/controller/controller.go` (`reconcile`): Use the new `shouldPublishRouterCA` function to check whether the CA certificate should be published in a configmap, and use the new `ensureRouterCAIsPublished` method create or update it and the new `ensureRouterCAIsUnpublished` method to delete it as appropriate.
(`ensureRouterForIngress`): Use the new `ensureDefaultCertificateDeleted` method to delete the operator-generated default certificate if `.spec.defaultCertificateSecret` is set on the clusteringress.
(`ensureDefaultCertificateForIngress`): Delete unnecessary comment.  Replace `ensureRouterCACertificate` with `getRouterCA`.
(`ensureDefaultCertificateDeleted`): New function that deletes the operator-generated default certificate.
(`getRouterCA`): New function to get the CA, or create it if it does not already exist, using `ensureRouterCACertificate`.
(`ensureRouterCACertificate`): Rename from this...
(`ensureRouterCACertificateSecret`): ...to this.  Change from returning the CA itself to returning the secret.  Delete unnecessary comment.  Do not create the configmap, which is now the responsibility of the `reconcile` function.
(`shouldPublishRouterCA`): New function that returns a Boolean value indicating whether there exists any clusteringress that uses the generated default certificate (in which case the CA certificate that was used to generate them should be published).
(`ensureRouterCAIsPublished`): New function that creates or updates the configmap as needed.
(`ensureRouterCAIsUnpublished`): New function that deletes the configmap.
* `pkg/operator/controller/controller_test.go` (`TestShouldPublishRouterCA`): New test for `shouldPublishRouterCA`.
* `test/e2e/operator_test.go` (`TestClusterIngressUpdate`): Make sure that the configmap exists for the default clusteringress, is deleted when the clusteringress has a custom default certificate set, and is recreated when the clusteringress is changed back to using a default certificate generated by the operator.