### PR TITLE
Put router-ca configmap in openshift-config-managed

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - namespaces
   - secrets
   - serviceaccounts

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -37,6 +37,11 @@ const (
 	// all states. TODO: Make this generic and not tied to the "default" ingress.
 	ClusterIngressFinalizer = "ingress.openshift.io/default-cluster-ingress"
 
+	// GlobalMachineSpecifiedConfigNamespace is the location for global
+	// config.  In particular, the operator will put the configmap with the
+	// CA certificate in this namespace.
+	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
+
 	// caCertSecretName is the name of the secret that holds the CA certificate
 	// that the operator will use to create default certificates for
 	// clusteringresses.
@@ -468,7 +473,7 @@ func (r *reconciler) ensureRouterCACertificate() (*crypto.CA, error) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      caCertConfigMapName,
-			Namespace: r.Namespace,
+			Namespace: GlobalMachineSpecifiedConfigNamespace,
 		},
 	}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: cm.Namespace, Name: cm.Name}, cm)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -578,7 +578,7 @@ func TestRouterCACertificate(t *testing.T) {
 	var certData []byte
 	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
 		cm := &corev1.ConfigMap{}
-		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: "router-ca"}, cm)
+		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-config-managed", Name: "router-ca"}, cm)
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
## Put router-ca configmap in openshift-config-managed

* `manifests/00-cluster-role.yaml`: Grant the operator create, get, list, watch, and delete access to configmaps.
* `pkg/operator/controller/controller.go` (`GlobalMachineSpecifiedConfigNamespace`): New constant for the "openshift-config-managed" namespace.
(`ensureRouterCACertificate`): Create the `router-ca` configmap in openshift-config-managed.
* `test/e2e/operator_test.go` (`TestRouterCACertificate`): Get the `router-ca` configmap from the `openshift-config-managed` namespace.

---

Per https://github.com/openshift/cluster-kube-apiserver-operator/pull/222#discussion_r252894997.

/hold
This should go in after https://github.com/openshift/cluster-ingress-operator/pull/110.

Should we create a new role for access to the `openshift-config-managed` namespace?