### PR TITLE
Change the ClusterOperator object's name

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -24,7 +24,7 @@ import (
 // syncOperatorStatus computes the operator's current status and therefrom
 // creates or updates the ClusterOperator resource for the operator.
 func (r *reconciler) syncOperatorStatus() error {
-	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: r.Namespace}}
+	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: "ingress"}}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co)
 	isNotFound := errors.IsNotFound(err)
 	if err != nil && !isNotFound {

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -56,14 +56,14 @@ func getClient() (client.Client, string, error) {
 }
 
 func TestOperatorAvailable(t *testing.T) {
-	cl, ns, err := getClient()
+	cl, _, err := getClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	co := &configv1.ClusterOperator{}
 	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
-		if err := cl.Get(context.TODO(), types.NamespacedName{Name: ns}, co); err != nil {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Name: "ingress"}, co); err != nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
Change the name of the ClusterOperator object from "openshift-ingress-operator" to "ingress".

* `pkg/operator/controller/status.go` (`syncOperatorStatus`): Change the ClusterOperator name from "openshift-ingress-operator" to "ingress".
* `test/e2e/operator_test.go` (`TestOperatorAvailable`): Adjust to the new name for the ClusterOperator.