### PR TITLE
WIP: dns: clean DNS records on clusteringress deletion

### DIFF
--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -uo pipefail
 
-WHAT="${WHAT:-all}"
+WHAT="${WHAT:-managed}"
 
 # Disable the CVO
 oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,13 +1,49 @@
 package dns
 
+import "fmt"
+
 // Manager knows how to manage DNS zones only as pertains to routing.
 type Manager interface {
-	// EnsureAlias creates or updates an A record.
-	EnsureAlias(domain, target string) error
+	// Ensure will create or update record.
+	Ensure(record *Record) error
+
+	// Delete will delete record.
+	Delete(record *Record) error
 }
 
 var _ Manager = &NoopManager{}
 
 type NoopManager struct{}
 
-func (_ *NoopManager) EnsureAlias(domain, target string) error { return nil }
+func (_ *NoopManager) Ensure(record *Record) error { return nil }
+func (_ *NoopManager) Delete(record *Record) error { return nil }
+
+// Record represents a DNS record.
+type Record struct {
+	// Type is the DNS record type.
+	Type RecordType
+
+	// Alias are the options for an ALIAS record.
+	Alias *AliasRecord
+}
+
+// RecordType is a DNS record type.
+type RecordType string
+
+const (
+	// ALIASRecord is a DNS ALIAS record.
+	ALIASRecord RecordType = "ALIAS"
+)
+
+// AliasRecord is a DNS ALIAS record.
+type AliasRecord struct {
+	// Domain is the record name.
+	Domain string
+
+	// Target is the mapped destination name of Domain.
+	Target string
+}
+
+func (r *AliasRecord) String() string {
+	return fmt.Sprintf("%s -> %s", r.Domain, r.Target)
+}


### PR DESCRIPTION
When a clusteringress is deleted, ensure that any existing DNS records created
for a load balancer service are also deleted.