### PR TITLE
Add credentials request for AWS.

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -1,0 +1,23 @@
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-ingress
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: cloud-credentials
+    namespace: openshift-ingress-operator
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - elasticloadbalancing:DescribeLoadBalancers
+      - route53:ListHostedZones
+      - route53:ChangeResourceRecordSets
+      - tag:GetResources
+      resource: "*"
+---


### PR DESCRIPTION
Relocated from cloud-credentials-operator repo per recent discussions.
Ingress team will have control over your own creds going forward.