### PR TITLE
dns/aws: update public zone discovery to search parent domains

### DIFF
--- a/pkg/dns/aws/dns_test.go
+++ b/pkg/dns/aws/dns_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+type candidateZone struct {
+	public bool
+	name   string
+}
+
+func (cz candidateZone) ToHostedZone() *route53.HostedZone {
+	return &route53.HostedZone{Name: aws.String(cz.name), Config: &route53.HostedZoneConfig{PrivateZone: aws.Bool(!cz.public)}}
+}
+
+func Test_findNearestPublicParentZone(t *testing.T) {
+	tests := []struct {
+		domain string
+		last   candidateZone
+		zones  []candidateZone
+
+		exp string
+	}{{
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+
+		exp: "",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			public: true,
+			name:   "team-1.staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "team-1.staging.20190205.dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "dev.openshift.com.",
+		}},
+
+		exp: "dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "ging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "staging.20190205.dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "staging.20190205.dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "dev.openshift.com.",
+		}, {
+			name: "staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		last: candidateZone{
+			public: true,
+			name:   "staging.20190205.dev.openshift.com.",
+		},
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "20190205.dev.openshift.com.",
+		}},
+
+		exp: "staging.20190205.dev.openshift.com.",
+	}, {
+		domain: "team-1.staging.20190205.dev.openshift.com.",
+		last: candidateZone{
+			public: true,
+			name:   "20190205.dev.openshift.com.",
+		},
+		zones: []candidateZone{{
+			name: "team-1.staging.20190205.dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "dev.openshift.com.",
+		}, {
+			public: true,
+			name:   "staging.20190205.dev.openshift.com.",
+		}},
+
+		exp: "staging.20190205.dev.openshift.com.",
+	}}
+
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("#%d", idx), func(t *testing.T) {
+			var zones []*route53.HostedZone
+			for _, z := range test.zones {
+				zones = append(zones, z.ToHostedZone())
+			}
+			var last *route53.HostedZone
+			if test.last.name != "" {
+				last = test.last.ToHostedZone()
+			}
+			got := findNearestPublicParentZone(test.domain, zones, last)
+			if test.exp != aws.StringValue(got.Name) {
+				t.Fatalf("exp: %s got: %s", test.exp, aws.StringValue(got.Name))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The installer needs to move towards [1] where the private zone named as `cluster_name.base_domain` ie. `cluster_domain` because of [2], but the
public zone still remains `base_domain` as that cannot be created by instaler.

This means that cluster-ingress-operator cannot use the public r53 zone with the same name as the `base_domain` from `DNS.config.openshift.io` [3] as it will be set to the
`cluster_domain`.

This changes the public zone discovery to find a public zone which is the nearest parent domain to `cluster_domain`.

[1]: [openshift/installer#1169](https://github.com/openshift/installer/pull/1169)
[2]: [openshift/installer#1136](https://github.com/openshift/installer/issues/1136)
[3]: https://github.com/openshift/api/blob/d67473e7f1907b74d1f27706260eecf0bc9f2a52/config/v1/types_dns.go#L28

/cc @wking @openshift/sig-network-edge 