### PR TITLE
Set pathlen constraint on router-ca

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -176,15 +176,7 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to list clusteringresses in namespace %s: %v", r.Namespace, err)
 		}
-		if shouldPublishRouterCA(ingresses.Items) {
-			if err := r.ensureRouterCAIsPublished(); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure router CA was published: %v", err))
-			}
-		} else {
-			if err := r.ensureRouterCAIsUnpublished(); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure router CA was unpublished: %v", err))
-			}
-		}
+		errs = append(errs, r.ensureRouterCAConfigMap(ingresses.Items))
 	}
 
 	return result, utilerrors.NewAggregate(errs)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -41,20 +40,10 @@ const (
 	// all states. TODO: Make this generic and not tied to the "default" ingress.
 	ClusterIngressFinalizer = "ingress.openshift.io/default-cluster-ingress"
 
-	// GlobalMachineSpecifiedConfigNamespace is the location for global
-	// config.  In particular, the operator will put the configmap with the
-	// CA certificate in this namespace.
-	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
-
 	// caCertSecretName is the name of the secret that holds the CA certificate
 	// that the operator will use to create default certificates for
 	// clusteringresses.
 	caCertSecretName = "router-ca"
-
-	// caCertConfigMapName is the name of the config map with the public key for
-	// the CA certificate, which the operator publishes for other operators
-	// to use.
-	caCertConfigMapName = "router-ca"
 )
 
 // New creates the operator controller from configuration. This is the
@@ -710,89 +699,4 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	}
 	updated.Spec.Replicas = &replicas
 	return true, updated
-}
-
-// shouldPublishRouterCA checks if some ClusterIngress uses the default
-// certificate, in which case the CA certificate needs to be published.
-func shouldPublishRouterCA(ingresses []ingressv1alpha1.ClusterIngress) bool {
-	for _, ci := range ingresses {
-		if ci.Spec.DefaultCertificateSecret == nil {
-			return true
-		}
-	}
-	return false
-}
-
-// ensureRouterCAIsPublished ensures a configmap exists with the CA certificate
-// in a well known namespace.
-func (r *reconciler) ensureRouterCAIsPublished() error {
-	secret, err := r.ensureRouterCACertificateSecret()
-	if err != nil {
-		return fmt.Errorf("failed to get CA secret: %v", err)
-	}
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      caCertConfigMapName,
-			Namespace: GlobalMachineSpecifiedConfigNamespace,
-		},
-	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: cm.Namespace, Name: cm.Name}, cm)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get configmap %s/%s: %v", cm.Namespace, cm.Name, err)
-		}
-
-		cm.Data = map[string]string{"ca-bundle.crt": string(secret.Data["tls.crt"])}
-		if err := r.Client.Create(context.TODO(), cm); err != nil {
-			if errors.IsAlreadyExists(err) {
-				return nil
-			}
-
-			return fmt.Errorf("failed to create configmap %s/%s: %v", cm.Namespace, cm.Name, err)
-		}
-
-		logrus.Infof("created configmap %s/%s", cm.Namespace, cm.Name)
-
-		return nil
-	}
-
-	if !bytes.Equal(secret.Data["tls.crt"], []byte(cm.Data["ca-bundle.crt"])) {
-		cm.Data["ca-bundle.crt"] = string(secret.Data["tls.crt"])
-		if err := r.Client.Update(context.TODO(), cm); err != nil {
-			if errors.IsAlreadyExists(err) {
-				return nil
-			}
-
-			return fmt.Errorf("failed to update configmap %s/%s: %v", cm.Namespace, cm.Name, err)
-		}
-
-		logrus.Infof("updated configmap %s/%s", cm.Namespace, cm.Name)
-
-		return nil
-	}
-
-	return nil
-}
-
-// ensureRouterCAIsUnpublished ensures the configmap with the CA certificate is
-// deleted.
-func (r *reconciler) ensureRouterCAIsUnpublished() error {
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      caCertConfigMapName,
-			Namespace: GlobalMachineSpecifiedConfigNamespace,
-		},
-	}
-	if err := r.Client.Delete(context.TODO(), cm); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to delete configmap %s/%s: %v", cm.Namespace, cm.Name, err)
-	}
-
-	logrus.Infof("deleted configmap %s/%s", cm.Namespace, cm.Name)
-
-	return nil
 }

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -12,8 +12,6 @@ import (
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/slice"
 
-	"github.com/openshift/library-go/pkg/crypto"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -39,11 +37,6 @@ const (
 	// considered for processing; this ensures the operator has a chance to handle
 	// all states. TODO: Make this generic and not tied to the "default" ingress.
 	ClusterIngressFinalizer = "ingress.openshift.io/default-cluster-ingress"
-
-	// caCertSecretName is the name of the secret that holds the CA certificate
-	// that the operator will use to create default certificates for
-	// clusteringresses.
-	caCertSecretName = "router-ca"
 )
 
 // New creates the operator controller from configuration. This is the
@@ -604,65 +597,6 @@ func (r *reconciler) ensureDefaultCertificateDeleted(deployment *appsv1.Deployme
 	logrus.Infof("deleted secret %s/%s", secret.Namespace, secret.Name)
 
 	return nil
-}
-
-// getRouterCA gets the CA, or creates it if it does not already exist.
-func (r *reconciler) getRouterCA() (*crypto.CA, error) {
-	secret, err := r.ensureRouterCACertificateSecret()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get CA secret: %v", err)
-	}
-
-	certBytes := secret.Data["tls.crt"]
-	keyBytes := secret.Data["tls.key"]
-
-	ca, err := crypto.GetCAFromBytes(certBytes, keyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get CA from secret %s/%s: %v", secret.Namespace, secret.Name, err)
-	}
-
-	return ca, nil
-}
-
-// ensureRouterCACertificateSecret ensures a CA certificate secret exists that
-// can be used to sign the default certificates for ClusterIngresses.
-func (r *reconciler) ensureRouterCACertificateSecret() (*corev1.Secret, error) {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      caCertSecretName,
-			Namespace: r.Namespace,
-		},
-	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		// TODO Use certrotationcontroller from library-go.
-		signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
-		caConfig, err := crypto.MakeCAConfig(signerName, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make CA config: %v", err)
-		}
-
-		secret.Type = corev1.SecretTypeTLS
-		certBytes, keyBytes, err := caConfig.GetPEMBytes()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get certificate: %v", err)
-		}
-		secret.Data = map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		}
-		if err := r.Client.Create(context.TODO(), secret); err != nil {
-			return nil, fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
-	}
-
-	return secret, nil
 }
 
 // ensureRouterDeleted ensures that any router resources associated with the

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -169,15 +169,13 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 	// TODO: This should be in a different reconciler as it's independent of an
 	// individual ingress. We only really need to trigger this when a
 	// clusteringress is added or deleted...
-	if len(errs) == 0 {
-		// Find all clusteringresses to compute CA states.
-		ingresses := &ingressv1alpha1.ClusterIngressList{}
-		err = r.Client.List(context.TODO(), &client.ListOptions{Namespace: r.Namespace}, ingresses)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to list clusteringresses in namespace %s: %v", r.Namespace, err)
-		}
-		errs = append(errs, r.ensureRouterCAConfigMap(ingresses.Items))
+	// Find all clusteringresses to compute CA states.
+	ingresses := &ingressv1alpha1.ClusterIngressList{}
+	err = r.Client.List(context.TODO(), &client.ListOptions{Namespace: r.Namespace}, ingresses)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list clusteringresses in namespace %s: %v", r.Namespace, err)
 	}
+	errs = append(errs, r.ensureRouterCAConfigMap(ingresses.Items))
 
 	return result, utilerrors.NewAggregate(errs)
 }

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -339,7 +339,12 @@ func (r *reconciler) ensureRouterForIngress(ci *ingressv1alpha1.ClusterIngress, 
 	}
 
 	if ci.Spec.DefaultCertificateSecret == nil {
-		if err := r.ensureDefaultCertificateForIngress(current, ci); err != nil {
+		caSecret, err := r.ensureRouterCACertificateSecret()
+		if err != nil {
+			return fmt.Errorf("failed to get CA secret: %v", err)
+		}
+
+		if err := r.ensureDefaultCertificateForIngress(caSecret, current, ci); err != nil {
 			errs = append(errs, fmt.Errorf("failed to create default certificate for clusteringress %s: %v", ci.Name, err))
 			return utilerrors.NewAggregate(errs)
 		}

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -343,16 +343,9 @@ func (r *reconciler) ensureRouterForIngress(ci *ingressv1alpha1.ClusterIngress, 
 		return utilerrors.NewAggregate(errs)
 	}
 
-	if ci.Spec.DefaultCertificateSecret == nil {
-		if err := r.ensureDefaultCertificateForIngress(caSecret, current, ci); err != nil {
-			errs = append(errs, fmt.Errorf("failed to create default certificate for clusteringress %s: %v", ci.Name, err))
-			return utilerrors.NewAggregate(errs)
-		}
-	} else {
-		if err := r.ensureDefaultCertificateDeleted(current, ci); err != nil {
-			errs = append(errs, fmt.Errorf("failed to delete operator-generated default certificate for clusteringress %s: %v", ci.Name, err))
-			return utilerrors.NewAggregate(errs)
-		}
+	if err := r.ensureDefaultCertificateForIngress(caSecret, current, ci); err != nil {
+		errs = append(errs, err)
+		return utilerrors.NewAggregate(errs)
 	}
 
 	if err := r.ensureMetricsIntegration(ci, internalSvc, deploymentRef); err != nil {

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -518,85 +517,6 @@ func (r *reconciler) ensureInternalRouterServiceForIngress(ci *ingressv1alpha1.C
 	}
 
 	return svc, nil
-}
-
-// ensureDefaultCertificateForIngress ensures that a default certificate exists
-// for a given ClusterIngress.
-func (r *reconciler) ensureDefaultCertificateForIngress(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
-			Namespace: deployment.Namespace,
-		},
-	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		ca, err := r.getRouterCA()
-		if err != nil {
-			return fmt.Errorf("failed to get CA certificate: %v", err)
-		}
-		hostnames := sets.NewString(fmt.Sprintf("*.%s", *ci.Spec.IngressDomain))
-		cert, err := ca.MakeServerCert(hostnames, 0)
-		if err != nil {
-			return fmt.Errorf("failed to make CA: %v", err)
-		}
-
-		secret.Type = corev1.SecretTypeTLS
-		certBytes, keyBytes, err := cert.GetPEMBytes()
-		if err != nil {
-			return fmt.Errorf("failed to get certificate from secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-		secret.Data = map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		}
-		trueVar := true
-		deploymentRef := metav1.OwnerReference{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       deployment.Name,
-			UID:        deployment.UID,
-			Controller: &trueVar,
-		}
-		secret.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
-		if err := r.Client.Create(context.TODO(), secret); err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
-			}
-
-			return nil
-		}
-		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
-	}
-
-	return nil
-}
-
-// ensureDefaultCertificateDeleted ensures any operator-generated default
-// certificate for a given ClusterIngress is deleted.
-func (r *reconciler) ensureDefaultCertificateDeleted(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
-			Namespace: deployment.Namespace,
-		},
-	}
-	err := r.Client.Delete(context.TODO(), secret)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-
-		return fmt.Errorf("failed to delete secret %s/%s: %v", secret.Namespace, secret.Name, err)
-	}
-
-	logrus.Infof("deleted secret %s/%s", secret.Namespace, secret.Name)
-
-	return nil
 }
 
 // ensureRouterDeleted ensures that any router resources associated with the

--- a/pkg/operator/controller/controller_ca_configmap.go
+++ b/pkg/operator/controller/controller_ca_configmap.go
@@ -27,6 +27,22 @@ const (
 	caCertConfigMapName = "router-ca"
 )
 
+// ensureRouterCAConfigMap will create or delete the configmap for the router CA
+// as appropriate.
+func (r *reconciler) ensureRouterCAConfigMap(ingresses []ingressv1alpha1.ClusterIngress) error {
+	if shouldPublishRouterCA(ingresses) {
+		if err := r.ensureRouterCAIsPublished(); err != nil {
+			return fmt.Errorf("failed to ensure router CA was published: %v", err)
+		}
+	} else {
+		if err := r.ensureRouterCAIsUnpublished(); err != nil {
+			return fmt.Errorf("failed to ensure router CA was unpublished: %v", err)
+		}
+	}
+
+	return nil
+}
+
 // shouldPublishRouterCA checks if some ClusterIngress uses the default
 // certificate, in which case the CA certificate needs to be published.
 func shouldPublishRouterCA(ingresses []ingressv1alpha1.ClusterIngress) bool {

--- a/pkg/operator/controller/controller_ca_configmap.go
+++ b/pkg/operator/controller/controller_ca_configmap.go
@@ -1,0 +1,113 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// GlobalMachineSpecifiedConfigNamespace is the location for global
+	// config.  In particular, the operator will put the configmap with the
+	// CA certificate in this namespace.
+	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
+
+	// caCertConfigMapName is the name of the config map with the public key
+	// for the CA certificate, which the operator publishes for other
+	// operators to use.
+	caCertConfigMapName = "router-ca"
+)
+
+// shouldPublishRouterCA checks if some ClusterIngress uses the default
+// certificate, in which case the CA certificate needs to be published.
+func shouldPublishRouterCA(ingresses []ingressv1alpha1.ClusterIngress) bool {
+	for _, ci := range ingresses {
+		if ci.Spec.DefaultCertificateSecret == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureRouterCAIsPublished ensures a configmap exists with the CA certificate
+// in a well known namespace.
+func (r *reconciler) ensureRouterCAIsPublished() error {
+	secret, err := r.ensureRouterCACertificateSecret()
+	if err != nil {
+		return fmt.Errorf("failed to get CA secret: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caCertConfigMapName,
+			Namespace: GlobalMachineSpecifiedConfigNamespace,
+		},
+	}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: cm.Namespace, Name: cm.Name}, cm)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get configmap %s/%s: %v", cm.Namespace, cm.Name, err)
+		}
+
+		cm.Data = map[string]string{"ca-bundle.crt": string(secret.Data["tls.crt"])}
+		if err := r.Client.Create(context.TODO(), cm); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to create configmap %s/%s: %v", cm.Namespace, cm.Name, err)
+		}
+
+		logrus.Infof("created configmap %s/%s", cm.Namespace, cm.Name)
+
+		return nil
+	}
+
+	if !bytes.Equal(secret.Data["tls.crt"], []byte(cm.Data["ca-bundle.crt"])) {
+		cm.Data["ca-bundle.crt"] = string(secret.Data["tls.crt"])
+		if err := r.Client.Update(context.TODO(), cm); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to update configmap %s/%s: %v", cm.Namespace, cm.Name, err)
+		}
+
+		logrus.Infof("updated configmap %s/%s", cm.Namespace, cm.Name)
+
+		return nil
+	}
+
+	return nil
+}
+
+// ensureRouterCAIsUnpublished ensures the configmap with the CA certificate is
+// deleted.
+func (r *reconciler) ensureRouterCAIsUnpublished() error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caCertConfigMapName,
+			Namespace: GlobalMachineSpecifiedConfigNamespace,
+		},
+	}
+	if err := r.Client.Delete(context.TODO(), cm); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete configmap %s/%s: %v", cm.Namespace, cm.Name, err)
+	}
+
+	logrus.Infof("deleted configmap %s/%s", cm.Namespace, cm.Name)
+
+	return nil
+}

--- a/pkg/operator/controller/controller_ca_secret.go
+++ b/pkg/operator/controller/controller_ca_secret.go
@@ -101,21 +101,3 @@ func (r *reconciler) createRouterCASecret(secret *corev1.Secret) error {
 	logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
 	return nil
 }
-
-// getRouterCA gets the CA, or creates it if it does not already exist.
-func (r *reconciler) getRouterCA() (*crypto.CA, error) {
-	secret, err := r.ensureRouterCACertificateSecret()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get CA secret: %v", err)
-	}
-
-	certBytes := secret.Data["tls.crt"]
-	keyBytes := secret.Data["tls.key"]
-
-	ca, err := crypto.GetCAFromBytes(certBytes, keyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get CA from secret %s/%s: %v", secret.Namespace, secret.Name, err)
-	}
-
-	return ca, nil
-}

--- a/pkg/operator/controller/controller_ca_secret.go
+++ b/pkg/operator/controller/controller_ca_secret.go
@@ -22,45 +22,84 @@ const (
 	caCertSecretName = "router-ca"
 )
 
+// routerCASecretName returns the namespaced name for the router CA secret.
+func routerCASecretName(namespace string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      caCertSecretName,
+	}
+}
+
 // ensureRouterCACertificateSecret ensures a CA certificate secret exists that
 // can be used to sign the default certificates for ClusterIngresses.
 func (r *reconciler) ensureRouterCACertificateSecret() (*corev1.Secret, error) {
+	current, err := r.currentRouterCASecret()
+	if err != nil {
+		return nil, err
+	}
+	if current != nil {
+		return current, nil
+	}
+	desired, err := desiredRouterCASecret(r.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.createRouterCASecret(desired); err != nil {
+		return nil, fmt.Errorf("failed to create router CA secret: %v", err)
+	}
+	return r.currentRouterCASecret()
+}
+
+// currentRouterCASecret returns the current router CA secret.
+func (r *reconciler) currentRouterCASecret() (*corev1.Secret, error) {
+	name := routerCASecretName(r.Namespace)
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(context.TODO(), name, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+// desiredRouterCASecret returns the desired router CA secret.  Note: Because
+// the secret has a generated certificate, this function is non-deterministic.
+func desiredRouterCASecret(namespace string) (*corev1.Secret, error) {
+	// TODO Use certrotationcontroller from library-go.
+	signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
+	caConfig, err := crypto.MakeCAConfig(signerName, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make CA config: %v", err)
+	}
+
+	certBytes, keyBytes, err := caConfig.GetPEMBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get certificate: %v", err)
+	}
+
+	name := routerCASecretName(namespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      caCertSecretName,
-			Namespace: r.Namespace,
+			Name:      name.Name,
+			Namespace: name.Namespace,
 		},
-	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		// TODO Use certrotationcontroller from library-go.
-		signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
-		caConfig, err := crypto.MakeCAConfig(signerName, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make CA config: %v", err)
-		}
-
-		secret.Type = corev1.SecretTypeTLS
-		certBytes, keyBytes, err := caConfig.GetPEMBytes()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get certificate: %v", err)
-		}
-		secret.Data = map[string][]byte{
+		Data: map[string][]byte{
 			"tls.crt": certBytes,
 			"tls.key": keyBytes,
-		}
-		if err := r.Client.Create(context.TODO(), secret); err != nil {
-			return nil, fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+		},
+		Type: corev1.SecretTypeTLS,
 	}
-
 	return secret, nil
+}
+
+// createRouterCASecret creates the router CA secret.
+func (r *reconciler) createRouterCASecret(secret *corev1.Secret) error {
+	if err := r.Client.Create(context.TODO(), secret); err != nil {
+		return err
+	}
+	logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+	return nil
 }
 
 // getRouterCA gets the CA, or creates it if it does not already exist.

--- a/pkg/operator/controller/controller_ca_secret.go
+++ b/pkg/operator/controller/controller_ca_secret.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/library-go/pkg/crypto"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// caCertSecretName is the name of the secret that holds the CA certificate
+	// that the operator will use to create default certificates for
+	// clusteringresses.
+	caCertSecretName = "router-ca"
+)
+
+// ensureRouterCACertificateSecret ensures a CA certificate secret exists that
+// can be used to sign the default certificates for ClusterIngresses.
+func (r *reconciler) ensureRouterCACertificateSecret() (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caCertSecretName,
+			Namespace: r.Namespace,
+		},
+	}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		}
+
+		// TODO Use certrotationcontroller from library-go.
+		signerName := fmt.Sprintf("%s@%d", "cluster-ingress-operator", time.Now().Unix())
+		caConfig, err := crypto.MakeCAConfig(signerName, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make CA config: %v", err)
+		}
+
+		secret.Type = corev1.SecretTypeTLS
+		certBytes, keyBytes, err := caConfig.GetPEMBytes()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get certificate: %v", err)
+		}
+		secret.Data = map[string][]byte{
+			"tls.crt": certBytes,
+			"tls.key": keyBytes,
+		}
+		if err := r.Client.Create(context.TODO(), secret); err != nil {
+			return nil, fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		}
+
+		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+	}
+
+	return secret, nil
+}
+
+// getRouterCA gets the CA, or creates it if it does not already exist.
+func (r *reconciler) getRouterCA() (*crypto.CA, error) {
+	secret, err := r.ensureRouterCACertificateSecret()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA secret: %v", err)
+	}
+
+	certBytes := secret.Data["tls.crt"]
+	keyBytes := secret.Data["tls.key"]
+
+	ca, err := crypto.GetCAFromBytes(certBytes, keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA from secret %s/%s: %v", secret.Namespace, secret.Name, err)
+	}
+
+	return ca, nil
+}

--- a/pkg/operator/controller/controller_default_certificate.go
+++ b/pkg/operator/controller/controller_default_certificate.go
@@ -1,0 +1,96 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ensureDefaultCertificateForIngress ensures that a default certificate exists
+// for a given ClusterIngress.
+func (r *reconciler) ensureDefaultCertificateForIngress(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
+			Namespace: deployment.Namespace,
+		},
+	}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		}
+
+		ca, err := r.getRouterCA()
+		if err != nil {
+			return fmt.Errorf("failed to get CA certificate: %v", err)
+		}
+		hostnames := sets.NewString(fmt.Sprintf("*.%s", *ci.Spec.IngressDomain))
+		cert, err := ca.MakeServerCert(hostnames, 0)
+		if err != nil {
+			return fmt.Errorf("failed to make CA: %v", err)
+		}
+
+		secret.Type = corev1.SecretTypeTLS
+		certBytes, keyBytes, err := cert.GetPEMBytes()
+		if err != nil {
+			return fmt.Errorf("failed to get certificate from secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		}
+		secret.Data = map[string][]byte{
+			"tls.crt": certBytes,
+			"tls.key": keyBytes,
+		}
+		trueVar := true
+		deploymentRef := metav1.OwnerReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       deployment.Name,
+			UID:        deployment.UID,
+			Controller: &trueVar,
+		}
+		secret.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
+		if err := r.Client.Create(context.TODO(), secret); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
+			}
+
+			return nil
+		}
+		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+	}
+
+	return nil
+}
+
+// ensureDefaultCertificateDeleted ensures any operator-generated default
+// certificate for a given ClusterIngress is deleted.
+func (r *reconciler) ensureDefaultCertificateDeleted(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
+			Namespace: deployment.Namespace,
+		},
+	}
+	err := r.Client.Delete(context.TODO(), secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete secret %s/%s: %v", secret.Namespace, secret.Name, err)
+	}
+
+	logrus.Infof("deleted secret %s/%s", secret.Namespace, secret.Name)
+
+	return nil
+}

--- a/pkg/operator/controller/controller_default_certificate.go
+++ b/pkg/operator/controller/controller_default_certificate.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/library-go/pkg/crypto"
+
 	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,7 +20,7 @@ import (
 
 // ensureDefaultCertificateForIngress ensures that a default certificate exists
 // for a given ClusterIngress.
-func (r *reconciler) ensureDefaultCertificateForIngress(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
+func (r *reconciler) ensureDefaultCertificateForIngress(caSecret *corev1.Secret, deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
@@ -31,10 +33,11 @@ func (r *reconciler) ensureDefaultCertificateForIngress(deployment *appsv1.Deplo
 			return fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
 
-		ca, err := r.getRouterCA()
+		ca, err := crypto.GetCAFromBytes(caSecret.Data["tls.crt"], caSecret.Data["tls.key"])
 		if err != nil {
-			return fmt.Errorf("failed to get CA certificate: %v", err)
+			return fmt.Errorf("failed to get CA from secret %s/%s: %v", caSecret.Namespace, caSecret.Name, err)
 		}
+
 		hostnames := sets.NewString(fmt.Sprintf("*.%s", *ci.Spec.IngressDomain))
 		cert, err := ca.MakeServerCert(hostnames, 0)
 		if err != nil {

--- a/pkg/operator/controller/controller_default_certificate.go
+++ b/pkg/operator/controller/controller_default_certificate.go
@@ -18,82 +18,123 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// ensureDefaultCertificateForIngress ensures that a default certificate exists
-// for a given ClusterIngress.
+// routerDefaultCertificateSecretName returns the namespaced name for the router
+// default certificate secret.
+func routerDefaultCertificateSecretName(ci *ingressv1alpha1.ClusterIngress, namespace string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("router-certs-%s", ci.Name),
+	}
+}
+
+// ensureDefaultCertificateForIngress creates or deletes an operator-generated
+// default certificate for a given ClusterIngress as appropriate.
 func (r *reconciler) ensureDefaultCertificateForIngress(caSecret *corev1.Secret, deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
-			Namespace: deployment.Namespace,
-		},
-	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, secret)
+	ca, err := crypto.GetCAFromBytes(caSecret.Data["tls.crt"], caSecret.Data["tls.key"])
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-
-		ca, err := crypto.GetCAFromBytes(caSecret.Data["tls.crt"], caSecret.Data["tls.key"])
-		if err != nil {
-			return fmt.Errorf("failed to get CA from secret %s/%s: %v", caSecret.Namespace, caSecret.Name, err)
-		}
-
-		hostnames := sets.NewString(fmt.Sprintf("*.%s", *ci.Spec.IngressDomain))
-		cert, err := ca.MakeServerCert(hostnames, 0)
-		if err != nil {
-			return fmt.Errorf("failed to make CA: %v", err)
-		}
-
-		secret.Type = corev1.SecretTypeTLS
-		certBytes, keyBytes, err := cert.GetPEMBytes()
-		if err != nil {
-			return fmt.Errorf("failed to get certificate from secret %s/%s: %v", secret.Namespace, secret.Name, err)
-		}
-		secret.Data = map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		}
-		trueVar := true
-		deploymentRef := metav1.OwnerReference{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       deployment.Name,
-			UID:        deployment.UID,
-			Controller: &trueVar,
-		}
-		secret.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
-		if err := r.Client.Create(context.TODO(), secret); err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create secret %s/%s: %v", secret.Namespace, secret.Name, err)
-			}
-
-			return nil
-		}
-		logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+		return fmt.Errorf("failed to get CA from secret %s/%s: %v", caSecret.Namespace, caSecret.Name, err)
 	}
-
+	desired, err := desiredRouterDefaultCertificateSecret(ca, deployment, ci)
+	if err != nil {
+		return err
+	}
+	current, err := r.currentRouterDefaultCertificate(ci, deployment)
+	if err != nil {
+		return err
+	}
+	switch {
+	case desired == nil && current == nil:
+		// Nothing to do.
+	case desired == nil && current != nil:
+		if err := r.deleteRouterDefaultCertificate(current); err != nil {
+			return fmt.Errorf("failed to delete default certificate: %v", err)
+		}
+	case desired != nil && current == nil:
+		if err := r.createRouterDefaultCertificate(desired); err != nil {
+			return fmt.Errorf("failed to create default certificate: %v", err)
+		}
+	case desired != nil && current != nil:
+		// TODO Update if CA certificate changed.
+	}
 	return nil
 }
 
-// ensureDefaultCertificateDeleted ensures any operator-generated default
-// certificate for a given ClusterIngress is deleted.
-func (r *reconciler) ensureDefaultCertificateDeleted(deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) error {
+// desiredRouterDefaultCertificateSecret returns the desired default certificate
+// secret.
+func desiredRouterDefaultCertificateSecret(ca *crypto.CA, deployment *appsv1.Deployment, ci *ingressv1alpha1.ClusterIngress) (*corev1.Secret, error) {
+	if ci.Spec.DefaultCertificateSecret != nil {
+		return nil, nil
+	}
+
+	hostnames := sets.NewString(fmt.Sprintf("*.%s", *ci.Spec.IngressDomain))
+	cert, err := ca.MakeServerCert(hostnames, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make certificate: %v", err)
+	}
+
+	certBytes, keyBytes, err := cert.GetPEMBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode certificate: %v", err)
+	}
+
+	name := routerDefaultCertificateSecretName(ci, deployment.Namespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("router-certs-%s", ci.Name),
-			Namespace: deployment.Namespace,
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": certBytes,
+			"tls.key": keyBytes,
 		},
 	}
-	err := r.Client.Delete(context.TODO(), secret)
-	if err != nil {
+	trueVar := true
+	deploymentRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       deployment.Name,
+		UID:        deployment.UID,
+		Controller: &trueVar,
+	}
+	secret.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
+	return secret, nil
+}
+
+// currentRouterDefaultCertificate returns the current router default
+// certificate secret.
+func (r *reconciler) currentRouterDefaultCertificate(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment) (*corev1.Secret, error) {
+	name := routerDefaultCertificateSecretName(ci, deployment.Namespace)
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(context.TODO(), name, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+// createRouterDefaultCertificate creates a router default certificate secret.
+func (r *reconciler) createRouterDefaultCertificate(secret *corev1.Secret) error {
+	if err := r.Client.Create(context.TODO(), secret); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return nil
+		}
+		return err
+	}
+	logrus.Infof("created secret %s/%s", secret.Namespace, secret.Name)
+	return nil
+}
+
+// deleteRouterDefaultCertificate deletes the router default certificate secret.
+func (r *reconciler) deleteRouterDefaultCertificate(secret *corev1.Secret) error {
+	if err := r.Client.Delete(context.TODO(), secret); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-
-		return fmt.Errorf("failed to delete secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		return err
 	}
-
 	logrus.Infof("deleted secret %s/%s", secret.Namespace, secret.Name)
-
 	return nil
 }


### PR DESCRIPTION
## Move CA configmap code to a separate file

* `pkg/operator/controller/controller.go` (`caCertConfigMapName`, `GlobalMachineSpecifiedConfigNamespace`, `shouldPublishRouterCA`, `ensureRouterCAIsPublished`, `ensureRouterCAIsUnpublished`): Move from here...
* `pkg/operator/controller/controller_ca_configmap.go`: ...to this new file.

## Move CA secret code to a separate file

* `pkg/operator/controller/controller.go` (`caCertSecretName`, `ensureRouterCACertificateSecret`, `getRouterCA`): Move from here...
* `pkg/operator/controller/controller_ca_secret.go`: ...to this new file.

## Move default certificate code to a separate file

* `pkg/operator/controller/controller.go` (`ensureDefaultCertificateForIngress`, `ensureDefaultCertificateDeleted`): Move from here...
* `pkg/operator/controller/controller_default_certificate.go`: ...to this new file.

## Factor configmap publishing out of reconcile loop

* `pkg/operator/controller/controller.go`: Refactor configmap publishing...
* `pkg/operator/controller/controller_ca_configmap.go` (`ensureRouterCAConfigMap`): ...into this new function.

## Ensure router CA configmap even if other steps fail

Always call `ensureRouterCAConfigMap`, even if there were failures during reconciliation.

This new approach could prematurely delete the configmap if updating a clusteringress with a custom certificate fails.  However, the old approach had the more serious problem that it could prevent the configmap from ever getting published if reconciliation had a any kind of persistent failure.

* `pkg/operator/controller/controller.go` (`reconcile`): Unconditionally call `ensureRouterCAConfigMap`.

## Refactor router CA secret handling

Refactor `ensureRouterCACertificateSecret` in terms of reconciling current and desired state.

* `pkg/operator/controller/controller_ca_secret.go` (`routerCASecretName`): New function that returns the namespaced name of the secret.
(`ensureRouterCACertificateSecret`): Get current secret using the new `currentRouterCASecret` method.  If it doesn't exist, create it using the new `desiredRouterCASecret` function and `createRouterCASecret` method.
(`currentRouterCASecret`): New method.
(`desiredRouterCASecret`): New function.
(`createRouterCASecret`): New method.

## Delete `getRouterCA`

* `pkg/operator/controller/controller.go` (`ensureRouterForIngress`): Get the CA secret using `ensureRouterCACertificateSecret` and pass it to `ensureDefaultCertificateForIngress`.
* `pkg/operator/controller/controller_ca_secret.go` (`getRouterCA`): Delete.
* `pkg/operator/controller/controller_default_certificate.go` (`ensureDefaultCertificateForIngress`): Add parameter for the CA secret, and use it instead of `getRouterCA`.

## Refactor router CA configmap handling

Refactor `ensureRouterCAConfigMap` in terms of reconciling current and desired state.

* `pkg/operator/controller/controller.go` (`reconcile`): Get the CA secret using `ensureRouterCACertificateSecret` and pass it to `ensureRouterForIngress` and `ensureRouterCAConfigMap`.
(`ensureRouterForIngress`): Add parameter for the CA secret.  Delete use of `ensureRouterCACertificateSecret`.
* `pkg/operator/controller/controller_ca_configmap.go` (`routerCAConfigMapName`): New function that returns the namespaced name of the configmap.
(`ensureRouterCAConfigMap`): Add parameter for the CA secret.  Get the desired configmap using the new `desiredRouterCAConfigMap` function and the current configmaps using the new `currentRouterCAConfigMap` method, and reconcile them using the new `deleteRouterCAConfigMap`, `createRouterCAConfigMap`, and `updateRouterCAConfigMap` methods.
(`ensureRouterCAIsPublished`, `ensureRouterCAIsUnpublished`): Deleted.
(`desiredRouterCAConfigMap`): New function.
(`currentRouterCAConfigMap`, `createRouterCAConfigMap`, `updateRouterCAConfigMap`, `deleteRouterCAConfigMap`): New methods.
(`routerCAConfigMapsEqual`): New function.

## Refactor router default certificate handling

Refactor `ensureDefaultCertificateForIngress` in terms of reconciling current and desired state.

* `pkg/operator/controller/controller.go` (`ensureRouterForIngress`): Always call `ensureDefaultCertificateForIngress`, which now creates or deletes the default certificate secret as appropriate.  Delete call to `ensureDefaultCertificateDeleted`.
* `pkg/operator/controller/controller_default_certificate.go` (`routerDefaultCertificateSecretName`): New function that returns the namespaced name of the secret.
(`ensureDefaultCertificateForIngress`): Get desired and current default certificate secrets using the new `desiredRouterDefaultCertificateSecret` function and `currentRouterDefaultCertificate` method, and reconcile them using the new `deleteRouterDefaultCertificate` and `createRouterDefaultCertificate` methods.
(`desiredRouterDefaultCertificateSecret`): New function.
(`currentRouterDefaultCertificate`, `createRouterDefaultCertificate`, `deleteRouterDefaultCertificate`): New methods.

## Set pathlen constraint on router-ca

Constrain the self-signed CA certificate to a path length of 0.

This PR resolves [NE-148](https://jira.coreos.com/browse/NE-148).

* `pkg/operator/controller/controller_ca_secret.go` (`generateRouterCA`): New function to generate a CA certificate and key with a path length constraint of 0.
(`desiredRouterCASecret`): Use `generateRouterCA`.