### PR TITLE
controller: refactor event triggering

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -157,6 +157,11 @@ func (f *Factory) RouterDeployment(cr *ingressv1alpha1.ClusterIngress) (*appsv1.
 
 	deployment.Name = name
 
+	if deployment.Labels == nil {
+		deployment.Labels = map[string]string{}
+	}
+	deployment.Labels["ingress.openshift.io/clusteringress"] = cr.Name
+
 	if deployment.Spec.Template.Labels == nil {
 		deployment.Spec.Template.Labels = map[string]string{}
 	}
@@ -303,6 +308,7 @@ func (f *Factory) RouterServiceInternal(cr *ingressv1alpha1.ClusterIngress) (*co
 		s.Labels = map[string]string{}
 	}
 	s.Labels["router"] = name
+	s.Labels["ingress.openshift.io/clusteringress"] = cr.Name
 
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -46,7 +46,7 @@ const (
 	// generate a cluster-signed certificate and populate the secret.
 	ServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
 
-	// OwningClusterIngressLabel should be applied to any objects "owned by" to a
+	// OwningClusterIngressLabel should be applied to any objects "owned by" a
 	// clusteringress to aid in selection (especially in cases where an ownerref
 	// can't be established due to namespace boundaries).
 	OwningClusterIngressLabel = "ingress.openshift.io/clusteringress"

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -45,6 +45,11 @@ const (
 	// Annotation used to inform the certificate generation service to
 	// generate a cluster-signed certificate and populate the secret.
 	ServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
+
+	// OwningClusterIngressLabel should be applied to any objects "owned by" to a
+	// clusteringress to aid in selection (especially in cases where an ownerref
+	// can't be established due to namespace boundaries).
+	OwningClusterIngressLabel = "ingress.openshift.io/clusteringress"
 )
 
 func MustAssetReader(asset string) io.Reader {
@@ -160,7 +165,7 @@ func (f *Factory) RouterDeployment(cr *ingressv1alpha1.ClusterIngress) (*appsv1.
 	if deployment.Labels == nil {
 		deployment.Labels = map[string]string{}
 	}
-	deployment.Labels["ingress.openshift.io/clusteringress"] = cr.Name
+	deployment.Labels[OwningClusterIngressLabel] = cr.Name
 
 	if deployment.Spec.Template.Labels == nil {
 		deployment.Spec.Template.Labels = map[string]string{}
@@ -308,7 +313,7 @@ func (f *Factory) RouterServiceInternal(cr *ingressv1alpha1.ClusterIngress) (*co
 		s.Labels = map[string]string{}
 	}
 	s.Labels["router"] = name
-	s.Labels["ingress.openshift.io/clusteringress"] = cr.Name
+	s.Labels[OwningClusterIngressLabel] = cr.Name
 
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -98,8 +98,10 @@ type reconciler struct {
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	result, err := r.reconcile(request)
 	if err != nil {
-		// TODO: Figure out why the controller-runtime logger impl isn't logging
-		// these.
+		// TODO: We're not setting up the controller-runtime logger, so errors we
+		// bubble out are not being logged. For now, log them here, but we need to
+		// redo out logging and wire up the controller-runtime logger because who
+		// knows what else is being eaten.
 		logrus.Errorf("error: %v", err)
 	}
 	return result, err

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -171,7 +171,7 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 		}
 	}
 
-	// TODO: This should be in a different reconciler as it's independnt of an
+	// TODO: This should be in a different reconciler as it's independent of an
 	// individual ingress. We only really need to trigger this when a
 	// clusteringress is added or deleted...
 	if len(errs) == 0 {

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -210,7 +210,7 @@ func (r *reconciler) ensureIngressDeleted(ingress *ingressv1alpha1.ClusterIngres
 	}
 	logrus.Infof("deleted deployment for ingress %s", ingress.Name)
 	// Clean up the finalizer to allow the clusteringress to be deleted.
-	updated := ingress.DeepCopyObject().(*ingressv1alpha1.ClusterIngress)
+	updated := ingress.DeepCopy()
 	if slice.ContainsString(ingress.Finalizers, ClusterIngressFinalizer) {
 		updated.Finalizers = slice.RemoveString(updated.Finalizers, ClusterIngressFinalizer)
 		err = r.Client.Update(context.TODO(), updated)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -100,7 +100,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if err != nil {
 		// TODO: We're not setting up the controller-runtime logger, so errors we
 		// bubble out are not being logged. For now, log them here, but we need to
-		// redo out logging and wire up the controller-runtime logger because who
+		// redo our logging and wire up the controller-runtime logger because who
 		// knows what else is being eaten.
 		logrus.Errorf("error: %v", err)
 	}

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -89,7 +89,7 @@ func desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, infra *confi
 		service.Labels = map[string]string{}
 	}
 	service.Labels["router"] = name.Name
-	service.Labels["ingress.openshift.io/clusteringress"] = ci.Name
+	service.Labels[manifests.OwningClusterIngressLabel] = ci.Name
 
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = map[string]string{}

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -89,6 +89,7 @@ func desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, infra *confi
 		service.Labels = map[string]string{}
 	}
 	service.Labels["router"] = name.Name
+	service.Labels["ingress.openshift.io/clusteringress"] = ci.Name
 
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = map[string]string{}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -122,7 +122,7 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 		operatorController.Watch(&source.Informer{Informer: informer}, &handler.EnqueueRequestsFromMapFunc{
 			ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 				labels := a.Meta.GetLabels()
-				if ingressName, ok := labels["ingress.openshift.io/clusteringress"]; ok {
+				if ingressName, ok := labels[manifests.OwningClusterIngressLabel]; ok {
 					logrus.Infof("queueing %s for related %s", ingressName, a.Meta.GetSelfLink())
 					return []reconcile.Request{
 						{NamespacedName: types.NamespacedName{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -125,10 +125,12 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 				if ingressName, ok := labels[manifests.OwningClusterIngressLabel]; ok {
 					logrus.Infof("queueing %s for related %s", ingressName, a.Meta.GetSelfLink())
 					return []reconcile.Request{
-						{NamespacedName: types.NamespacedName{
-							Namespace: config.Namespace,
-							Name:      ingressName,
-						}},
+						{
+							NamespacedName: types.NamespacedName{
+								Namespace: config.Namespace,
+								Name:      ingressName,
+							},
+						},
 					}
 				} else {
 					return []reconcile.Request{}


### PR DESCRIPTION
Before this change, the ingress controller was receiving edge triggered events
for related resources, requiring us to look up the entire ingress list on every
event because we had no association from the related resources to the ingress.

With this change, related resources which should trigger a clusteringress
reconcile are labelled to refer to their owning clusteringress. This allows the
use of the controller-runtime `Mapper` interface to translate events for related
resources into clusteringress events. Now the ingresss controller can reconcile
a single clusteringress, which is:

1. Easier to understand and refactor, fitting with the way a controller should
be structured
2. Less susceptible to hot loop bugs, as related resource events can now be
coalesced and rate limited at the scope of a single ingress