### PR TITLE
Requeue if status update fails

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -97,6 +97,7 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 		err := r.syncOperatorStatus()
 		if err != nil {
 			logrus.Infof("failed to sync operator status: %v", err)
+			result.Requeue = true
 		}
 	}()
 


### PR DESCRIPTION
Tell the controller to requeue if `syncOperatorStatus` fails.  Failing to update the clusteroperator status may block cluster-version-operator from progressing, so it is important to retry the update immediately, rather than waiting for the next event or the resync interval.

* `pkg/operator/controller/controller.go` (`reconcile`): Set `result.Requeue` to `true` if `syncOperatorStatus` fails.

---

@ironcladlou, @pravisankar, not tested, but does the general idea make sense?