### PR TITLE
controller: clean up error handling

### DIFF
--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -9,6 +9,8 @@ oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-o
 # Uninstall the cluster-ingress-operator
 oc delete -n openshift-ingress-operator deployments/ingress-operator
 oc patch -n openshift-ingress-operator clusteringresses/default --patch '{"metadata":{"finalizers": []}}' --type=merge
+# TODO: this leaves DNS dangling
+oc patch -n openshift-ingress services/router-default --patch '{"metadata":{"finalizers": []}}' --type=merge
 oc delete clusteroperator.config.openshift.io/openshift-ingress-operator
 oc delete --force --grace-period=0 -n openshift-ingress-operator clusteringresses/default
 

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -140,7 +140,7 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 			infraConfig = nil
 		}
 		if dnsConfig == nil || infraConfig == nil {
-			// For now, if the cluster configs are irretrievable, defer reconciliation
+			// For now, if the cluster configs are unavailable, defer reconciliation
 			// because weaving conditionals everywhere to deal with various nil states
 			// is too complicated. It doesn't seem too risky to rely on the invariant
 			// of the cluster config being available.

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -72,9 +72,6 @@ type Config struct {
 // events.
 type reconciler struct {
 	Config
-
-	dnsConfig   *configv1.DNS
-	infraConfig *configv1.Infrastructure
 }
 
 // Reconcile expects request to refer to a clusteringress in the operator
@@ -93,6 +90,8 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, error) {
+	result := reconcile.Result{}
+
 	// TODO: Should this be another controller?
 	defer func() {
 		err := r.syncOperatorStatus()
@@ -111,62 +110,60 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 			// This means the ingress was already deleted/finalized and there are
 			// stale queue entries (or something edge triggering from a related
 			// resource that got deleted async).
-			ingress = nil
+			logrus.Infof("clusteringress %q not found and reconciliation will be skipped", request)
 		} else {
-			return reconcile.Result{}, fmt.Errorf("failed to get clusteringress %q: %v", request, err)
+			// Try again later.
+			logrus.Errorf("failed to get clusteringress %q: %v", request, err)
+			result.RequeueAfter = 10 * time.Second
 		}
+		ingress = nil
 	}
 
 	caSecret, err := r.ensureRouterCACertificateSecret()
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get CA secret: %v", err)
+		return reconcile.Result{}, fmt.Errorf("failed to ensure CA secret: %v", err)
 	}
 
 	// Collect errors as we go.
 	errs := []error{}
-	result := reconcile.Result{}
 
+	// Only reconcile the ingress itself if it exists.
 	if ingress != nil {
-		// Only reconcile the ingress itself if it exists.
 		dnsConfig := &configv1.DNS{}
 		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, dnsConfig); err != nil {
-			errs = append(errs, fmt.Errorf("failed to get dns 'cluster': %v", err))
-			r.dnsConfig = nil
-			if errors.IsNotFound(err) {
-				result.RequeueAfter = 10 * time.Second
-			}
-		} else {
-			r.dnsConfig = dnsConfig
+			logrus.Errorf("failed to get dns 'cluster': %v", err)
+			dnsConfig = nil
 		}
-
 		infraConfig := &configv1.Infrastructure{}
 		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
-			errs = append(errs, fmt.Errorf("failed to get infrastructure 'cluster': %v", err))
-			r.infraConfig = nil
-			if errors.IsNotFound(err) {
-				result.RequeueAfter = 10 * time.Second
-			}
-		} else {
-			r.infraConfig = infraConfig
+			logrus.Errorf("failed to get infrastructure 'cluster': %v", err)
+			infraConfig = nil
 		}
-
-		// Ensure we have all the necessary scaffolding on which to place router
-		// instances.
-		err = r.ensureRouterNamespace()
-		if err != nil {
-			errs = append(errs, err)
-			return result, utilerrors.NewAggregate(errs)
-		}
-
-		if ingress.DeletionTimestamp != nil {
-			// Handle deletion.
-			if err := r.ensureIngressDeleted(ingress); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure ingress deletion: %v", err))
-			}
+		if dnsConfig == nil || infraConfig == nil {
+			// For now, if the cluster configs are irretrievable, defer reconciliation
+			// because weaving conditionals everywhere to deal with various nil states
+			// is too complicated. It doesn't seem too risky to rely on the invariant
+			// of the cluster config being available.
+			result.RequeueAfter = 10 * time.Second
 		} else {
-			// Handle everything else.
-			if err := r.ensureRouterForIngress(ingress, caSecret, &result); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure clusteringress: %v", err))
+			// Ensure we have all the necessary scaffolding on which to place router
+			// instances.
+			err = r.ensureRouterNamespace()
+			if err != nil {
+				errs = append(errs, err)
+				return result, utilerrors.NewAggregate(errs)
+			}
+
+			if ingress.DeletionTimestamp != nil {
+				// Handle deletion.
+				if err := r.ensureIngressDeleted(ingress, dnsConfig); err != nil {
+					errs = append(errs, fmt.Errorf("failed to ensure ingress deletion: %v", err))
+				}
+			} else {
+				// Handle everything else.
+				if err := r.ensureRouterForIngress(ingress, caSecret, infraConfig, dnsConfig, &result); err != nil {
+					errs = append(errs, fmt.Errorf("failed to ensure clusteringress: %v", err))
+				}
 			}
 		}
 	}
@@ -187,9 +184,9 @@ func (r *reconciler) reconcile(request reconcile.Request) (reconcile.Result, err
 
 // ensureIngressDeleted tries to delete ingress, and if successful, will remove
 // the finalizer.
-func (r *reconciler) ensureIngressDeleted(ingress *ingressv1alpha1.ClusterIngress) error {
+func (r *reconciler) ensureIngressDeleted(ingress *ingressv1alpha1.ClusterIngress, dnsConfig *configv1.DNS) error {
 	// TODO: This should also be tied to the HA type.
-	err := r.finalizeLoadBalancerService(ingress)
+	err := r.finalizeLoadBalancerService(ingress, dnsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to finalize load balancer service for %s: %v", ingress.Name, err)
 	}
@@ -289,7 +286,7 @@ func (r *reconciler) ensureRouterNamespace() error {
 
 // ensureRouterForIngress ensures all necessary router resources exist for a
 // given clusteringress.
-func (r *reconciler) ensureRouterForIngress(ci *ingressv1alpha1.ClusterIngress, caSecret *corev1.Secret, result *reconcile.Result) error {
+func (r *reconciler) ensureRouterForIngress(ci *ingressv1alpha1.ClusterIngress, caSecret *corev1.Secret, infraConfig *configv1.Infrastructure, dnsConfig *configv1.DNS, result *reconcile.Result) error {
 	expected, err := r.ManifestFactory.RouterDeployment(ci)
 	if err != nil {
 		return fmt.Errorf("failed to build router deployment: %v", err)
@@ -329,11 +326,11 @@ func (r *reconciler) ensureRouterForIngress(ci *ingressv1alpha1.ClusterIngress, 
 	}
 
 	errs := []error{}
-	lbService, err := r.ensureLoadBalancerService(ci, current)
+	lbService, err := r.ensureLoadBalancerService(ci, current, infraConfig)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure load balancer service for %s: %v", ci.Name, err))
 	}
-	if err = r.ensureDNS(ci, lbService); err != nil {
+	if err = r.ensureDNS(ci, lbService, dnsConfig); err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure DNS for %s: %v", ci.Name, err))
 	}
 

--- a/pkg/operator/controller/controller_dns.go
+++ b/pkg/operator/controller/controller_dns.go
@@ -16,7 +16,7 @@ import (
 // ensureDNS will create DNS records for the given LB service. If service is
 // nil, nothing is done.
 func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) error {
-	dnsRecords, err := r.desiredDNSRecords(ci, service, dnsConfig)
+	dnsRecords, err := desiredDNSRecords(ci, service, dnsConfig)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *core
 // If service is nil, no records are desired. If an ingress domain is in use,
 // records are desired in every specified zone present in the cluster DNS
 // configuration.
-func (r *reconciler) desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) ([]*dns.Record, error) {
+func desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) ([]*dns.Record, error) {
 	records := []*dns.Record{}
 
 	// If no service exists, no DNS records should exist.

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -35,7 +35,7 @@ const (
 // Always returns the current LB service if one exists (whether it already
 // existed or was created during the course of the function).
 func (r *reconciler) ensureLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment, infraConfig *configv1.Infrastructure) (*corev1.Service, error) {
-	desiredLBService, err := r.desiredLoadBalancerService(ci, deployment, infraConfig)
+	desiredLBService, err := desiredLoadBalancerService(ci, deployment, infraConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func loadBalancerServiceName(ci *ingressv1alpha1.ClusterIngress) types.Namespace
 // clusteringress, or nil if an LB service isn't desired. An LB service is
 // desired if the high availability type is Cloud. An LB service will declare an
 // owner reference to the given deployment.
-func (r *reconciler) desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment, infraConfig *configv1.Infrastructure) (*corev1.Service, error) {
+func desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment, infraConfig *configv1.Infrastructure) (*corev1.Service, error) {
 	if ci.Spec.HighAvailability == nil || ci.Spec.HighAvailability.Type != ingressv1alpha1.CloudClusterIngressHA {
 		return nil, nil
 	}
@@ -132,7 +132,7 @@ func (r *reconciler) finalizeLoadBalancerService(ci *ingressv1alpha1.ClusterIngr
 	if service == nil {
 		return nil
 	}
-	records, err := r.desiredDNSRecords(ci, service, dnsConfig)
+	records, err := desiredDNSRecords(ci, service, dnsConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -34,8 +34,8 @@ const (
 // ensureLoadBalancerService creates an LB service if one is desired but absent.
 // Always returns the current LB service if one exists (whether it already
 // existed or was created during the course of the function).
-func (r *reconciler) ensureLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment) (*corev1.Service, error) {
-	desiredLBService, err := r.desiredLoadBalancerService(ci, deployment)
+func (r *reconciler) ensureLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment, infraConfig *configv1.Infrastructure) (*corev1.Service, error) {
+	desiredLBService, err := r.desiredLoadBalancerService(ci, deployment, infraConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func loadBalancerServiceName(ci *ingressv1alpha1.ClusterIngress) types.Namespace
 // clusteringress, or nil if an LB service isn't desired. An LB service is
 // desired if the high availability type is Cloud. An LB service will declare an
 // owner reference to the given deployment.
-func (r *reconciler) desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment) (*corev1.Service, error) {
+func (r *reconciler) desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, deployment *appsv1.Deployment, infraConfig *configv1.Infrastructure) (*corev1.Service, error) {
 	if ci.Spec.HighAvailability == nil || ci.Spec.HighAvailability.Type != ingressv1alpha1.CloudClusterIngressHA {
 		return nil, nil
 	}
@@ -96,10 +96,7 @@ func (r *reconciler) desiredLoadBalancerService(ci *ingressv1alpha1.ClusterIngre
 	}
 	service.Spec.Selector["router"] = name.Name
 
-	if r.infraConfig == nil {
-		return nil, fmt.Errorf("infra config not found")
-	}
-	if r.infraConfig.Status.Platform == configv1.AWSPlatform {
+	if infraConfig.Status.Platform == configv1.AWSPlatform {
 		if service.Annotations == nil {
 			service.Annotations = map[string]string{}
 		}
@@ -127,7 +124,7 @@ func (r *reconciler) currentLoadBalancerService(ci *ingressv1alpha1.ClusterIngre
 // finalizeLoadBalancerService deletes any DNS entries associated with any
 // current LB service associated with the clusteringress and then finalizes the
 // service.
-func (r *reconciler) finalizeLoadBalancerService(ci *ingressv1alpha1.ClusterIngress) error {
+func (r *reconciler) finalizeLoadBalancerService(ci *ingressv1alpha1.ClusterIngress, dnsConfig *configv1.DNS) error {
 	service, err := r.currentLoadBalancerService(ci)
 	if err != nil {
 		return err
@@ -135,7 +132,7 @@ func (r *reconciler) finalizeLoadBalancerService(ci *ingressv1alpha1.ClusterIngr
 	if service == nil {
 		return nil
 	}
-	records, err := r.desiredDNSRecords(ci, service)
+	records, err := r.desiredDNSRecords(ci, service, dnsConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When reconciling a clusteringress, establish the invariant that DNS and
Infrastructure cluster config must exist; this makes it easier to deal with
error handling and there's little we can do without cluster config anyway. Make
it possible to do some additional work when not able to reconcile a
clusteringress. Pass DNS and Infrastructure around where needed for consistency
with the other refactored bits.