### PR TITLE
Process as much as possible during reconcile and requeue in case of any errors

### DIFF
--- a/pkg/operator/controller/controller_dns.go
+++ b/pkg/operator/controller/controller_dns.go
@@ -35,11 +35,6 @@ func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *core
 func desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) ([]*dns.Record, error) {
 	records := []*dns.Record{}
 
-	// If no service exists, no DNS records should exist.
-	if service == nil {
-		return records, nil
-	}
-
 	// If the clusteringress has no ingress domain, we cannot configure any
 	// DNS records.
 	if len(ci.Status.IngressDomain) == 0 {

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -57,8 +57,7 @@ func (r *reconciler) ensureRouterDeleted(ci *ingressv1alpha1.ClusterIngress) err
 	name := routerDeploymentName(ci)
 	deployment.Name = name.Name
 	deployment.Namespace = name.Namespace
-	err := r.Client.Delete(context.TODO(), deployment)
-	if !errors.IsNotFound(err) {
+	if err := r.Client.Delete(context.TODO(), deployment); !errors.IsNotFound(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Do not use Result.Requeue or Result.RequeueAfter when returning errors
as controller will ignore these Requeue/RequeueAfter fields and the current
item is automatically rate limited.

- Some more cleanup:
  * Caller will invoke sub methods only when the prereq args are valid.
  * Tolerate some failures and try to create/update as many related resources
    as possible during reconcile.