### PR TITLE
Improves zapr logger contextual information

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	_   dns.Manager = &Manager{}
-	log             = logf.Logger.WithName("aws-dns-manager")
+	log             = logf.Logger.WithName("dns")
 )
 
 // Manager provides AWS DNS record management. In this implementation, calling

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -14,13 +14,15 @@ var Logger logr.Logger
 
 func init() {
 	// Build a zap development logger.
-	zapLog, err := zap.NewDevelopment()
+	zapLogger, err := zap.NewDevelopment(zap.AddCallerSkip(1))
 	if err != nil {
 		panic(fmt.Sprintf("error building logger: %v", err))
 	}
+	defer zapLogger.Sync()
+
 	// zapr defines an implementation of the Logger
 	// interface built on top of Zap (go.uber.org/zap).
-	Logger = zapr.NewLogger(zapLog)
+	Logger = zapr.NewLogger(zapLogger).WithName("operator")
 	Logger.Info("started zapr logger")
 }
 

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -37,7 +37,7 @@ const (
 	ClusterIngressFinalizer = "ingress.openshift.io/default-cluster-ingress"
 )
 
-var log = logf.Logger.WithName("cluster-ingress-controller")
+var log = logf.Logger.WithName("controller")
 
 // New creates the operator controller from configuration. This is the
 // controller that handles all the logic for implementing ingress based on

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -42,7 +42,7 @@ var (
 	// so only add types here that are _guaranteed_ to exist before the operator
 	// starts.
 	scheme *runtime.Scheme
-	log    = logf.Logger.WithName("base-operator")
+	log    = logf.Logger.WithName("init")
 )
 
 func init() {


### PR DESCRIPTION
PR #126 was merged before implementing final touches to improve contextual information of log messages. This PR prevents reporting the wrapper code as the caller and reduces the verbosity of logger names.