### PR TITLE
Adds info log msg indicating ns/secret used by DNSManager

### DIFF
--- a/cmd/cluster-ingress-operator/main.go
+++ b/cmd/cluster-ingress-operator/main.go
@@ -118,8 +118,9 @@ func createDNSManager(cl client.Client, namespace string, infraConfig *configv1.
 		awsCreds := &corev1.Secret{}
 		err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: cloudCredentialsSecretName}, awsCreds)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get aws creds from %s/%s: %v", awsCreds.Namespace, awsCreds.Name, err)
+			return nil, fmt.Errorf("failed to get aws creds from secret %s/%s: %v", awsCreds.Namespace, awsCreds.Name, err)
 		}
+		log.Info("using aws creds from secret", "namespace", awsCreds.Namespace, "name", awsCreds.Name)
 		manager, err := awsdns.NewManager(awsdns.Config{
 			AccessID:  string(awsCreds.Data["aws_access_key_id"]),
 			AccessKey: string(awsCreds.Data["aws_secret_access_key"]),


### PR DESCRIPTION
PR #122 was closed before PR #126 was implemented. This PR adds an info-level log message stating the secret being used by DNSManager. I found this to be helpful while troubleshooting dns and learning how DNSManager works.