### PR TITLE
Treat HA configuration as immutable

### DIFF
--- a/pkg/operator/controller/controller_dns.go
+++ b/pkg/operator/controller/controller_dns.go
@@ -13,8 +13,8 @@ import (
 
 // ensureDNS will create DNS records for the given LB service. If service is
 // nil, nothing is done.
-func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS, ha ingressv1alpha1.ClusterIngressHighAvailability) error {
-	dnsRecords, err := desiredDNSRecords(ci, service, dnsConfig, ha.Type)
+func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) error {
+	dnsRecords, err := desiredDNSRecords(ci, service, dnsConfig)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func (r *reconciler) ensureDNS(ci *ingressv1alpha1.ClusterIngress, service *core
 // If service is nil, no records are desired. If an ingress domain is in use,
 // records are desired in every specified zone present in the cluster DNS
 // configuration.
-func desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS, haType ingressv1alpha1.ClusterIngressHAType) ([]*dns.Record, error) {
+func desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Service, dnsConfig *configv1.DNS) ([]*dns.Record, error) {
 	records := []*dns.Record{}
 
 	// If no service exists, no DNS records should exist.
@@ -47,7 +47,7 @@ func desiredDNSRecords(ci *ingressv1alpha1.ClusterIngress, service *corev1.Servi
 	}
 
 	// If the HA type is not cloud, then we don't manage DNS.
-	if haType != ingressv1alpha1.CloudClusterIngressHA {
+	if ci.Status.HighAvailability.Type != ingressv1alpha1.CloudClusterIngressHA {
 		return records, nil
 	}
 

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -31,6 +31,11 @@ func TestDesiredRouterDeployment(t *testing.T) {
 				},
 			},
 		},
+		Status: ingressv1alpha1.ClusterIngressStatus{
+			HighAvailability: ingressv1alpha1.ClusterIngressHighAvailability{
+				Type: ingressv1alpha1.NoClusterIngressHA,
+			},
+		},
 	}
 	routerImage := "quay.io/openshift/router:latest"
 	infraConfig := &configv1.Infrastructure{
@@ -39,7 +44,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		},
 	}
 
-	deployment, err := desiredRouterDeployment(ci, routerImage, infraConfig, ingressv1alpha1.NoClusterIngressHA)
+	deployment, err := desiredRouterDeployment(ci, routerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
@@ -129,7 +134,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	}
 
 	ci.Status.IngressDomain = "example.com"
-	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig, ingressv1alpha1.CloudClusterIngressHA)
+	ci.Status.HighAvailability.Type = ingressv1alpha1.CloudClusterIngressHA
+	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
@@ -179,7 +185,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		},
 	}
 	ci.Spec.Replicas = 3
-	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig, ingressv1alpha1.UserDefinedClusterIngressHA)
+	ci.Status.HighAvailability.Type = ingressv1alpha1.UserDefinedClusterIngressHA
+	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}


### PR DESCRIPTION
Determine the effective HA configuration and persist it to the clusteringress's status at the beginning of reconciling a clusteringress. Use the HA configuration from status for subsequent reconciliation steps and future reconciling.

* `pkg/operator/controller/controller.go` (`Reconcile`): Use `enforceEffectiveIngressDomain` to ensure the clusteringress's status has the effective HA configuration in its status.
(`effectiveHighAvailability`): Rename...
(`enforceEffectiveHighAvailability`): ... to this.  Publish the effective HA configuration to the clusteringress's status.
(`ensureIngressDeleted`): Delete `ha` variable.  Delete argument to `finalizeLoadBalancerService`.
(`ensureRouterNamespace`): Delete `ha` variable and argument to `ensureRouterNamespace`, `ensureLoadBalancerService`, `ensureDNS`, and `syncClusterIngressStatus`.
(`syncClusterIngressStatus`): Delete `ha` parameter.  Delete setting HA configuration in the clusteringress's status.
* `pkg/operator/controller/controller_dns.go` (`ensureDNS`): Delete `ha` parameter.  Delete argument to `desiredDNSRecords`.
(`desiredDNSRecords`): Delete `haType` parameter.  Instead, use the HA configuration from the clusteringress's status.
* `pkg/operator/controller/controller_lb.go` (`ensureLoadBalancerService`): Delete `ha` parameter.  Delete argument to `desiredLoadBalancerService`.
(`desiredLoadBalancerService`): Delete `haType` parameter.  Instead, use the HA configuration from the clusteringress's status.
(`finalizeLoadBalancerService`): Delete `ha` parameter.  Delete argument to `desiredDNSRecords`.
* `pkg/operator/controller/controller_router_deployment.go` (`ensureRouterDeployment`): Delete `ha` parameter.  Delete argument to `desiredRouterDeployment`.
(`desiredRouterDeployment`): Delete `haType` parameter.  Instead. use the HA configuration from the clusteringress's status.
* `pkg/operator/controller/controller_router_deployment_test.go:` Pass HA configuration test input in the clusteringress's status.  Fix calls to `desiredRouterDeployment`.