### PR TITLE
Publish global secret with default certificates and keys

### DIFF
--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -34,3 +34,4 @@ if [ "$WHAT" == "all" ]; then
 fi
 
 oc delete -n openshift-config-managed configmaps/router-ca
+oc delete -n openshift-config-managed secrets/router-certs

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -2,7 +2,8 @@
 //
 //   1. Managing a CA for minting self-signed certs
 //   2. Managing self-signed certificates for any clusteringresses which require them
-//   3. Publishing in-use wildcard certificates to `openshift-config-managed`
+//   3. Publishing the CA to `openshift-config-managed`
+//   4. Publishing in-use certificates to `openshift-config-managed`
 package certificate
 
 import (
@@ -21,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -64,6 +66,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, fmt.Errorf("failed to ensure router CA: %v", err)
 	}
 
+	defaultCertificateChanged := false
 	result := reconcile.Result{}
 	errs := []error{}
 	ingress := &ingressv1alpha1.ClusterIngress{}
@@ -96,7 +99,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 				UID:        deployment.UID,
 				Controller: &trueVar,
 			}
-			err = r.ensureDefaultCertificateForIngress(ca, deployment.Namespace, deploymentRef, ingress)
+			defaultCertificateChanged, err = r.ensureDefaultCertificateForIngress(ca, deployment.Namespace, deploymentRef, ingress)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to ensure default cert for %s: %v", ingress.Name, err))
 			}
@@ -106,8 +109,21 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	ingresses := &ingressv1alpha1.ClusterIngressList{}
 	if err := r.client.List(context.TODO(), &client.ListOptions{Namespace: r.operatorNamespace}, ingresses); err != nil {
 		errs = append(errs, fmt.Errorf("failed to list clusteringresses: %v", err))
-	} else if err := r.ensureRouterCAConfigMap(ca, ingresses.Items); err != nil {
-		errs = append(errs, fmt.Errorf("failed to publish router CA: %v", err))
+	} else {
+		if err := r.ensureRouterCAConfigMap(ca, ingresses.Items); err != nil {
+			errs = append(errs, fmt.Errorf("failed to publish router CA: %v", err))
+		}
+
+		if defaultCertificateChanged {
+			secrets := &corev1.SecretList{}
+			if err := r.client.List(context.TODO(), &client.ListOptions{Namespace: "openshift-ingress"}, secrets); err != nil {
+				errs = append(errs, fmt.Errorf("failed to list secrets: %v", err))
+			} else {
+				if err := r.ensureRouterCertsGlobalSecret(secrets.Items, ingresses.Items); err != nil {
+					errs = append(errs, fmt.Errorf("failed to ensure router-certs secret: %v", err))
+				}
+			}
+		}
 	}
 
 	return result, utilerrors.NewAggregate(errs)

--- a/pkg/operator/controller/certificate/publish_certs.go
+++ b/pkg/operator/controller/certificate/publish_certs.go
@@ -1,0 +1,161 @@
+package certificate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ensureRouterCertsGlobalSecret will create, update, or delete the global
+// certificates secret as appropriate.
+func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []ingressv1alpha1.ClusterIngress) error {
+	desired, err := desiredRouterCertsGlobalSecret(secrets, ingresses)
+	if err != nil {
+		return err
+	}
+	current, err := r.currentRouterCertsGlobalSecret()
+	if err != nil {
+		return err
+	}
+	switch {
+	case desired == nil && current == nil:
+		// Nothing to do.
+	case desired == nil && current != nil:
+		if deleted, err := r.deleteRouterCertsGlobalSecret(current); err != nil {
+			return fmt.Errorf("failed to ensure router certificates secret was unpublished: %v", err)
+		} else if deleted {
+			r.recorder.Eventf(current, "Normal", "UnpublishedRouterCertificates", "Unpublished router certificates")
+		}
+	case desired != nil && current == nil:
+		if created, err := r.createRouterCertsGlobalSecret(desired); err != nil {
+			return fmt.Errorf("failed to ensure router certificates secret was published: %v", err)
+		} else if created {
+			r.recorder.Eventf(desired, "Normal", "PublishedRouterCertificates", "Published router certificates")
+		}
+	case desired != nil && current != nil:
+		if updated, err := r.updateRouterCertsGlobalSecret(current, desired); err != nil {
+			return fmt.Errorf("failed to update published router certificates secret: %v", err)
+		} else if updated {
+			r.recorder.Eventf(desired, "Normal", "UpdatedPublishedRouterCertificates", "Updated the published router certificates")
+		}
+	}
+	return nil
+}
+
+// desiredRouterCertsGlobalSecret returns the desired router-certs global
+// secret.
+func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []ingressv1alpha1.ClusterIngress) (*corev1.Secret, error) {
+	if len(ingresses) == 0 || len(secrets) == 0 {
+		return nil, nil
+	}
+
+	nameToSecret := map[string]*corev1.Secret{}
+	for i, certSecret := range secrets {
+		nameToSecret[certSecret.Name] = &secrets[i]
+	}
+
+	ingressToSecret := map[*ingressv1alpha1.ClusterIngress]*corev1.Secret{}
+	for i, ingress := range ingresses {
+		secretName := controller.RouterDefaultCertificateSecretName(&ingress, "")
+		name := secretName.Name
+		if ingress.Spec.DefaultCertificateSecret != nil && len(*ingress.Spec.DefaultCertificateSecret) > 0 {
+			name = *ingress.Spec.DefaultCertificateSecret
+		}
+		if secret, ok := nameToSecret[name]; ok {
+			ingressToSecret[&ingresses[i]] = secret
+		}
+	}
+
+	name := controller.RouterCertsGlobalSecretName()
+	globalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Data: map[string][]byte{},
+	}
+	for ingress, certSecret := range ingressToSecret {
+		if len(ingress.Status.IngressDomain) == 0 {
+			continue
+		}
+		pem := bytes.Join([][]byte{
+			certSecret.Data["tls.crt"],
+			certSecret.Data["tls.key"],
+		}, nil)
+		globalSecret.Data[ingress.Status.IngressDomain] = pem
+	}
+	return globalSecret, nil
+}
+
+// currentRouterCertsGlobalSecret returns the current router-certs global
+// secret.
+func (r *reconciler) currentRouterCertsGlobalSecret() (*corev1.Secret, error) {
+	name := controller.RouterCertsGlobalSecretName()
+	secret := &corev1.Secret{}
+	if err := r.client.Get(context.TODO(), name, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+// createRouterCertsGlobalSecret creates a router-certs global secret.  Returns
+// true if the secret was created, false otherwise.
+func (r *reconciler) createRouterCertsGlobalSecret(secret *corev1.Secret) (bool, error) {
+	if err := r.client.Create(context.TODO(), secret); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// updateRouterCertsGlobalSecret updates the router-certs global secret.
+// Returns true if the secret was updated, false otherwise.
+func (r *reconciler) updateRouterCertsGlobalSecret(current, desired *corev1.Secret) (bool, error) {
+	if routerCertsSecretsEqual(current, desired) {
+		return false, nil
+	}
+	updated := current.DeepCopy()
+	updated.Data = desired.Data
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// deleteRouterCertsGlobalSecret deletes the router-certs global secret.
+// Returns true if the secret was deleted, false otherwise.
+func (r *reconciler) deleteRouterCertsGlobalSecret(secret *corev1.Secret) (bool, error) {
+	if err := r.client.Delete(context.TODO(), secret); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// routerCertsSecretsEqual compares two router-certs secrets.  Returns true if
+// the secrets should be considered equal for the purpose of determining whether
+// an update is necessary, false otherwise
+func routerCertsSecretsEqual(a, b *corev1.Secret) bool {
+	if !reflect.DeepEqual(a.Data, b.Data) {
+		return false
+	}
+	return true
+}

--- a/pkg/operator/controller/certificate/publish_certs_test.go
+++ b/pkg/operator/controller/certificate/publish_certs_test.go
@@ -1,0 +1,208 @@
+package certificate
+
+import (
+	"bytes"
+	"testing"
+
+	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newSecret returns a secret with the specified name and with data fields
+// "tls.crt" and "tls.key" containing valid PEM-encoded certificate and private
+// key, respectively.  Note that the certificate and key are valid only in the
+// sense that they respect PEM encoding, not that they have any particular
+// subject etc.
+func newSecret(name string) corev1.Secret {
+	const (
+		// defaultCert is a PEM-encoded certificate.
+		defaultCert = `-----BEGIN CERTIFICATE-----
+MIIDIjCCAgqgAwIBAgIBBjANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
+ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
+dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
+Y29tMB4XDTE2MDExMzE5NDA1N1oXDTI2MDExMDE5NDA1N1owfDEYMBYGA1UEAxMP
+d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIEwJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
+hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoTB0V4YW1wbGUx
+EDAOBgNVBAsTB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM0B
+u++oHV1wcphWRbMLUft8fD7nPG95xs7UeLPphFZuShIhhdAQMpvcsFeg+Bg9PWCu
+v3jZljmk06MLvuWLfwjYfo9q/V+qOZVfTVHHbaIO5RTXJMC2Nn+ACF0kHBmNcbth
+OOgF8L854a/P8tjm1iPR++vHnkex0NH7lyosVc/vAgMBAAGjDTALMAkGA1UdEwQC
+MAAwDQYJKoZIhvcNAQEFBQADggEBADjFm5AlNH3DNT1Uzx3m66fFjqqrHEs25geT
+yA3rvBuynflEHQO95M/8wCxYVyuAx4Z1i4YDC7tx0vmOn/2GXZHY9MAj1I8KCnwt
+Jik7E2r1/yY0MrkawljOAxisXs821kJ+Z/51Ud2t5uhGxS6hJypbGspMS7OtBbw7
+8oThK7cWtCXOldNF6ruqY1agWnhRdAq5qSMnuBXuicOP0Kbtx51a1ugE3SnvQenJ
+nZxdtYUXvEsHZC/6bAtTfNh+/SwgxQJuL2ZM+VG3X2JIKY8xTDui+il7uTh422lq
+wED8uwKl+bOj6xFDyw4gWoBxRobsbFaME8pkykP1+GnKDberyAM=
+-----END CERTIFICATE-----
+`
+		// defaultKey is a PEM-encoded private key.
+		defaultKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDNAbvvqB1dcHKYVkWzC1H7fHw+5zxvecbO1Hiz6YRWbkoSIYXQ
+EDKb3LBXoPgYPT1grr942ZY5pNOjC77li38I2H6Pav1fqjmVX01Rx22iDuUU1yTA
+tjZ/gAhdJBwZjXG7YTjoBfC/OeGvz/LY5tYj0fvrx55HsdDR+5cqLFXP7wIDAQAB
+AoGAfE7P4Zsj6zOzGPI/Izj7Bi5OvGnEeKfzyBiH9Dflue74VRQkqqwXs/DWsNv3
+c+M2Y3iyu5ncgKmUduo5X8D9To2ymPRLGuCdfZTxnBMpIDKSJ0FTwVPkr6cYyyBk
+5VCbc470pQPxTAAtl2eaO1sIrzR4PcgwqrSOjwBQQocsGAECQQD8QOra/mZmxPbt
+bRh8U5lhgZmirImk5RY3QMPI/1/f4k+fyjkU5FRq/yqSyin75aSAXg8IupAFRgyZ
+W7BT6zwBAkEA0A0ugAGorpCbuTa25SsIOMxkEzCiKYvh0O+GfGkzWG4lkSeJqGME
+keuJGlXrZNKNoCYLluAKLPmnd72X2yTL7wJARM0kAXUP0wn324w8+HQIyqqBj/gF
+Vt9Q7uMQQ3s72CGu3ANZDFS2nbRZFU5koxrggk6lRRk1fOq9NvrmHg10AQJABOea
+pgfj+yGLmkUw8JwgGH6xCUbHO+WBUFSlPf+Y50fJeO+OrjqPXAVKeSV3ZCwWjKT4
+9viXJNJJ4WfF0bO/XwJAOMB1wQnEOSZ4v+laMwNtMq6hre5K8woqteXICoGcIWe8
+u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
+-----END RSA PRIVATE KEY-----
+`
+	)
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte(defaultCert),
+			"tls.key": []byte(defaultKey),
+		},
+	}
+}
+
+// newClusterIngress returns a new clusteringress with the specified name,
+// default certificate secret name (or nil if empty), and ingress domain, for
+// use as a test input.
+func newClusterIngress(name, defaultCertificateSecretName, domain string) ingressv1alpha1.ClusterIngress {
+	clusteringress := ingressv1alpha1.ClusterIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: ingressv1alpha1.ClusterIngressStatus{
+			IngressDomain: domain,
+		},
+	}
+	if len(defaultCertificateSecretName) != 0 {
+		clusteringress.Spec.DefaultCertificateSecret = &defaultCertificateSecretName
+	}
+	return clusteringress
+}
+
+// TestDesiredRouterCertsGlobalSecret verifies that we get the expected global
+// secret for the default clusteringress and for various combinations of
+// clusteringresses and default certificate secrets.
+func TestDesiredRouterCertsGlobalSecret(t *testing.T) {
+	type testInputs struct {
+		ingresses []ingressv1alpha1.ClusterIngress
+		secrets   []corev1.Secret
+	}
+	type testOutputs struct {
+		secret *corev1.Secret
+	}
+	var (
+		defaultCert = newSecret("router-certs-default")
+		defaultCI   = newClusterIngress("default", "", "apps.my.devcluster.openshift.com")
+
+		ci1 = newClusterIngress("ci1", "s1", "dom1")
+		ci2 = newClusterIngress("ci2", "s2", "dom2")
+		s1  = newSecret("s1")
+		s2  = newSecret("s2")
+		// data has the PEM for defaultCert, s1, and s2 (which all have
+		// the same certificate and key).
+		data = bytes.Join([][]byte{
+			s1.Data["tls.crt"],
+			s1.Data["tls.key"],
+		}, nil)
+	)
+	testCases := []struct {
+		description string
+		inputs      testInputs
+		output      testOutputs
+	}{
+		{
+			description: "default configuration",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{defaultCI},
+				[]corev1.Secret{defaultCert},
+			},
+			output: testOutputs{
+				&corev1.Secret{
+					Data: map[string][]byte{"apps.my.devcluster.openshift.com": data},
+				},
+			},
+		},
+		{
+			description: "no ingresses",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{},
+				[]corev1.Secret{},
+			},
+			output: testOutputs{nil},
+		},
+		{
+			description: "no secrets",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{ci1},
+				[]corev1.Secret{},
+			},
+			output: testOutputs{nil},
+		},
+		{
+			description: "missing secret",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{ci1, ci2},
+				[]corev1.Secret{s1},
+			},
+			output: testOutputs{
+				&corev1.Secret{
+					Data: map[string][]byte{"dom1": data},
+				},
+			},
+		},
+		{
+			description: "extra secret",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{ci2},
+				[]corev1.Secret{s1, s2},
+			},
+			output: testOutputs{
+				&corev1.Secret{
+					Data: map[string][]byte{"dom2": data},
+				},
+			},
+		},
+		{
+			description: "perfect match",
+			inputs: testInputs{
+				[]ingressv1alpha1.ClusterIngress{ci1, ci2},
+				[]corev1.Secret{s1, s2},
+			},
+			output: testOutputs{
+				&corev1.Secret{
+					Data: map[string][]byte{
+						"dom1": data,
+						"dom2": data,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		expected := tc.output.secret
+		actual, err := desiredRouterCertsGlobalSecret(tc.inputs.secrets, tc.inputs.ingresses)
+		if err != nil {
+			t.Errorf("failed to get desired router-ca global secret: %v", err)
+			continue
+		}
+		if expected == nil || actual == nil {
+			if expected != nil {
+				t.Errorf("%q: expected %v, got nil", tc.description, expected)
+			}
+			if actual != nil {
+				t.Errorf("%q: expected nil, got %v", tc.description, actual)
+			}
+			continue
+		}
+		if !routerCertsSecretsEqual(expected, actual) {
+			t.Errorf("%q: expected %v, got %v", tc.description, expected, actual)
+		}
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -23,6 +23,11 @@ const (
 	// for the CA certificate, which the operator publishes for other
 	// operators to use.
 	caCertConfigMapName = "router-ca"
+
+	// routerCertsGlobalSecretName is the name of the secret with the
+	// default certificates and their keys, which the operator publishes for
+	// other operators to use.
+	routerCertsGlobalSecretName = "router-certs"
 )
 
 // RouterDeploymentName returns the namespaced name for the router deployment.
@@ -46,6 +51,15 @@ func RouterCAConfigMapName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: GlobalMachineSpecifiedConfigNamespace,
 		Name:      caCertConfigMapName,
+	}
+}
+
+// RouterCertsGlobalSecretName returns the namespaced name for the router certs
+// secret.
+func RouterCertsGlobalSecretName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: GlobalMachineSpecifiedConfigNamespace,
+		Name:      routerCertsGlobalSecretName,
 	}
 }
 


### PR DESCRIPTION
Publish a `router-certs` secret in the `openshift-config-managed` namespace that has all routers' configured default certificates and their private keys.

This commit resolves [NE-166](https://jira.coreos.com/browse/NE-166).

* `pkg/operator/controller/names.go` (`routerCertsGlobalSecretName`): New constant.
(`RouterCertsGlobalSecretName`): New function to generate the namespaced name for the secret with the routers' default certificates and their keys.
* `pkg/operator/controller/certificate/publish_certs.go`: New file.
(`ensureRouterCertsGlobalSecret`): New method that creates, updates, or deletes the secret as needed.
(`desiredRouterCertsGlobalSecret`): New function.
(`currentRouterCertsGlobalSecret`, `createRouterCertsGlobalSecret`, `updateRouterCertsGlobalSecret`, `deleteRouterCertsGlobalSecret`): New methods.
(`routerCertsSecretsEqual`): New function.
* `pkg/operator/controller/certificate/publish_certs_test.go`: New file.
(`newSecret`, `newClusterIngress`): New functions.
(`TestDesiredRouterCertsGlobalSecret`): New test for `desiredRouterCertsGlobalSecret`.
* `pkg/operator/controller/certificate/default_cert.go`
(`ensureDefaultCertificateForIngress`): Return a Boolean value indicating whether or not the method created, updated, or deleted the secret for the default certificate.
* `pkg/operator/controller/certificate/controller.go` (`Reconcile`): Use the new return value from `ensureDefaultCertificateForIngress`.  If it is true, list secrets and call the new `ensureRouterCertsGlobalSecret` method.
* `hack/uninstall.sh`: Delete the `router-certs` secret.