### PR TITLE
Remove unnecessary IsAlreadyExists() checks during resource creation.

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -34,11 +34,10 @@ const (
 	OperatorRole             = "assets/router/operator-role.yaml"
 	OperatorRoleBinding      = "assets/router/operator-role-binding.yaml"
 
-	MetricsServiceMonitorAsset = "assets/router/metrics/service-monitor.yaml"
-	MetricsClusterRole         = "assets/router/metrics/cluster-role.yaml"
-	MetricsClusterRoleBinding  = "assets/router/metrics/cluster-role-binding.yaml"
-	MetricsRole                = "assets/router/metrics/role.yaml"
-	MetricsRoleBinding         = "assets/router/metrics/role-binding.yaml"
+	MetricsClusterRole        = "assets/router/metrics/cluster-role.yaml"
+	MetricsClusterRoleBinding = "assets/router/metrics/cluster-role-binding.yaml"
+	MetricsRole               = "assets/router/metrics/role.yaml"
+	MetricsRoleBinding        = "assets/router/metrics/role-binding.yaml"
 
 	// Annotation used to inform the certificate generation service to
 	// generate a cluster-signed certificate and populate the secret.

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -282,11 +282,10 @@ func (r *reconciler) ensureRouterNamespace() error {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router cluster role %s: %v", cr.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), cr); err == nil {
-			log.Info("created router cluster role", "name", cr.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), cr); err != nil {
 			return fmt.Errorf("failed to create router cluster role %s: %v", cr.Name, err)
 		}
+		log.Info("created router cluster role", "name", cr.Name)
 	}
 
 	ns, err := r.ManifestFactory.RouterNamespace()
@@ -297,11 +296,10 @@ func (r *reconciler) ensureRouterNamespace() error {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router namespace %q: %v", ns.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), ns); err == nil {
-			log.Info("created router namespace", "name", ns.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), ns); err != nil {
 			return fmt.Errorf("failed to create router namespace %s: %v", ns.Name, err)
 		}
+		log.Info("created router namespace", "name", ns.Name)
 	}
 
 	sa, err := r.ManifestFactory.RouterServiceAccount()
@@ -312,11 +310,10 @@ func (r *reconciler) ensureRouterNamespace() error {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router service account %s/%s: %v", sa.Namespace, sa.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), sa); err == nil {
-			log.Info("created router service account", "namespace", sa.Namespace, "name", sa.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), sa); err != nil {
 			return fmt.Errorf("failed to create router service account %s/%s: %v", sa.Namespace, sa.Name, err)
 		}
+		log.Info("created router service account", "namespace", sa.Namespace, "name", sa.Name)
 	}
 
 	crb, err := r.ManifestFactory.RouterClusterRoleBinding()
@@ -327,11 +324,10 @@ func (r *reconciler) ensureRouterNamespace() error {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router cluster role binding %s: %v", crb.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), crb); err == nil {
-			log.Info("created router cluster role binding", "name", crb.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), crb); err != nil {
 			return fmt.Errorf("failed to create router cluster role binding %s: %v", crb.Name, err)
 		}
+		log.Info("created router cluster role binding", "name", crb.Name)
 	}
 
 	return nil
@@ -393,11 +389,10 @@ func (r *reconciler) ensureMetricsIntegration(ci *ingressv1alpha1.ClusterIngress
 		}
 
 		statsSecret.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
-		if err := r.Client.Create(context.TODO(), statsSecret); err == nil {
-			log.Info("created router stats secret", "namespace", statsSecret.Namespace, "name", statsSecret.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), statsSecret); err != nil {
 			return fmt.Errorf("failed to create router stats secret %s/%s: %v", statsSecret.Namespace, statsSecret.Name, err)
 		}
+		log.Info("created router stats secret", "namespace", statsSecret.Namespace, "name", statsSecret.Name)
 	}
 
 	cr, err := r.ManifestFactory.MetricsClusterRole()
@@ -408,11 +403,10 @@ func (r *reconciler) ensureMetricsIntegration(ci *ingressv1alpha1.ClusterIngress
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics cluster role %s: %v", cr.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), cr); err == nil {
-			log.Info("created router metrics cluster role", "name", cr.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), cr); err != nil {
 			return fmt.Errorf("failed to create router metrics cluster role %s: %v", cr.Name, err)
 		}
+		log.Info("created router metrics cluster role", "name", cr.Name)
 	}
 
 	crb, err := r.ManifestFactory.MetricsClusterRoleBinding()
@@ -423,11 +417,10 @@ func (r *reconciler) ensureMetricsIntegration(ci *ingressv1alpha1.ClusterIngress
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics cluster role binding %s: %v", crb.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), crb); err == nil {
-			log.Info("created router metrics cluster role binding", "name", crb.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), crb); err != nil {
 			return fmt.Errorf("failed to create router metrics cluster role binding %s: %v", crb.Name, err)
 		}
+		log.Info("created router metrics cluster role binding", "name", crb.Name)
 	}
 
 	mr, err := r.ManifestFactory.MetricsRole()
@@ -438,11 +431,10 @@ func (r *reconciler) ensureMetricsIntegration(ci *ingressv1alpha1.ClusterIngress
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics role %s: %v", mr.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), mr); err == nil {
-			log.Info("created router metrics role", "name", mr.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), mr); err != nil {
 			return fmt.Errorf("failed to create router metrics role %s: %v", mr.Name, err)
 		}
+		log.Info("created router metrics role", "name", mr.Name)
 	}
 
 	mrb, err := r.ManifestFactory.MetricsRoleBinding()
@@ -453,11 +445,10 @@ func (r *reconciler) ensureMetricsIntegration(ci *ingressv1alpha1.ClusterIngress
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics role binding %s: %v", mrb.Name, err)
 		}
-		if err := r.Client.Create(context.TODO(), mrb); err == nil {
-			log.Info("created router metrics role binding", "name", mrb.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), mrb); err != nil {
 			return fmt.Errorf("failed to create router metrics role binding %s: %v", mrb.Name, err)
 		}
+		log.Info("created router metrics role binding", "name", mrb.Name)
 	}
 
 	if _, err := r.ensureServiceMonitor(ci, svc, deploymentRef); err != nil {
@@ -505,11 +496,10 @@ func (r *reconciler) ensureInternalRouterServiceForIngress(ci *ingressv1alpha1.C
 		}
 
 		svc.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
-		if err := r.Client.Create(context.TODO(), svc); err == nil {
-			log.Info("created router service", "namespace", svc.Namespace, "name", svc.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), svc); err != nil {
 			return nil, fmt.Errorf("failed to create router service %s/%s: %v", svc.Namespace, svc.Name, err)
 		}
+		log.Info("created router service", "namespace", svc.Namespace, "name", svc.Name)
 	}
 
 	return svc, nil

--- a/pkg/operator/controller/controller_ca_configmap.go
+++ b/pkg/operator/controller/controller_ca_configmap.go
@@ -109,9 +109,6 @@ func (r *reconciler) currentRouterCAConfigMap() (*corev1.ConfigMap, error) {
 // createRouterCAConfigMap creates a router CA configmap.
 func (r *reconciler) createRouterCAConfigMap(cm *corev1.ConfigMap) error {
 	if err := r.Client.Create(context.TODO(), cm); err != nil {
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
 		return err
 	}
 	log.Info("created configmap", "namespace", cm.Namespace, "name", cm.Name)
@@ -126,9 +123,6 @@ func (r *reconciler) updateRouterCAConfigMap(current, desired *corev1.ConfigMap)
 	updated := current.DeepCopy()
 	updated.Data = desired.Data
 	if err := r.Client.Update(context.TODO(), updated); err != nil {
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
 		return err
 	}
 	log.Info("updated configmap", "namespace", updated.Namespace, "name", updated.Name)

--- a/pkg/operator/controller/controller_default_certificate.go
+++ b/pkg/operator/controller/controller_default_certificate.go
@@ -114,9 +114,6 @@ func (r *reconciler) currentRouterDefaultCertificate(ci *ingressv1alpha1.Cluster
 // createRouterDefaultCertificate creates a router default certificate secret.
 func (r *reconciler) createRouterDefaultCertificate(secret *corev1.Secret) error {
 	if err := r.Client.Create(context.TODO(), secret); err != nil {
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
 		return err
 	}
 	log.Info("created secret", "namespace", secret.Namespace, "name", secret.Name)

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -42,12 +42,11 @@ func (r *reconciler) ensureLoadBalancerService(ci *ingressv1alpha1.ClusterIngres
 		return nil, err
 	}
 	if desiredLBService != nil && currentLBService == nil {
-		if err := r.Client.Create(context.TODO(), desiredLBService); err == nil {
-			log.Info("created load balancer service", "namespace", desiredLBService.Namespace, "name", desiredLBService.Name)
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), desiredLBService); err != nil {
 			return nil, fmt.Errorf("failed to create load balancer service %s/%s: %v", desiredLBService.Namespace, desiredLBService.Name, err)
 		}
-		return r.currentLoadBalancerService(ci)
+		log.Info("created load balancer service", "namespace", desiredLBService.Namespace, "name", desiredLBService.Name)
+		return desiredLBService
 	}
 	return currentLBService, nil
 }

--- a/pkg/operator/controller/controller_service_monitor.go
+++ b/pkg/operator/controller/controller_service_monitor.go
@@ -24,12 +24,11 @@ func (r *reconciler) ensureServiceMonitor(ci *ingressv1alpha1.ClusterIngress, sv
 	}
 
 	if desired != nil && current == nil {
-		if err := r.Client.Create(context.TODO(), desired); err == nil {
-			log.Info("created servicemonitor", "namespace", desired.GetNamespace(), "name", desired.GetName())
-		} else if !errors.IsAlreadyExists(err) {
+		if err := r.Client.Create(context.TODO(), desired); err != nil {
 			return nil, fmt.Errorf("failed to create servicemonitor %s/%s: %v", desired.GetNamespace(), desired.GetName(), err)
 		}
-		return r.currentServiceMonitor(ci)
+		log.Info("created servicemonitor", "namespace", desired.GetNamespace(), "name", desired.GetName())
+		return desired
 	}
 	return current, nil
 }


### PR DESCRIPTION
- If we are just creating resource without get op, then IsAlreadyExists() check is needed
but when we are using get resource and in case of not found error, create
the resource pattern this check is unnecessary as we know that this error
will not occur.

- Remove stale 'MetricsServiceMonitorAsset' constant, no longer needed