### PR TITLE
Improve and expand checks in deploymentConfigChanged

### DIFF
--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -249,6 +249,7 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
 	if cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty()) &&
 		cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) &&
+		cmp.Equal(current.Spec.Template.Spec.Containers[0].Env, expected.Spec.Template.Spec.Containers[0].Env, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b corev1.EnvVar) bool { return a.Name < b.Name })) &&
 		current.Spec.Replicas != nil &&
 		*current.Spec.Replicas == *expected.Spec.Replicas {
 		return false, nil
@@ -261,6 +262,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	}
 	updated.Spec.Template.Spec.Volumes = volumes
 	updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
+	updated.Spec.Template.Spec.Containers[0].Env = expected.Spec.Template.Spec.Containers[0].Env
 	replicas := int32(1)
 	if expected.Spec.Replicas != nil {
 		replicas = *expected.Spec.Replicas

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -248,6 +248,7 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 // for the cluster ingress deployment and if not returns the updated config.
 func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
 	if cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty()) &&
+		cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) &&
 		current.Spec.Replicas != nil &&
 		*current.Spec.Replicas == *expected.Spec.Replicas {
 		return false, nil
@@ -259,6 +260,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 		volumes[i] = *vol.DeepCopy()
 	}
 	updated.Spec.Template.Spec.Volumes = volumes
+	updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
 	replicas := int32(1)
 	if expected.Spec.Replicas != nil {
 		replicas = *expected.Spec.Replicas

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -258,6 +258,14 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if .spec.template.spec.nodeSelector changes",
+			mutate: func(deployment *appsv1.Deployment) {
+				ns := map[string]string{"xyzzy": "quux"}
+				deployment.Spec.Template.Spec.NodeSelector = ns
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -8,6 +8,8 @@ import (
 
 	ingressv1alpha1 "github.com/openshift/cluster-ingress-operator/pkg/apis/ingress/v1alpha1"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -221,5 +223,76 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	if deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName != secretName {
 		t.Errorf("expected router Deployment volume with secret %s, got %s",
 			secretName, deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName)
+	}
+}
+
+func TestDeploymentConfigChanged(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*appsv1.Deployment)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *appsv1.Deployment) {},
+			expect:      false,
+		},
+		{
+			description: "if .uid changes",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.UID = "2"
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.template.spec.volumes is set to empty",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes = []corev1.Volume{}
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.template.spec.volumes is set to nil",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes = nil
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		nineteen := int32(19)
+		original := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "router-original",
+				Namespace: "openshift-ingress",
+				UID:       "1",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "secrets-volume",
+									},
+								},
+							},
+						},
+					},
+				},
+				Replicas: &nineteen,
+			},
+		}
+		mutated := original.DeepCopy()
+		tc.mutate(mutated)
+		if changed, updated := deploymentConfigChanged(&original, mutated); changed != tc.expect {
+			t.Errorf("%s, expect deploymentConfigChanged to be %t, got %t", tc.description, tc.expect, changed)
+		} else if changed {
+			if changedAgain, _ := deploymentConfigChanged(mutated, updated); changedAgain {
+				t.Errorf("%s, deploymentConfigChanged does not behave as a fixed point function", tc.description)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Improve volumes handling

Fix assumptions in `deploymentConfigChanged` about the deployment's pod template spec, and make the comparison and update more general.  Specifically, do not assume that the deployment has any volumes, do use `cmp.Equal` to compare the entire slice of volumes rather than only checking the first, and use a `for` loop plus `DeepCopy` to copy the updated volumes.

Before this change, `deploymentConfigChanged` did not react to changes to other volumes and could even panic with an out-of-bounds index if there were no volumes.  Any deployment that the operator creates will always have at least one volume, but we might as well be resilient in case someone else directly modifies the deployment.

* `pkg/operator/controller/controller_router_deployment.go` (`deploymentConfigChanged`): Delete a stale comment.  Use `cmp.Equal` to compare volumes.  Use a `for` loop plus `DeepCopy` to update volumes.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDeploymentConfigChanged`): Add tests for `deploymentConfigChanged`.

## Check node selector

Make `deploymentConfigChanged` check whether the deployment's pod template spec's node selector changed and set it in the updated deployment.

This commit fixes [bug 1683761](https://bugzilla.redhat.com/show_bug.cgi?id=1683761).

* `pkg/operator/controller/controller_router_deployment.go` (`deploymentConfigChanged`): Compare node selector.  Set the node selector in the updated deployment.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDeploymentConfigChanged`): Add test case for node selector.

## Check environment variables

Make `deploymentConfigChanged` check whether the deployment's pod template spec's container's environment variables changed and set them in the updated deployment.

This commit fixes [bug 1683762](https://bugzilla.redhat.com/show_bug.cgi?id=1683762) and [bug 1683763](https://bugzilla.redhat.com/show_bug.cgi?id=1683763).

* `pkg/operator/controller/controller_router_deployment.go` (`updateRouterDeployment`): Compare environment variables.  Set the environment variables in the updated deployment.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDeploymentConfigChanged`): Add test cases for changing `ROUTER_CANONICAL_HOSTNAME` or `ROUTER_USE_PROXY_PROTOCOL`, adding `NAMESPACE_LABELS`, or deleting `ROUTE_LABELS`.

---

This is more targeted than the approach we took in https://github.com/openshift/cluster-ingress-operator/pull/94 and had to revert.  Still, the approach here is broader than it strictly needs to be to resolve the referenced issues.  I'll pay close attention to the cluster-ingress-operator logs from e2e-aws-operator, and I am open to narrowing the added comparisons if need be.