### PR TITLE
Add function for name of in-use default certificate

### DIFF
--- a/pkg/operator/controller/certificate/default_cert.go
+++ b/pkg/operator/controller/certificate/default_cert.go
@@ -80,7 +80,7 @@ func desiredRouterDefaultCertificateSecret(ca *crypto.CA, namespace string, depl
 		return nil, fmt.Errorf("failed to encode certificate: %v", err)
 	}
 
-	name := controller.RouterDefaultCertificateSecretName(ci, namespace)
+	name := controller.RouterOperatorGeneratedDefaultCertificateSecretName(ci, namespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.Name,
@@ -99,7 +99,7 @@ func desiredRouterDefaultCertificateSecret(ca *crypto.CA, namespace string, depl
 // currentRouterDefaultCertificate returns the current router default
 // certificate secret.
 func (r *reconciler) currentRouterDefaultCertificate(ci *ingressv1alpha1.ClusterIngress, namespace string) (*corev1.Secret, error) {
-	name := controller.RouterDefaultCertificateSecretName(ci, namespace)
+	name := controller.RouterOperatorGeneratedDefaultCertificateSecretName(ci, namespace)
 	secret := &corev1.Secret{}
 	if err := r.client.Get(context.TODO(), name, secret); err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/operator/controller/certificate/publish_certs.go
+++ b/pkg/operator/controller/certificate/publish_certs.go
@@ -64,12 +64,8 @@ func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []ingress
 
 	ingressToSecret := map[*ingressv1alpha1.ClusterIngress]*corev1.Secret{}
 	for i, ingress := range ingresses {
-		secretName := controller.RouterDefaultCertificateSecretName(&ingress, "")
-		name := secretName.Name
-		if ingress.Spec.DefaultCertificateSecret != nil && len(*ingress.Spec.DefaultCertificateSecret) > 0 {
-			name = *ingress.Spec.DefaultCertificateSecret
-		}
-		if secret, ok := nameToSecret[name]; ok {
+		name := controller.RouterEffectiveDefaultCertificateSecretName(&ingress, "")
+		if secret, ok := nameToSecret[name.Name]; ok {
 			ingressToSecret[&ingresses[i]] = secret
 		}
 	}

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -198,11 +198,8 @@ func desiredRouterDeployment(ci *ingressv1alpha1.ClusterIngress, routerImage str
 	}
 
 	// Fill in the default certificate secret name.
-	secretName := fmt.Sprintf("router-certs-%s", ci.Name)
-	if ci.Spec.DefaultCertificateSecret != nil && len(*ci.Spec.DefaultCertificateSecret) > 0 {
-		secretName = *ci.Spec.DefaultCertificateSecret
-	}
-	deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName = secretName
+	secretName := RouterEffectiveDefaultCertificateSecretName(ci, deployment.Namespace)
+	deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName = secretName.Name
 
 	return deployment, nil
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -63,11 +63,21 @@ func RouterCertsGlobalSecretName() types.NamespacedName {
 	}
 }
 
-// RouterDefaultCertificateSecretName returns the namespaced name for the router
-// default certificate secret.
-func RouterDefaultCertificateSecretName(ci *ingressv1alpha1.ClusterIngress, namespace string) types.NamespacedName {
+// RouterOperatorGeneratedDefaultCertificateSecretName returns the namespaced name for
+// the operator-generated router default certificate secret.
+func RouterOperatorGeneratedDefaultCertificateSecretName(ci *ingressv1alpha1.ClusterIngress, namespace string) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: namespace,
 		Name:      fmt.Sprintf("router-certs-%s", ci.Name),
 	}
+}
+
+// RouterEffectiveDefaultCertificateSecretName returns the namespaced name for
+// the in-use router default certificate secret.
+func RouterEffectiveDefaultCertificateSecretName(ci *ingressv1alpha1.ClusterIngress, namespace string) types.NamespacedName {
+	name := RouterOperatorGeneratedDefaultCertificateSecretName(ci, namespace).Name
+	if ci.Spec.DefaultCertificateSecret != nil && len(*ci.Spec.DefaultCertificateSecret) > 0 {
+		name = *ci.Spec.DefaultCertificateSecret
+	}
+	return types.NamespacedName{Namespace: namespace, Name: name}
 }


### PR DESCRIPTION
* `pkg/operator/controller/names.go`
(`RouterDefaultCertificateSecretName`): Rename...
(`RouterOperatorGeneratedDefaultCertificateSecretName`): ...to this.
(`RouterEffectiveDefaultCertificateSecretName`): New function to get the name of the in-use router default certificate secret.
* `pkg/operator/controller/certificate/default_cert.go` (`desiredRouterDefaultCertificateSecret`, `currentRouterDefaultCertificate`): Use `RouterOperatorGeneratedDefaultCertificateSecretName`.
* `pkg/operator/controller/certificate/publish_certs.go` (`desiredRouterCertsGlobalSecret`):
* `pkg/operator/controller/controller_router_deployment.go` (`desiredRouterDeployment`): Use `RouterEffectiveDefaultCertificateSecretName`.

---

This PR addresses https://github.com/openshift/cluster-ingress-operator/pull/139#discussion_r261397620 (@ironcladlou).