### PR TITLE
Use object from API when recording an event

### DIFF
--- a/pkg/operator/controller/certificate/ca.go
+++ b/pkg/operator/controller/certificate/ca.go
@@ -34,9 +34,15 @@ func (r *reconciler) ensureRouterCASecret() (*corev1.Secret, error) {
 	if created, err := r.createRouterCASecret(desired); err != nil {
 		return nil, fmt.Errorf("failed to create CA secret: %v", err)
 	} else if created {
-		r.recorder.Event(desired, "Normal", "CreatedWildcardCACert", "Created a default wildcard CA certificate")
+		new, err := r.currentRouterCASecret()
+		if err != nil {
+			return nil, err
+		}
+		r.recorder.Event(new, "Normal", "CreatedWildcardCACert", "Created a default wildcard CA certificate")
+		return new, nil
+
 	}
-	return desired, nil
+	return r.currentRouterCASecret()
 }
 
 // currentRouterCASecret returns the current router CA secret.

--- a/pkg/operator/controller/certificate/publish_ca.go
+++ b/pkg/operator/controller/certificate/publish_ca.go
@@ -36,13 +36,17 @@ func (r *reconciler) ensureRouterCAConfigMap(secret *corev1.Secret, ingresses []
 		if created, err := r.createRouterCAConfigMap(desired); err != nil {
 			return fmt.Errorf("failed to ensure router CA was published: %v", err)
 		} else if created {
-			r.recorder.Eventf(desired, "Normal", "PublishedDefaultRouterCA", "Published default router CA")
+			new, err := r.currentRouterCAConfigMap()
+			if err != nil {
+				return err
+			}
+			r.recorder.Eventf(new, "Normal", "PublishedDefaultRouterCA", "Published default router CA")
 		}
 	case desired != nil && current != nil:
 		if updated, err := r.updateRouterCAConfigMap(current, desired); err != nil {
 			return fmt.Errorf("failed to update published router CA: %v", err)
 		} else if updated {
-			r.recorder.Eventf(desired, "Normal", "UpdatedPublishedDefaultRouterCA", "Updated the published default router CA")
+			r.recorder.Eventf(current, "Normal", "UpdatedPublishedDefaultRouterCA", "Updated the published default router CA")
 		}
 	}
 	return nil

--- a/pkg/operator/controller/certificate/publish_certs.go
+++ b/pkg/operator/controller/certificate/publish_certs.go
@@ -38,13 +38,17 @@ func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingr
 		if created, err := r.createRouterCertsGlobalSecret(desired); err != nil {
 			return fmt.Errorf("failed to ensure router certificates secret was published: %v", err)
 		} else if created {
-			r.recorder.Eventf(desired, "Normal", "PublishedRouterCertificates", "Published router certificates")
+			new, err := r.currentRouterCertsGlobalSecret()
+			if err != nil {
+				return err
+			}
+			r.recorder.Eventf(new, "Normal", "PublishedRouterCertificates", "Published router certificates")
 		}
 	case desired != nil && current != nil:
 		if updated, err := r.updateRouterCertsGlobalSecret(current, desired); err != nil {
 			return fmt.Errorf("failed to update published router certificates secret: %v", err)
 		} else if updated {
-			r.recorder.Eventf(desired, "Normal", "UpdatedPublishedRouterCertificates", "Updated the published router certificates")
+			r.recorder.Eventf(current, "Normal", "UpdatedPublishedRouterCertificates", "Updated the published router certificates")
 		}
 	}
 	return nil


### PR DESCRIPTION
Avoid "Could not construct reference to: [...] due to: 'selfLink was empty, can't make reference'. Will not report event: [...]" errors from the event recorder by using an object we have gotten from the API, as opposed to one we have constructed ourselves (which is missing the self link).

* `pkg/operator/controller/certificate/ca.go` (`ensureRouterCASecret`): After creating the secret, get the newly created object from the API.  Use the object from the API for the event recorder and for the return value.
* `pkg/operator/controller/certificate/publish_ca.go` (`ensureRouterCAConfigMap`): After creating the configmap, get the newly created object from the API, and use this object for the event recorder. When updating the configmap, use the object we got earlier from the API for the event recorder.
* `pkg/operator/controller/certificate/publish_certs.go` (`ensureRouterCertsGlobalSecret`): After creating the secret, get the newly created object from the API, and use this object for the event recorder. When updating the secret, use the object we got earlier from the API for the event recorder.

---

@ironcladlou, the cited error indicates that I was wrong that `r.client.Update` updates its parameter.  It looks like it mutates the parameter, but evidently not with the updated object.