### PR TITLE
Bug 1688099: Default to HostNetwork on libvirt

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -188,6 +188,8 @@ func haTypeForInfra(infraConfig *configv1.Infrastructure) operatorv1.EndpointPub
 	switch infraConfig.Status.Platform {
 	case configv1.AWSPlatform:
 		return operatorv1.LoadBalancerServiceStrategyType
+	case configv1.LibvirtPlatform:
+		return operatorv1.HostNetworkStrategyType
 	}
 	return operatorv1.PrivateStrategyType
 }


### PR DESCRIPTION
## Default to `HostNetwork` on libvirt

* `pkg/operator/controller/controller.go` (`haTypeForInfra`): Use `HostNetwork` as the default endpoint publishing strategy if the platform is libvirt.

## Rename `haTypeForInfra`, `enforceEffectiveHighAvailability`

* `pkg/operator/controller/controller.go` (`haTypeForInfra`): Rename...
(`publishingStrategyTypeForInfra`): ...to this.
(`enforceEffectiveHighAvailability`): Rename...
(`enforceEffectiveEndpointPublishingStrategy`): ...to this.
