### PR TITLE
Bug 1687640: Fix creation of service monitor to report router metrics

### DIFF
--- a/cmd/cluster-ingress-operator/main.go
+++ b/cmd/cluster-ingress-operator/main.go
@@ -9,6 +9,7 @@ import (
 	awsdns "github.com/openshift/cluster-ingress-operator/pkg/dns/aws"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator"
+	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -43,7 +44,7 @@ func main() {
 		log.Error(err, "failed to get kube config")
 		os.Exit(1)
 	}
-	kubeClient, err := operator.Client(kubeConfig)
+	kubeClient, err := operatorclient.NewClient(kubeConfig)
 	if err != nil {
 		log.Error(err, "failed to create kube client")
 		os.Exit(1)

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var (
+	// scheme contains all the API types necessary for the operator's dynamic
+	// clients to work. Any new non-core types must be added here.
+	//
+	// NOTE: The discovery mechanism used by the client won't automatically refresh,
+	// so only add types here that are _guaranteed_ to exist before the operator
+	// starts.
+	scheme *runtime.Scheme
+)
+
+func init() {
+	scheme = kscheme.Scheme
+	if err := operatorv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := configv1.Install(scheme); err != nil {
+		panic(err)
+	}
+}
+
+func GetScheme() *runtime.Scheme {
+	return scheme
+}
+
+// NewClient builds an operator-compatible kube client from the given REST config.
+func NewClient(kubeConfig *rest.Config) (client.Client, error) {
+	mapper, err := apiutil.NewDiscoveryRESTMapper(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover api rest mapper: %v", err)
+	}
+	kubeClient, err := client.New(kubeConfig, client.Options{
+		Scheme: scheme,
+		Mapper: mapper,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %v", err)
+	}
+	return kubeClient, nil
+}

--- a/pkg/operator/controller/controller_internal_service.go
+++ b/pkg/operator/controller/controller_internal_service.go
@@ -31,7 +31,7 @@ func (r *reconciler) ensureInternalIngressControllerService(ic *operatorv1.Ingre
 		return current, nil
 	}
 
-	if err := r.Client.Create(context.TODO(), desired); err != nil {
+	if err := r.client.Create(context.TODO(), desired); err != nil {
 		return nil, fmt.Errorf("failed to create internal ingresscontroller service: %v", err)
 	}
 	log.Info("created internal ingresscontroller service", "service", desired)
@@ -40,7 +40,7 @@ func (r *reconciler) ensureInternalIngressControllerService(ic *operatorv1.Ingre
 
 func (r *reconciler) currentInternalIngressControllerService(ic *operatorv1.IngressController) (*corev1.Service, error) {
 	current := &corev1.Service{}
-	err := r.Client.Get(context.TODO(), InternalIngressControllerServiceName(ic), current)
+	err := r.client.Get(context.TODO(), InternalIngressControllerServiceName(ic), current)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -42,7 +42,7 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 		return nil, err
 	}
 	if desiredLBService != nil && currentLBService == nil {
-		if err := r.Client.Create(context.TODO(), desiredLBService); err != nil {
+		if err := r.client.Create(context.TODO(), desiredLBService); err != nil {
 			return nil, fmt.Errorf("failed to create load balancer service %s/%s: %v", desiredLBService.Namespace, desiredLBService.Name, err)
 		}
 		log.Info("created load balancer service", "namespace", desiredLBService.Namespace, "name", desiredLBService.Name)
@@ -95,7 +95,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 // clusteringress.
 func (r *reconciler) currentLoadBalancerService(ci *operatorv1.IngressController) (*corev1.Service, error) {
 	service := &corev1.Service{}
-	if err := r.Client.Get(context.TODO(), loadBalancerServiceName(ci), service); err != nil {
+	if err := r.client.Get(context.TODO(), loadBalancerServiceName(ci), service); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -148,7 +148,7 @@ func (r *reconciler) finalizeLoadBalancerService(ci *operatorv1.IngressControlle
 	updated := service.DeepCopy()
 	if slice.ContainsString(updated.Finalizers, loadBalancerServiceFinalizer) {
 		updated.Finalizers = slice.RemoveString(updated.Finalizers, loadBalancerServiceFinalizer)
-		if err := r.Client.Update(context.TODO(), updated); err != nil {
+		if err := r.client.Update(context.TODO(), updated); err != nil {
 			return fmt.Errorf("failed to remove finalizer from service %s for ingress %s/%s: %v", service.Namespace, service.Name, ci.Name, err)
 		}
 	}

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -60,7 +60,7 @@ func (r *reconciler) ensureRouterDeleted(ci *operatorv1.IngressController) error
 	name := routerDeploymentName(ci)
 	deployment.Name = name.Name
 	deployment.Namespace = name.Namespace
-	if err := r.Client.Delete(context.TODO(), deployment); !errors.IsNotFound(err) {
+	if err := r.client.Delete(context.TODO(), deployment); !errors.IsNotFound(err) {
 		return err
 	}
 	return nil
@@ -234,7 +234,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, routerImage strin
 // currentRouterDeployment returns the current router deployment.
 func (r *reconciler) currentRouterDeployment(ci *operatorv1.IngressController) (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
-	if err := r.Client.Get(context.TODO(), routerDeploymentName(ci), deployment); err != nil {
+	if err := r.client.Get(context.TODO(), routerDeploymentName(ci), deployment); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -244,7 +244,7 @@ func (r *reconciler) currentRouterDeployment(ci *operatorv1.IngressController) (
 
 // createRouterDeployment creates a router deployment.
 func (r *reconciler) createRouterDeployment(deployment *appsv1.Deployment) error {
-	if err := r.Client.Create(context.TODO(), deployment); err != nil {
+	if err := r.client.Create(context.TODO(), deployment); err != nil {
 		return fmt.Errorf("failed to create router deployment %s/%s: %v", deployment.Namespace, deployment.Name, err)
 	}
 	log.Info("created router deployment", "namespace", deployment.Namespace, "name", deployment.Name)
@@ -258,7 +258,7 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 		return nil
 	}
 
-	if err := r.Client.Update(context.TODO(), updated); err != nil {
+	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return fmt.Errorf("failed to update router deployment %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
 	log.Info("updated router deployment", "namespace", updated.Namespace, "name", updated.Name)

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -28,7 +28,7 @@ const (
 // creates or updates the ClusterOperator resource for the operator.
 func (r *reconciler) syncOperatorStatus() error {
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: IngressClusterOperatorName}}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co)
 	isNotFound := errors.IsNotFound(err)
 	if err != nil && !isNotFound {
 		return fmt.Errorf("failed to get clusteroperator %s: %v", co.Name, err)
@@ -71,13 +71,13 @@ func (r *reconciler) syncOperatorStatus() error {
 	}
 
 	if isNotFound {
-		if err := r.Client.Create(context.TODO(), co); err != nil {
+		if err := r.client.Create(context.TODO(), co); err != nil {
 			return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
 		}
 		log.Info("created clusteroperator", "object", co)
 	} else {
 		if !statusesEqual(*oldStatus, co.Status) {
-			err = r.Client.Status().Update(context.TODO(), co)
+			err = r.client.Status().Update(context.TODO(), co)
 			if err != nil {
 				return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
 			}
@@ -95,7 +95,7 @@ func (r *reconciler) getOperatorState() (*corev1.Namespace, []operatorv1.Ingress
 			"error building router namespace: %v", err)
 	}
 
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil, nil, nil
 		}
@@ -105,14 +105,14 @@ func (r *reconciler) getOperatorState() (*corev1.Namespace, []operatorv1.Ingress
 	}
 
 	ingressList := &operatorv1.IngressControllerList{}
-	err = r.Client.List(context.TODO(), &client.ListOptions{Namespace: r.Namespace}, ingressList)
+	err = r.client.List(context.TODO(), &client.ListOptions{Namespace: r.Namespace}, ingressList)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf(
 			"failed to list ClusterIngresses: %v", err)
 	}
 
 	deploymentList := &appsv1.DeploymentList{}
-	err = r.Client.List(context.TODO(), &client.ListOptions{Namespace: ns.Name}, deploymentList)
+	err = r.client.List(context.TODO(), &client.ListOptions{Namespace: ns.Name}, deploymentList)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf(
 			"failed to list Deployment: %v", err)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -17,7 +17,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-ingress-operator/pkg/operator"
+	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +52,7 @@ func getClient() (client.Client, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get kube config: %s", err)
 	}
-	kubeClient, err := operator.Client(kubeConfig)
+	kubeClient, err := operatorclient.NewClient(kubeConfig)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create kube client: %s", err)
 	}


### PR DESCRIPTION
- Use a new kube client for fetching and creating ServiceMonitor resource
to avoid cached REST scheme/mapper of controller client.