### PR TITLE
Bug 1687931: Add certificate-publisher-controller

### DIFF
--- a/pkg/operator/controller/certificate-publisher/controller.go
+++ b/pkg/operator/controller/certificate-publisher/controller.go
@@ -1,0 +1,193 @@
+// The certificate-publisher controller is responsible for publishing in-use
+// certificates to the "router-certs" secret in the "openshift-config-managed"
+// namespace.
+package certificatepublisher
+
+import (
+	"context"
+	"fmt"
+
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"k8s.io/client-go/tools/record"
+
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName = "certificate-publisher-controller"
+)
+
+var log = logf.Logger.WithName(controllerName)
+
+type reconciler struct {
+	client            client.Client
+	operatorCache     cache.Cache
+	operandCache      cache.Cache
+	recorder          record.EventRecorder
+	operatorNamespace string
+	operandNamespace  string
+}
+
+// New returns a new controller that publishes a "router-certs" secret in the
+// openshift-config-managed namespace with all in-use default certificates.
+func New(mgr manager.Manager, operandCache cache.Cache, cl client.Client, operatorNamespace, operandNamespace string) (runtimecontroller.Controller, error) {
+	operatorCache := mgr.GetCache()
+	reconciler := &reconciler{
+		client:            cl,
+		operatorCache:     operatorCache,
+		operandCache:      operandCache,
+		recorder:          mgr.GetRecorder(controllerName),
+		operatorNamespace: operatorNamespace,
+		operandNamespace:  operandNamespace,
+	}
+	c, err := runtimecontroller.New(controllerName, mgr, runtimecontroller.Options{Reconciler: reconciler})
+	if err != nil {
+		return nil, err
+	}
+
+	// Index ingresscontrollers over the default certificate name so that
+	// secretIsInUse and secretToIngressController can look up
+	// ingresscontrollers that reference the secret.
+	if err := operatorCache.IndexField(&operatorv1.IngressController{}, "defaultCertificateName", func(o runtime.Object) []string {
+		secret := controller.RouterEffectiveDefaultCertificateSecretName(o.(*operatorv1.IngressController), operandNamespace)
+		return []string{secret.Name}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create index for ingresscontroller: %v", err)
+	}
+
+	secretsInformer, err := operandCache.GetInformer(&corev1.Secret{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create informer for secrets: %v", err)
+	}
+	if err := c.Watch(&source.Informer{Informer: secretsInformer}, &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(reconciler.secretToIngressController)}, predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return reconciler.secretIsInUse(e.Meta) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return reconciler.secretIsInUse(e.Meta) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return reconciler.secretIsInUse(e.MetaNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return reconciler.secretIsInUse(e.Meta) },
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := c.Watch(&source.Kind{Type: &operatorv1.IngressController{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return reconciler.hasSecret(e.Meta, e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return reconciler.hasSecret(e.Meta, e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return reconciler.secretChanged(e.ObjectOld, e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return reconciler.hasSecret(e.Meta, e.Object) },
+	}); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// secretToIngressController maps a secret to a slice of reconcile requests,
+// one request per ingresscontroller that references the secret.
+func (r *reconciler) secretToIngressController(o handler.MapObject) []reconcile.Request {
+	requests := []reconcile.Request{}
+	controllers, err := r.ingressControllersWithSecret(o.Meta.GetName())
+	if err != nil {
+		log.Error(err, "failed to list ingresscontrollers for secret", "related", o.Meta.GetSelfLink())
+		return requests
+	}
+	for _, ic := range controllers {
+		log.Info("queueing ingresscontroller", "name", ic.Name, "related", o.Meta.GetSelfLink())
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: ic.Namespace,
+				Name:      ic.Name,
+			},
+		}
+		requests = append(requests, request)
+	}
+	return requests
+}
+
+// ingressControllersWithSecret returns the ingresscontrollers that reference
+// the given secret.
+func (r *reconciler) ingressControllersWithSecret(secretName string) ([]operatorv1.IngressController, error) {
+	controllers := &operatorv1.IngressControllerList{}
+	lo := &client.ListOptions{}
+	lo.MatchingField("defaultCertificateName", secretName)
+	if err := r.operatorCache.List(context.Background(), lo, controllers); err != nil {
+		return nil, err
+	}
+	return controllers.Items, nil
+}
+
+// secretIsInUse returns true if the given secret is referenced by some
+// ingresscontroller.
+func (r *reconciler) secretIsInUse(meta metav1.Object) bool {
+	controllers, err := r.ingressControllersWithSecret(meta.GetName())
+	if err != nil {
+		log.Error(err, "failed to list ingresscontrollers for secret", "related", meta.GetSelfLink())
+		return false
+	}
+	return len(controllers) > 0
+}
+
+// hasSecret returns true if the effective default certificate secret for the
+// given ingresscontroller exists, false otherwise.
+func (r *reconciler) hasSecret(meta metav1.Object, o runtime.Object) bool {
+	ic := o.(*operatorv1.IngressController)
+	secretName := controller.RouterEffectiveDefaultCertificateSecretName(ic, r.operandNamespace)
+	secret := &corev1.Secret{}
+	if err := r.operandCache.Get(context.Background(), secretName, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return false
+		}
+		log.Error(err, "failed to look up secret for ingresscontroller", "name", secretName, "related", meta.GetSelfLink())
+	}
+	return true
+}
+
+// secretChanged returns true if the effective domain or effective default
+// certificate secret for the given ingresscontroller has changed, false
+// otherwise.
+func (r *reconciler) secretChanged(old, new runtime.Object) bool {
+	oldController := old.(*operatorv1.IngressController)
+	newController := new.(*operatorv1.IngressController)
+	oldSecret := controller.RouterEffectiveDefaultCertificateSecretName(oldController, r.operandNamespace)
+	newSecret := controller.RouterEffectiveDefaultCertificateSecretName(newController, r.operandNamespace)
+	oldStatus := oldController.Status.Domain
+	newStatus := newController.Status.Domain
+	return oldSecret != newSecret || oldStatus != newStatus
+}
+
+func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Info("Reconciling", "request", request)
+
+	controllers := &operatorv1.IngressControllerList{}
+	if err := r.operatorCache.List(context.TODO(), &client.ListOptions{Namespace: r.operatorNamespace}, controllers); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list ingresscontrollers: %v", err)
+	}
+
+	secrets := &corev1.SecretList{}
+	if err := r.operandCache.List(context.TODO(), &client.ListOptions{Namespace: r.operandNamespace}, secrets); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list secrets: %v", err)
+	}
+
+	if err := r.ensureRouterCertsGlobalSecret(secrets.Items, controllers.Items); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to ensure global secret: %v", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/operator/controller/certificate-publisher/publish_certs.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs.go
@@ -1,4 +1,4 @@
-package certificate
+package certificatepublisher
 
 import (
 	"bytes"

--- a/pkg/operator/controller/certificate-publisher/publish_certs.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs.go
@@ -17,7 +17,7 @@ import (
 // ensureRouterCertsGlobalSecret will create, update, or delete the global
 // certificates secret as appropriate.
 func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []operatorv1.IngressController) error {
-	desired, err := desiredRouterCertsGlobalSecret(secrets, ingresses)
+	desired, err := desiredRouterCertsGlobalSecret(secrets, ingresses, r.operandNamespace)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingr
 
 // desiredRouterCertsGlobalSecret returns the desired router-certs global
 // secret.
-func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []operatorv1.IngressController) (*corev1.Secret, error) {
+func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []operatorv1.IngressController, operandNamespace string) (*corev1.Secret, error) {
 	if len(ingresses) == 0 || len(secrets) == 0 {
 		return nil, nil
 	}
@@ -68,7 +68,7 @@ func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []operato
 
 	ingressToSecret := map[*operatorv1.IngressController]*corev1.Secret{}
 	for i, ingress := range ingresses {
-		name := controller.RouterEffectiveDefaultCertificateSecretName(&ingress, "")
+		name := controller.RouterEffectiveDefaultCertificateSecretName(&ingress, operandNamespace)
 		if secret, ok := nameToSecret[name.Name]; ok {
 			ingressToSecret[&ingresses[i]] = secret
 		}

--- a/pkg/operator/controller/certificate-publisher/publish_certs_test.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs_test.go
@@ -187,7 +187,7 @@ func TestDesiredRouterCertsGlobalSecret(t *testing.T) {
 
 	for _, tc := range testCases {
 		expected := tc.output.secret
-		actual, err := desiredRouterCertsGlobalSecret(tc.inputs.secrets, tc.inputs.ingresses)
+		actual, err := desiredRouterCertsGlobalSecret(tc.inputs.secrets, tc.inputs.ingresses, "openshift-ingress")
 		if err != nil {
 			t.Errorf("failed to get desired router-ca global secret: %v", err)
 			continue

--- a/pkg/operator/controller/certificate-publisher/publish_certs_test.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs_test.go
@@ -1,4 +1,4 @@
-package certificate
+package certificatepublisher
 
 import (
 	"bytes"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,6 +10,7 @@ import (
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	certcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate"
+	certpublishercontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate-publisher"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -149,6 +150,11 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 	// Set up the certificate controller
 	if _, err := certcontroller.New(operatorManager, kubeClient, config.Namespace); err != nil {
 		return nil, fmt.Errorf("failed to create cacert controller: %v", err)
+	}
+
+	// Set up the certificate-publisher controller
+	if _, err := certpublishercontroller.New(operatorManager, operandCache, kubeClient, config.Namespace, "openshift-ingress"); err != nil {
+		return nil, fmt.Errorf("failed to create certificate-publisher controller: %v", err)
 	}
 
 	return &Operator{

--- a/test/e2e/certificate_publisher_test.go
+++ b/test/e2e/certificate_publisher_test.go
@@ -1,0 +1,162 @@
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage/names"
+)
+
+// TestCreateIngressControllerThenSecret creates an ingresscontroller that
+// references a secret that does not exist, then creates the secret and verifies
+// that the operator updates the "router-certs" global secret.
+func TestCreateIngressControllerThenSecret(t *testing.T) {
+	cl, ns, err := getClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := names.SimpleNameGenerator.GenerateName("test-")
+
+	// Create the ingresscontroller.
+	var one int32 = 1
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			DefaultCertificate: &corev1.LocalObjectReference{
+				Name: name,
+			},
+			Domain: name,
+			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+				Type: operatorv1.PrivateStrategyType,
+			},
+			Replicas: &one,
+		},
+	}
+	if err := cl.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create the ingresscontroller: %v", err)
+	}
+	defer func() {
+		if err := cl.Delete(context.TODO(), ic); err != nil {
+			t.Fatalf("failed to delete the ingresscontroller: %v", err)
+		}
+	}()
+
+	// Wait for the ingresscontroller to be reconciled.
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ic.Namespace, Name: ic.Name}, ic); err != nil {
+			return false, nil
+		}
+		if len(ic.Status.Domain) == 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe reconciliation of ingresscontroller: %v", err)
+	}
+
+	// Create the secret.
+	secret, err := createDefaultCertTestSecret(cl, name)
+	if err != nil {
+		t.Fatalf("failed to create secret: %v", err)
+	}
+	defer func() {
+		if err := cl.Delete(context.TODO(), secret); err != nil {
+			t.Errorf("failed to delete secret: %v", err)
+		}
+	}()
+
+	// Wait for the "router-certs" secret to be updated.
+	err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+		globalSecret := &corev1.Secret{}
+		if err := cl.Get(context.TODO(), ingresscontroller.RouterCertsGlobalSecretName(), globalSecret); err != nil {
+			return false, nil
+		}
+		if _, ok := globalSecret.Data[ic.Spec.Domain]; !ok {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe updated global secret: %v", err)
+	}
+}
+
+// TestCreateSecretThenIngressController creates a secret, then creates an
+// ingresscontroller that references the secret and verifies that the operator
+// updates the "router-certs" global secret.
+func TestCreateSecretThenIngressController(t *testing.T) {
+	cl, ns, err := getClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := names.SimpleNameGenerator.GenerateName("test-")
+
+	// Create the secret.
+	secret, err := createDefaultCertTestSecret(cl, name)
+	if err != nil {
+		t.Fatalf("failed to create secret: %v", err)
+	}
+	defer func() {
+		if err := cl.Delete(context.TODO(), secret); err != nil {
+			t.Errorf("failed to delete secret: %v", err)
+		}
+	}()
+
+	// Create the ingresscontroller.
+	var one int32 = 1
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			DefaultCertificate: &corev1.LocalObjectReference{
+				Name: name,
+			},
+			Domain: name,
+			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+				Type: operatorv1.PrivateStrategyType,
+			},
+			Replicas: &one,
+		},
+	}
+	if err := cl.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create the ingresscontroller: %v", err)
+	}
+	defer func() {
+		if err := cl.Delete(context.TODO(), ic); err != nil {
+			t.Fatalf("failed to delete the ingresscontroller: %v", err)
+		}
+	}()
+
+	// Wait for the "router-certs" secret to be updated.
+	err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+		globalSecret := &corev1.Secret{}
+		if err := cl.Get(context.TODO(), ingresscontroller.RouterCertsGlobalSecretName(), globalSecret); err != nil {
+			return false, nil
+		}
+		if _, ok := globalSecret.Data[ic.Spec.Domain]; !ok {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe updated global secret: %v", err)
+	}
+}


### PR DESCRIPTION
## Add `certificate-publisher-controller`

Extract a new `certificate-publisher-controller` out of the existing `certificate-controller`.  The new controller watches ingresscontrollers in the operator namespace and default-certificate secrets in operand namespace and updates the `router-certs` secret in the `openshift-config-managed` namespace.

Because `certificate-controller` watches ingresscontrollers and not secrets, it was failing to update `router-certs` in some situations where the secret needed to be updated.  In particular, creating, updating, or deleting a secret _after_ creating an ingresscontroller that references the secret should cause `router-certs` to be updated.  The new controller ensures that `router-certs` is updated in this scenario.

* `pkg/operator/controller/certificate/controller.go` (`Reconcile`): Remove code to publish the `router-certs` secret.
* `pkg/operator/controller/certificate-publisher/controller.go`: New file.  Define a new controller that manages the `router-certs` secret.
* `pkg/operator/controller/certificate/publish_certs.go`:
* `pkg/operator/controller/certificate/publish_certs_test.go`: Move to `pkg/operator/controller/certificate-publisher/`.
* `pkg/operator/operator.go` (`New`): Initialize the new controller.
* `test/e2e/certificate_publisher_test.go`: New file.
(`TestCreateIngressControllerThenSecret`, `TestCreateSecretThenIngressController`): New tests.
* `test/e2e/operator_test.go` (`createDefaultCertTestSecret`): Add a parameter for the name.  Swap the return values to make the error the second value.
(`TestClusterIngressUpdate`): Pass `createDefaultCertTestSecret` a generated name.

## `desiredRouterCertsGlobalSecret`: Add namespace parameter

* `pkg/operator/controller/certificate-publisher/publish_certs.go`
(`ensureRouterCertsGlobalSecret`): Pass the operand namespace to `desiredRouterCertsGlobalSecret`.
(`desiredRouterCertsGlobalSecret`): Add a parameter for the operand namespace.  Pass this parameter (instead of the empty string) to `RouterEffectiveDefaultCertificateSecretName`.
* `pkg/operator/controller/certificate-publisher/publish_certs_test.go` (`TestDesiredRouterCertsGlobalSecret`): Adjust call to `desiredRouterCertsGlobalSecret`.