### PR TITLE
Increases poll time to 60s for ingress create/delete e2e test

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -144,7 +144,7 @@ func TestClusterIngressControllerCreateDelete(t *testing.T) {
 
 	// Verify the ingress controller deployment created the specified
 	// number of pod replicas.
-	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
 		if err := cl.Get(context.TODO(), types.NamespacedName{ing.Namespace, ing.Name}, ing); err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
The 30s poll time has caused CI test flakes. I recently experienced the flake locally for a new cluster. 60s should provide ample time to ensure a controller deployment has completed.