### PR TITLE
metrics: enable by default

### DIFF
--- a/cmd/cluster-ingress-operator/main.go
+++ b/cmd/cluster-ingress-operator/main.go
@@ -21,6 +21,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
@@ -34,6 +35,8 @@ const (
 var log = logf.Logger.WithName("entrypoint")
 
 func main() {
+	metrics.DefaultBindAddress = ":60000"
+
 	// Get a kube client.
 	kubeConfig, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
We're already declaring port 60000 for operator prometheus metrics.

This change enables the operator metrics listener on port 60000.

Example of metrics specific to controller-runtime which are captured by default:

```
$ curl http://localhost:60000/metrics                                                      
# HELP controller_runtime_reconcile_queue_length Length of reconcile queue per controller    
# TYPE controller_runtime_reconcile_queue_length gauge                                     
controller_runtime_reconcile_queue_length{controller="certificate-controller"} 0            
controller_runtime_reconcile_queue_length{controller="operator-controller"} 0                  
# HELP controller_runtime_reconcile_time_seconds Length of time per reconciliation per controller
# TYPE controller_runtime_reconcile_time_seconds histogram                                      
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.01"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.025"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.05"} 0                             
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.25"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="0.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="1"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="2.5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="10"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="certificate-controller",le="+Inf"} 1   
controller_runtime_reconcile_time_seconds_sum{controller="certificate-controller"} 0.40976698
controller_runtime_reconcile_time_seconds_count{controller="certificate-controller"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.01"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.025"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.05"} 0    
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.25"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="0.5"} 0      
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="2.5"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="10"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="operator-controller",le="+Inf"} 1 
controller_runtime_reconcile_time_seconds_sum{controller="operator-controller"} 2.596481827
controller_runtime_reconcile_time_seconds_count{controller="operator-controller"} 1             
# HELP controller_runtime_reconcile_total Total number of reconciliations per controller
# TYPE controller_runtime_reconcile_total counter                                           
controller_runtime_reconcile_total{controller="certificate-controller",result="success"} 1
controller_runtime_reconcile_total{controller="operator-controller",result="success"} 1         
```