### PR TITLE
Bug 1690333: Implement IngressController Available Status Condition

### DIFF
--- a/pkg/operator/controller/ingress_status.go
+++ b/pkg/operator/controller/ingress_status.go
@@ -1,0 +1,100 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// syncIngressControllerStatus computes the current status of ic and
+// updates status upon any changes since last sync.
+func (r *reconciler) syncIngressControllerStatus(deployment *appsv1.Deployment, ic *operatorv1.IngressController) error {
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("deployment has invalid spec.selector: %v", err)
+	}
+
+	updated := ic.DeepCopy()
+	updated.Status.AvailableReplicas = deployment.Status.AvailableReplicas
+	updated.Status.Selector = selector.String()
+	updated.Status.Conditions = computeIngressStatusConditions(updated.Status.Conditions, deployment)
+	if !ingressStatusesEqual(updated.Status, ic.Status) {
+		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
+			return fmt.Errorf("failed to update ingresscontroller status: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// computeIngressStatusConditions computes the ingress controller's current state.
+func computeIngressStatusConditions(conditions []operatorv1.OperatorCondition, deployment *appsv1.Deployment) []operatorv1.OperatorCondition {
+	availableCondition := &operatorv1.OperatorCondition{
+		Type:   operatorv1.IngressControllerAvailableConditionType,
+		Status: operatorv1.ConditionUnknown,
+	}
+	if deployment.Status.AvailableReplicas > 0 {
+		availableCondition.Status = operatorv1.ConditionTrue
+	} else {
+		availableCondition.Status = operatorv1.ConditionFalse
+		availableCondition.Reason = "DeploymentUnavailable"
+		availableCondition.Message = "no Deployment replicas available"
+	}
+	conditions = setIngressStatusCondition(conditions, availableCondition)
+
+	return conditions
+}
+
+// setIngressStatusCondition returns the IngressController condition result
+// of setting the specified condition in the given slice of conditions.
+func setIngressStatusCondition(oldConditions []operatorv1.OperatorCondition, condition *operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
+	condition.LastTransitionTime = metav1.Now()
+
+	var newConditions []operatorv1.OperatorCondition
+
+	found := false
+	for _, c := range oldConditions {
+		if condition.Type == c.Type {
+			if condition.Status == c.Status &&
+				condition.Reason == c.Reason &&
+				condition.Message == c.Message {
+				// The ingresscontroller status condition has not changed.
+				return oldConditions
+			}
+
+			found = true
+			newConditions = append(newConditions, *condition)
+		} else {
+			newConditions = append(newConditions, c)
+		}
+	}
+	if !found {
+		newConditions = append(newConditions, *condition)
+	}
+
+	return newConditions
+}
+
+// ingressStatusesEqual compares two IngressControllerStatus values.  Returns true
+// if the provided values should be considered equal for the purpose of determining
+// whether an update is necessary, false otherwise.
+func ingressStatusesEqual(a, b operatorv1.IngressControllerStatus) bool {
+	conditionCmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "LastTransitionTime"),
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(a, b operatorv1.OperatorCondition) bool { return a.Type < b.Type }),
+	}
+	if !cmp.Equal(a.Conditions, b.Conditions, conditionCmpOpts...) || a.AvailableReplicas != b.AvailableReplicas ||
+		a.Selector != b.Selector {
+		return false
+	}
+
+	return true
+}

--- a/pkg/operator/controller/ingress_status_test.go
+++ b/pkg/operator/controller/ingress_status_test.go
@@ -1,0 +1,258 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestComputeIngressStatusConditions(t *testing.T) {
+	testCases := []struct {
+		description     string
+		availRepl, repl int32
+		condType        string
+		condStatus      operatorv1.ConditionStatus
+	}{
+		{"0/2 deployment replicas available", 0, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionFalse},
+		{"1/2 deployment replicas available", 1, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionTrue},
+		{"2/2 deployment replicas available", 2, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionTrue},
+	}
+
+	for i, tc := range testCases {
+		deploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("ingress-controller-%d", i+1),
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          tc.repl,
+				AvailableReplicas: tc.availRepl,
+			},
+		}
+
+		expected := []operatorv1.OperatorCondition{
+			{
+				Type:   tc.condType,
+				Status: tc.condStatus,
+			},
+		}
+		actual := computeIngressStatusConditions([]operatorv1.OperatorCondition{}, deploy)
+		gotExpected := true
+		if len(actual) != len(expected) {
+			gotExpected = false
+		}
+		for _, conditionA := range actual {
+			foundMatchingCondition := false
+
+			for _, conditionB := range expected {
+				if conditionA.Type == conditionB.Type &&
+					conditionA.Status == conditionB.Status {
+					foundMatchingCondition = true
+					break
+				}
+			}
+
+			if !foundMatchingCondition {
+				gotExpected = false
+			}
+		}
+		if !gotExpected {
+			t.Fatalf("%q: expected %#v, got %#v", tc.description,
+				expected, actual)
+		}
+	}
+}
+
+func TestSetIngressStatusCondition(t *testing.T) {
+	testCases := []struct {
+		description   string
+		oldConditions []operatorv1.OperatorCondition
+		newCondition  *operatorv1.OperatorCondition
+		expected      []operatorv1.OperatorCondition
+	}{
+		{
+			description: "new condition",
+			newCondition: &operatorv1.OperatorCondition{
+				Type:   operatorv1.IngressControllerAvailableConditionType,
+				Status: operatorv1.ConditionTrue,
+			},
+			expected: []operatorv1.OperatorCondition{
+				{
+					Type:   operatorv1.IngressControllerAvailableConditionType,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+		},
+		{
+			description: "existing condition, unchanged",
+			oldConditions: []operatorv1.OperatorCondition{
+				{
+					Type:   operatorv1.IngressControllerAvailableConditionType,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+			newCondition: &operatorv1.OperatorCondition{
+				Type:   operatorv1.IngressControllerAvailableConditionType,
+				Status: operatorv1.ConditionTrue,
+			},
+			expected: []operatorv1.OperatorCondition{
+				{
+					Type:   operatorv1.IngressControllerAvailableConditionType,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+		},
+		{
+			description: "existing condition changed",
+			oldConditions: []operatorv1.OperatorCondition{
+				{
+					Type:   operatorv1.IngressControllerAvailableConditionType,
+					Status: operatorv1.ConditionFalse,
+				},
+			},
+			newCondition: &operatorv1.OperatorCondition{
+				Type:   operatorv1.IngressControllerAvailableConditionType,
+				Status: operatorv1.ConditionTrue,
+			},
+			expected: []operatorv1.OperatorCondition{
+				{
+					Type:   operatorv1.IngressControllerAvailableConditionType,
+					Status: operatorv1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := setIngressStatusCondition(tc.oldConditions, tc.newCondition)
+		a := operatorv1.IngressControllerStatus{Conditions: actual}
+		b := operatorv1.IngressControllerStatus{Conditions: tc.expected}
+		if !ingressStatusesEqual(a, b) {
+			t.Fatalf("%q: expected %v, got %v", tc.description,
+				tc.expected, actual)
+		}
+	}
+}
+
+func TestIngressStatusesEqual(t *testing.T) {
+	testCases := []struct {
+		description string
+		expected    bool
+		a, b        operatorv1.IngressControllerStatus
+	}{
+		{
+			description: "nil and non-nil slices are equal",
+			expected:    true,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+		},
+		{
+			description: "empty slices should be equal",
+			expected:    true,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+			b: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{},
+			},
+		},
+		{
+			description: "condition LastTransitionTime should be ignored",
+			expected:    true,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:               operatorv1.IngressControllerAvailableConditionType,
+						Status:             operatorv1.ConditionTrue,
+						LastTransitionTime: metav1.Unix(0, 0),
+					},
+				},
+			},
+			b: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:               operatorv1.IngressControllerAvailableConditionType,
+						Status:             operatorv1.ConditionTrue,
+						LastTransitionTime: metav1.Unix(1, 0),
+					},
+				},
+			},
+		},
+		{
+			description: "check condition reason differs",
+			expected:    false,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.IngressControllerAvailableConditionType,
+						Status: operatorv1.ConditionFalse,
+						Reason: "foo",
+					},
+				},
+			},
+			b: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.IngressControllerAvailableConditionType,
+						Status: operatorv1.ConditionFalse,
+						Reason: "bar",
+					},
+				},
+			},
+		},
+		{
+			description: "condition status differs",
+			expected:    false,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.IngressControllerAvailableConditionType,
+						Status: operatorv1.ConditionTrue,
+					},
+				},
+			},
+			b: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:   operatorv1.IngressControllerAvailableConditionType,
+						Status: operatorv1.ConditionFalse,
+					},
+				},
+			},
+		},
+		{
+			description: "check duplicate with single condition",
+			expected:    false,
+			a: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.IngressControllerAvailableConditionType,
+						Message: "foo",
+					},
+				},
+			},
+			b: operatorv1.IngressControllerStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:    operatorv1.IngressControllerAvailableConditionType,
+						Message: "foo",
+					},
+					{
+						Type:    operatorv1.IngressControllerAvailableConditionType,
+						Message: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		if actual := ingressStatusesEqual(tc.a, tc.b); actual != tc.expected {
+			t.Fatalf("%q: expected %v, got %v", tc.description, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Previously, ingresscontroller status conditions were not implemented.

This commit does the following:

- Implements the ingresscontroller `Available` status condition.
- Refactors ingress operator `Progressing` and `Available` status conditions to be calucalted from the ingresscontroller `Available` condition.
- Replaces deployment logic from ingress operator unit tests with ingresscontroller `Available` conditions.
- Adds ingresscontroller `Available` condition unit tests.

Provides the foundation for fixing bug 1683765 by reporting domain conflicts through status conditions.