### PR TITLE
update credentialsrequest from v1beta1 to v1

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloudcredential.openshift.io/v1beta1
+apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
   labels:
@@ -10,7 +10,7 @@ spec:
     name: cloud-credentials
     namespace: openshift-ingress-operator
   providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1beta1
+    apiVersion: cloudcredential.openshift.io/v1
     kind: AWSProviderSpec
     statementEntries:
     - effect: Allow


### PR DESCRIPTION
in order to avoid the CVO periodically applying v1beta1 and then having the cloud-cred-operator migrate it to v1 (see https://bugzilla.redhat.com/show_bug.cgi?id=1690069 ), just update the credentialsrequest in the manifests dir to v1 (no changes from v1beta1 to v1)