### PR TITLE
Fix load-balancer finalization

### DIFF
--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -118,20 +118,33 @@ func (r *reconciler) finalizeLoadBalancerService(ci *operatorv1.IngressControlle
 	if service == nil {
 		return nil
 	}
-	records, err := desiredDNSRecords(ci, service, dnsConfig)
-	if err != nil {
-		return err
-	}
-	dnsErrors := []error{}
-	for _, record := range records {
-		if err := r.DNSManager.Delete(record); err != nil {
-			dnsErrors = append(dnsErrors, fmt.Errorf("failed to delete DNS record %v for ingress %s/%s: %v", record, ci.Namespace, ci.Name, err))
-		} else {
-			log.Info("deleted DNS record for ingress", "namespace", ci.Namespace, "name", ci.Name, "record", record)
+	// We cannot published DNS records for a load balancer till it has been
+	// provisioned.  Thus if the service's status does not _currently_
+	// indicate that a load balancer has been provisioned, that means we
+	// _probably_ have not published any DNS records (and if we have, then
+	// we have lost track of them).
+	//
+	// TODO: Instead of trying to infer whether DNS records exist by looking
+	// at the service, we should be maintaining state with any DNS records
+	// that we have created for the ingresscontroller, for example by using
+	// an annotation on the ingresscontroller.
+	ingress := service.Status.LoadBalancer.Ingress
+	if len(ingress) > 0 && len(ingress[0].Hostname) > 0 {
+		records, err := desiredDNSRecords(ci, ingress[0].Hostname, dnsConfig)
+		if err != nil {
+			return err
 		}
-	}
-	if err := utilerrors.NewAggregate(dnsErrors); err != nil {
-		return err
+		dnsErrors := []error{}
+		for _, record := range records {
+			if err := r.DNSManager.Delete(record); err != nil {
+				dnsErrors = append(dnsErrors, fmt.Errorf("failed to delete DNS record %v for ingress %s/%s: %v", record, ci.Namespace, ci.Name, err))
+			} else {
+				log.Info("deleted DNS record for ingress", "namespace", ci.Namespace, "name", ci.Name, "record", record)
+			}
+		}
+		if err := utilerrors.NewAggregate(dnsErrors); err != nil {
+			return err
+		}
 	}
 	// Mutate a copy to avoid assuming we know where the current one came from
 	// (i.e. it could have been from a cache).


### PR DESCRIPTION
When finalizing a load-balancer service, check whether it has been provisioned, and if not, skip cleaning up its DNS records.

Before this commit, if an ingresscontroller was created with the `LoadBalancerService` endpoint publishing strategy and subsequently deleted before the load balancer had been provisioned, the finalization logic returned an error, which caused the controller to retry and fail to finalize the service repeatedly.

* `pkg/operator/controller/controller_dns.go` (`ensureDNS`): Check whether the load balancer has been provisioned.  Return an error if not.  Pass the host name from the load balancer to `desiredDNSRecords`.
(`desiredDNSRecords`): Take a host name instead of a load-balancer service.
* `pkg/operator/controller/controller_lb.go` (`finalizeLoadBalancerService`): Check whether the load balancer has been provisioned.  Skip DNS clean-up if not.  Pass the host name from the load balancer to `desiredDNSRecords`.