### PR TITLE
manifests: Simplify RouterNamespace

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	RouterNamespace          = "assets/router/namespace.yaml"
+	RouterNamespaceAsset     = "assets/router/namespace.yaml"
 	RouterServiceAccount     = "assets/router/service-account.yaml"
 	RouterClusterRole        = "assets/router/cluster-role.yaml"
 	RouterClusterRoleBinding = "assets/router/cluster-role-binding.yaml"
@@ -79,12 +79,12 @@ func (f *Factory) OperatorRoleBinding() (*rbacv1.RoleBinding, error) {
 	return crb, nil
 }
 
-func (f *Factory) RouterNamespace() (*corev1.Namespace, error) {
-	ns, err := NewNamespace(MustAssetReader(RouterNamespace))
+func RouterNamespace() *corev1.Namespace {
+	ns, err := NewNamespace(MustAssetReader(RouterNamespaceAsset))
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
-	return ns, nil
+	return ns
 }
 
 func (f *Factory) RouterServiceAccount() (*corev1.ServiceAccount, error) {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -35,10 +35,6 @@ func TestManifests(t *testing.T) {
 		},
 	}
 
-	if _, err := f.RouterNamespace(); err != nil {
-		t.Errorf("invalid RouterNamespace: %v", err)
-	}
-
 	if _, err := f.RouterServiceAccount(); err != nil {
 		t.Errorf("invalid RouterServiceAccount: %v", err)
 	}
@@ -71,8 +67,8 @@ func TestManifests(t *testing.T) {
 		t.Errorf("invalid RouterStatsSecret: %v", err)
 	}
 
+	RouterNamespace()
 	RouterDeployment(ci)
-
 	InternalIngressControllerService()
 	LoadBalancerService()
 }

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -290,10 +290,7 @@ func (r *reconciler) ensureRouterNamespace() error {
 		log.Info("created router cluster role", "name", cr.Name)
 	}
 
-	ns, err := r.ManifestFactory.RouterNamespace()
-	if err != nil {
-		return fmt.Errorf("failed to build router namespace: %v", err)
-	}
+	ns := manifests.RouterNamespace()
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router namespace %q: %v", ns.Name, err)


### PR DESCRIPTION
## manifests: Simplify `RouterNamespace`

Convert the `RouterNamespace` method into a function, and change it not to return an error value.

* `pkg/manifests/manifests.go` (`RouterNamespace`): Rename constant...
(`RouterNamespaceAsset`): ...to this.
(`RouterNamespace`): Drop the receiver and the error return value.  Panic if unable to read the asset.  Otherwise return the asset.
* `pkg/manifests/manifests_test.go`: Adjust test for `RouterNamespace`.
* `pkg/operator/controller/controller.go` (`ensureRouterNamespace`):
* `pkg/operator/controller/status.go` (`getOperatorState`): Adjust calls to `RouterNamespace`.
 
---

An alternative approach is to delete the router namespace asset and construct the namespace object in Go code.  See https://github.com/Miciah/cluster-ingress-operator/commit/895d7c5ebb6fc0fbbc06f0817654f1536faae65d:

* `assets/router/namespace.yaml`: Delete file.
* `pkg/manifests/bindata.go`: Regenerate.
* `pkg/manifests/manifests.go` (`RouterNamespace`): Delete constant.
(`RouterNamespace`): Delete method.
* `pkg/manifests/manifests_test.go` (`TestManifests`): Delete test for `RouterNamespace`.
* `pkg/operator/controller/controller.go` (`Config`): Rename `Namespace` to `OperatorNamespace`.  Add `OperandNamespace` field.
(`ensureRouterNamespace`): Construct the namespace object in Go instead of using the manifest factory.
* `pkg/operator/controller/status.go` (`getOperatorState`): Use the reconciler object's `OperatorNamespace` field instead of the manifest factory to get the namespace's name.
* `pkg/operator/operator.go` (`New`): Set the operator config's `OperatorNamespace` and `OperandNamespace` fields.