### PR TITLE
Add instructions for building remotely on a cluster

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -15,7 +15,9 @@ $ make build
 * An [OpenShift cluster](https://github.com/openshift/installer)
 * An admin-scoped `KUBECONFIG` for the cluster.
 
-Uninstall the existing operator and all its managed components:
+#### Building Locally
+
+To build the operator on your local machine and deploy it to the cluster, first uninstall the existing operator and all its managed components:
 
 ```
 $ hack/uninstall.sh
@@ -31,6 +33,41 @@ Follow the instructions to install the operator, e.g.:
 
 ```
 $ oc apply -f /tmp/manifests/path
+```
+
+#### Building Remotely on the Cluster
+
+To build the operator on the remote cluster, first create a buildconfig on the cluster:
+
+```
+$ make buildconfig
+```
+
+The above command will create a buildconfig using the current branch and the URL for the default push remote.  You can also specify an explicit branch or repository URL:
+
+```
+$ make buildconfig GIT_BRANCH=<branch> \
+     GIT_URL=https://github.com/<username>/cluster-ingress-operator.git
+```
+
+Note: If a buildconfig already exists from an earlier `make buildconfig` command, `make buildconfig` will update the existing buildconfig.
+
+Next, start a build from this buildconfig:
+
+```
+$ make cluster-build
+```
+
+Alternatively, if you want to see the logs during the build, specify the `V` flag:
+
+```
+$ make cluster-build V=1
+```
+
+Use the `DEPLOY` flag to start a build and then patch the operator to use the newly built image:
+
+```
+$ make cluster-build DEPLOY=1
 ```
 
 ## Tests

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ TEST ?= .*
 build:
 	$(GO_BUILD_RECIPE)
 
+.PHONY: buildconfig
+buildconfig:
+	hack/create-buildconfig.sh
+
+.PHONY: cluster-build
+cluster-build:
+	hack/start-build.sh
+
 .PHONY: generate
 generate:
 	hack/update-generated-bindata.sh

--- a/hack/buildconfig.yaml
+++ b/hack/buildconfig.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: ingress-operator-build
+  annotations:
+    description: "Template for building the ingress operator."
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ingress-operator
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ingress-operator
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ingress-operator:latest
+    source:
+      git:
+        uri: ${GIT_URL}
+        ref: ${GIT_BRANCH}
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+      type: Docker
+parameters:
+- description: 'URL for the ingress operator Git repository'
+  name: GIT_URL
+  value: https://github.com/openshift/cluster-ingress-operator
+- description: 'Git branch'
+  name: GIT_BRANCH
+  value: master

--- a/hack/create-buildconfig.sh
+++ b/hack/create-buildconfig.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -z "${GIT_BRANCH+1}" ]]
+then
+    GIT_BRANCH="$(git symbolic-ref --short HEAD)"
+fi
+
+if [[ -z "${GIT_URL+1}" ]]
+then
+    if ! GIT_REMOTE="$(git config "branch.${GIT_BRANCH}.pushDefault")" ||
+            [[ "$GIT_REMOTE" = '.' ]]
+    then GIT_REMOTE="$(git config 'remote.pushDefault')"
+    fi
+    GIT_URL=$(git config "remote.${GIT_REMOTE}.url")
+fi
+
+if [[ "$GIT_URL" =~ ^git@ ]]
+then
+    # Convert git@host:user/repo to https://host/user/repo.
+    GIT_URL="${GIT_URL/://}"
+    GIT_URL="https://${GIT_URL#git@}"
+fi
+
+oc process -f "$(dirname "$0")/buildconfig.yaml" \
+   -p "GIT_URL=$GIT_URL" \
+   -p "GIT_BRANCH=$GIT_BRANCH" \
+    | oc -n openshift-ingress-operator apply -f -

--- a/hack/start-build.sh
+++ b/hack/start-build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+oc -n openshift-ingress-operator start-build ingress-operator \
+   ${V+--follow} --wait
+
+if [[ -n "${DEPLOY+1}" ]]
+then
+    oc -n openshift-ingress-operator patch deploy/ingress-operator \
+       --type=strategic --patch='
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "ingress-operator",
+            "env": [
+              {
+                "name": "IMAGE",
+                "value": "image-registry.openshift-image-registry.svc:5000/openshift-ingress-operator/ingress-operator:latest"
+              }
+            ],
+            "image": "image-registry.openshift-image-registry.svc:5000/openshift-ingress-operator/ingress-operator:latest",
+            "imagePullPolicy": "Always"
+          }
+        ]
+      }
+    }
+  }
+}
+'
+fi


### PR DESCRIPTION
Provide a buildconfig, shell scripts, Makefile targets, and instructions for building the operator remotely on a cluster using the buildconfig.

* `HACKING.md`: Add instructions for building using a buildconfig.
* `Makefile`: Add `buildconfig` and `cluster-build` targets.
* `hack/buildconfig.yaml`: New file.
* `hack/create-buildconfig.sh`: New file.
* `hack/start-build.sh`: New file.