### PR TITLE
deploymentConfigChanged: Fix volume comparison

### DIFF
--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -270,7 +270,7 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
 	if cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty()) &&
 		cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) &&
-		cmp.Equal(current.Spec.Template.Spec.Containers[0].Env, expected.Spec.Template.Spec.Containers[0].Env, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b corev1.EnvVar) bool { return a.Name < b.Name })) &&
+		cmp.Equal(current.Spec.Template.Spec.Containers[0].Env, expected.Spec.Template.Spec.Containers[0].Env, cmpopts.EquateEmpty(), cmpopts.SortSlices(cmpEnvs)) &&
 		current.Spec.Template.Spec.Containers[0].Image == expected.Spec.Template.Spec.Containers[0].Image &&
 		current.Spec.Replicas != nil &&
 		*current.Spec.Replicas == *expected.Spec.Replicas {
@@ -293,3 +293,5 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	updated.Spec.Replicas = &replicas
 	return true, updated
 }
+
+func cmpEnvs(a, b corev1.EnvVar) bool    { return a.Name < b.Name }

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -268,7 +268,7 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 // deploymentConfigChanged checks if current config matches the expected config
 // for the cluster ingress deployment and if not returns the updated config.
 func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
-	if cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty()) &&
+	if cmp.Equal(current.Spec.Template.Spec.Volumes, expected.Spec.Template.Spec.Volumes, cmpopts.EquateEmpty(), cmpopts.SortSlices(cmpVolumes)) &&
 		cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) &&
 		cmp.Equal(current.Spec.Template.Spec.Containers[0].Env, expected.Spec.Template.Spec.Containers[0].Env, cmpopts.EquateEmpty(), cmpopts.SortSlices(cmpEnvs)) &&
 		current.Spec.Template.Spec.Containers[0].Image == expected.Spec.Template.Spec.Containers[0].Image &&
@@ -295,3 +295,4 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 }
 
 func cmpEnvs(a, b corev1.EnvVar) bool    { return a.Name < b.Name }
+func cmpVolumes(a, b corev1.Volume) bool { return a.Name < b.Name }

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -330,6 +330,14 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if the volumes change ordering",
+			mutate: func(deployment *appsv1.Deployment) {
+				vols := deployment.Spec.Template.Spec.Volumes
+				vols[1], vols[0] = vols[0], vols[1]
+			},
+			expect: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -345,9 +353,18 @@ func TestDeploymentConfigChanged(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
 							{
+								Name: "default-certificate",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: "secrets-volume",
+										SecretName:  "secrets-volume",
+									},
+								},
+							},
+							{
+								Name: "metrics-certs",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "router-metrics-certs-default",
 									},
 								},
 							},

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -263,6 +263,21 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the default-certificates default mode value changes",
+			mutate: func(deployment *appsv1.Deployment) {
+				newVal := int32(0)
+				deployment.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = &newVal
+			},
+			expect: true,
+		},
+		{
+			description: "if the default-certificates default mode value is omitted",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes[0].Secret.DefaultMode = nil
+			},
+			expect: false,
+		},
+		{
 			description: "if .spec.template.spec.nodeSelector changes",
 			mutate: func(deployment *appsv1.Deployment) {
 				ns := map[string]string{"xyzzy": "quux"}
@@ -342,6 +357,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 
 	for _, tc := range testCases {
 		nineteen := int32(19)
+		fourTwenty := int32(420) // = 0644 octal.
 		original := appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "router-original",
@@ -357,6 +373,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  "secrets-volume",
+										DefaultMode: &fourTwenty,
 									},
 								},
 							},


### PR DESCRIPTION
Fix several problems in how `deploymentConfigChanged` compares volumes that could cause spurious updates to the router deployment.

#### Add `cmpEnvs` helper function

* `pkg/operator/controller/controller_router_deployment.go` (`cmpEnvs`): Add helper function.
(`deploymentConfigChanged`): Use it.


#### Ignore volumes ordering

Ignore the ordering of volumes in the deployment's pod template spec when comparing deployments.

* `pkg/operator/controller/controller_router_deployment.go` (`deploymentConfigChanged`): Sort volumes on name when comparing volumes.
(`cmpVolumes`): New helper function.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDeploymentConfigChanged`): Add test case for volumes changing ordering.


#### Fix volume default mode comparison

The default value for a secret volume source's default mode is 420, so treat a nil value as equal to 420.

* `pkg/operator/controller/controller_router_deployment.go` (`cmpSecretVolumeSource`): New helper function.
(`deploymentConfigChanged`): Use `cmpSecretVolumeSource` when comparing volumes.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDeploymentConfigChanged`): Add test cases where the default mode for the default-certificates volume changes.