### PR TITLE
Adds IngressController CRD Validation & Generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,18 @@ build:
 	$(GO_BUILD_RECIPE)
 
 .PHONY: generate
-generate:
+generate: crd
 	hack/update-generated-bindata.sh
+
+# Generate ClusterIngress CRD from vendored API spec.
+.PHONY: crd
+crd:
+	go run ./vendor/github.com/openshift/library-go/cmd/crd-schema-gen/main.go --apis-dir vendor/github.com/openshift/api
+
+# Do not write the ClusterIngress CRD, only compare and return (code 1 if dirty).
+.PHONY: verify-crd
+verify-crd:
+	go run ./vendor/github.com/openshift/library-go/cmd/crd-schema-gen/main.go --apis-dir vendor/github.com/openshift/api --verify-only
 
 .PHONY: test
 test: verify
@@ -35,7 +45,7 @@ clean:
 	rm -f $(BIN)
 
 .PHONY: verify
-verify:
+verify: verify-crd
 	hack/verify-gofmt.sh
 	hack/verify-generated-bindata.sh
 

--- a/manifests/00-custom-resource-definition.yaml
+++ b/manifests/00-custom-resource-definition.yaml
@@ -17,3 +17,79 @@ spec:
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.availableReplicas
       labelSelectorPath: .status.labelSelector
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            defaultCertificate:
+              type: object
+            domain:
+              type: string
+            endpointPublishingStrategy:
+              properties:
+                type:
+                  type: string
+              required:
+              - type
+              type: object
+            namespaceSelector:
+              type: object
+            nodePlacement:
+              properties:
+                nodeSelector:
+                  type: object
+              type: object
+            replicas:
+              format: int32
+              type: integer
+            routeSelector:
+              type: object
+          type: object
+        status:
+          properties:
+            availableReplicas:
+              format: int32
+              type: integer
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            domain:
+              type: string
+            endpointPublishingStrategy:
+              properties:
+                type:
+                  type: string
+              required:
+              - type
+              type: object
+            selector:
+              type: string
+          required:
+          - availableReplicas
+          - selector
+          - domain
+          type: object
+      type: object


### PR DESCRIPTION
PR #185 is required before merging.

Previously, `IngressController` resource fields were not validated. Additionally, the associated CRD was manually managed. This commit adds:

- OpenAPI v3 schema validation to the `IngressController` custom resource and partially fixes Bug [1683766](https://bugzilla.redhat.com/show_bug.cgi?id=1683766).

- Adds `make crd` and `make verify-crd` to generate and verify crd modification respectively.
 
__Note:__ The schema is based on the currently vendored api definitions (853a7faf74b1c63a56e4010d39057559fa13271f) and not the latest from openshift/api.