### PR TITLE
Bug 1704982: Fix updating versions for ingress cluster operator

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -55,15 +55,15 @@ func main() {
 		log.Error(fmt.Errorf("missing environment variable"), "'WATCH_NAMESPACE' environment variable must be set")
 		os.Exit(1)
 	}
-	routerImage := os.Getenv("IMAGE")
-	if len(routerImage) == 0 {
+	ingressControllerImage := os.Getenv("IMAGE")
+	if len(ingressControllerImage) == 0 {
 		log.Error(fmt.Errorf("missing environment variable"), "'IMAGE' environment variable must be set")
 		os.Exit(1)
 	}
 	releaseVersion := os.Getenv("RELEASE_VERSION")
 	if len(releaseVersion) == 0 {
-		releaseVersion = controller.UnknownReleaseVersionName
-		log.Info("RELEASE_VERSION environment variable missing", "release version", controller.UnknownReleaseVersionName)
+		releaseVersion = controller.UnknownVersionValue
+		log.Info("RELEASE_VERSION environment variable missing", "release version", controller.UnknownVersionValue)
 	}
 
 	// Retrieve the cluster infrastructure config.
@@ -84,7 +84,7 @@ func main() {
 	operatorConfig := operatorconfig.Config{
 		OperatorReleaseVersion: releaseVersion,
 		Namespace:              operatorNamespace,
-		RouterImage:            routerImage,
+		IngressControllerImage: ingressControllerImage,
 	}
 
 	// Set up the DNS manager.

--- a/manifests/03-cluster-operator.yaml
+++ b/manifests/03-cluster-operator.yaml
@@ -1,7 +1,7 @@
+# This resource is not created by CVO, it is only used as a communication
+# mechanism to tell the CVO which ClusterOperator resource to wait for.
+# IngressController creates and updates this resource.
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: ingress
-spec: {}
-status:
-  # status is set at runtime

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -9,6 +9,6 @@ type Config struct {
 	// Namespace is the operator namespace.
 	Namespace string
 
-	// RouterImage is the router image to manage.
-	RouterImage string
+	// IngressControllerImage is the ingress controller image to manage.
+	IngressControllerImage string
 }

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -73,7 +73,7 @@ type Config struct {
 	ManifestFactory        *manifests.Factory
 	Namespace              string
 	DNSManager             dns.Manager
-	RouterImage            string
+	IngressControllerImage string
 	OperatorReleaseVersion string
 }
 

--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -24,7 +24,7 @@ import (
 // ensureRouterDeployment ensures the router deployment exists for a given
 // ingresscontroller.
 func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure) (*appsv1.Deployment, error) {
-	desired, err := desiredRouterDeployment(ci, r.Config.RouterImage, infraConfig)
+	desired, err := desiredRouterDeployment(ci, r.Config.IngressControllerImage, infraConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build router deployment: %v", err)
 	}
@@ -61,7 +61,7 @@ func (r *reconciler) ensureRouterDeleted(ci *operatorv1.IngressController) error
 }
 
 // desiredRouterDeployment returns the desired router deployment.
-func desiredRouterDeployment(ci *operatorv1.IngressController, routerImage string, infraConfig *configv1.Infrastructure) (*appsv1.Deployment, error) {
+func desiredRouterDeployment(ci *operatorv1.IngressController, ingressControllerImage string, infraConfig *configv1.Infrastructure) (*appsv1.Deployment, error) {
 	deployment := manifests.RouterDeployment()
 	name := RouterDeploymentName(ci)
 	deployment.Name = name.Name
@@ -210,7 +210,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, routerImage strin
 
 	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, env...)
 
-	deployment.Spec.Template.Spec.Containers[0].Image = routerImage
+	deployment.Spec.Template.Spec.Containers[0].Image = ingressControllerImage
 
 	if ci.Status.EndpointPublishingStrategy.Type == operatorv1.HostNetworkStrategyType {
 		// Expose ports 80 and 443 on the host to provide endpoints for

--- a/pkg/operator/controller/controller_router_deployment_test.go
+++ b/pkg/operator/controller/controller_router_deployment_test.go
@@ -48,14 +48,14 @@ func TestDesiredRouterDeployment(t *testing.T) {
 			},
 		},
 	}
-	routerImage := "quay.io/openshift/router:latest"
+	ingressControllerImage := "quay.io/openshift/router:latest"
 	infraConfig := &configv1.Infrastructure{
 		Status: configv1.InfrastructureStatus{
 			Platform: configv1.AWSPlatformType,
 		},
 	}
 
-	deployment, err := desiredRouterDeployment(ci, routerImage, infraConfig)
+	deployment, err := desiredRouterDeployment(ci, ingressControllerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	ci.Status.Domain = "example.com"
 	ci.Status.EndpointPublishingStrategy.Type = operatorv1.LoadBalancerServiceStrategyType
-	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig)
+	deployment, err = desiredRouterDeployment(ci, ingressControllerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	var expectedReplicas int32 = 3
 	ci.Spec.Replicas = &expectedReplicas
 	ci.Status.EndpointPublishingStrategy.Type = operatorv1.HostNetworkStrategyType
-	deployment, err = desiredRouterDeployment(ci, routerImage, infraConfig)
+	deployment, err = desiredRouterDeployment(ci, ingressControllerImage, infraConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	if *deployment.Spec.Replicas != expectedReplicas {
 		t.Errorf("expected replicas to be %d, got %d", expectedReplicas, *deployment.Spec.Replicas)
 	}
-	if e, a := routerImage, deployment.Spec.Template.Spec.Containers[0].Image; e != a {
+	if e, a := ingressControllerImage, deployment.Spec.Template.Spec.Containers[0].Image; e != a {
 		t.Errorf("expected router Deployment image %q, got %q", e, a)
 	}
 

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -20,18 +21,24 @@ import (
 )
 
 const (
-	IngressClusterOperatorName     = "ingress"
-	UnknownReleaseVersionName      = "unknown"
+	IngressClusterOperatorName = "ingress"
+
+	OperatorVersionName          = "operator"
+	IngressControllerVersionName = "ingress-controller"
+	UnknownVersionValue          = "unknown"
+
 	ingressesEqualConditionMessage = "desired and current number of IngressControllers are equal"
-	operatorVersionName            = "operator"
 )
 
 // syncOperatorStatus computes the operator's current status and therefrom
 // creates or updates the ClusterOperator resource for the operator.
 func (r *reconciler) syncOperatorStatus() error {
+	ns := manifests.RouterNamespace()
+
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: IngressClusterOperatorName}}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co); err != nil {
 		if errors.IsNotFound(err) {
+			initializeClusterOperator(co, ns.Name)
 			if err := r.client.Create(context.TODO(), co); err != nil {
 				return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
 			}
@@ -40,44 +47,20 @@ func (r *reconciler) syncOperatorStatus() error {
 			return fmt.Errorf("failed to get clusteroperator %s: %v", co.Name, err)
 		}
 	}
+	oldStatus := co.Status.DeepCopy()
 
-	ns, ingresses, err := r.getOperatorState()
+	ingresses, ns, err := r.getOperatorState(ns.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get operator state: %v", err)
 	}
+	allIngressesAvailable := checkAllIngressesAvailable(ingresses)
 
-	oldStatus := co.Status.DeepCopy()
-	co.Status.Conditions = computeOperatorStatusConditions(oldStatus.Conditions, ns, ingresses)
-	co.Status.RelatedObjects = []configv1.ObjectReference{
-		{
-			Resource: "namespaces",
-			Name:     "openshift-ingress-operator",
-		},
-		{
-			Resource: "namespaces",
-			Name:     ns.Name,
-		},
-	}
-
-	// An available operator resets release version
-	for _, condition := range co.Status.Conditions {
-		if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionTrue {
-			co.Status.Versions = []configv1.OperandVersion{
-				{
-					Name:    operatorVersionName,
-					Version: r.OperatorReleaseVersion,
-				},
-				{
-					Name:    "ingress-controller",
-					Version: r.RouterImage,
-				},
-			}
-		}
-	}
+	co.Status.Versions = r.computeOperatorStatusVersions(oldStatus.Versions, allIngressesAvailable)
+	co.Status.Conditions = r.computeOperatorStatusConditions(oldStatus.Conditions,
+		ns, allIngressesAvailable, co.Status.Versions)
 
 	if !operatorStatusesEqual(*oldStatus, co.Status) {
-		err = r.client.Status().Update(context.TODO(), co)
-		if err != nil {
+		if err := r.client.Status().Update(context.TODO(), co); err != nil {
 			return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
 		}
 	}
@@ -85,18 +68,53 @@ func (r *reconciler) syncOperatorStatus() error {
 	return nil
 }
 
+// Populate versions and conditions in cluster operator status as CVO expects these fields.
+func initializeClusterOperator(co *configv1.ClusterOperator, nsName string) {
+	co.Status.Versions = []configv1.OperandVersion{
+		{
+			Name:    OperatorVersionName,
+			Version: UnknownVersionValue,
+		},
+		{
+			Name:    IngressControllerVersionName,
+			Version: UnknownVersionValue,
+		},
+	}
+	co.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionUnknown,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionUnknown,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionUnknown,
+		},
+	}
+	co.Status.RelatedObjects = []configv1.ObjectReference{
+		{
+			Resource: "namespaces",
+			Name:     "openshift-ingress-operator",
+		},
+		{
+			Resource: "namespaces",
+			Name:     nsName,
+		},
+	}
+}
+
 // getOperatorState gets and returns the resources necessary to compute the
 // operator's current state.
-func (r *reconciler) getOperatorState() (*corev1.Namespace, []operatorv1.IngressController, error) {
-	ns := manifests.RouterNamespace()
-
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
+func (r *reconciler) getOperatorState(nsName string) ([]operatorv1.IngressController, *corev1.Namespace, error) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: nsName}, ns); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil, nil
 		}
-
-		return nil, nil, fmt.Errorf(
-			"error getting Namespace %s: %v", ns.Name, err)
+		return nil, nil, fmt.Errorf("error getting Namespace %s: %v", nsName, err)
 	}
 
 	ingressList := &operatorv1.IngressControllerList{}
@@ -104,24 +122,77 @@ func (r *reconciler) getOperatorState() (*corev1.Namespace, []operatorv1.Ingress
 		return nil, nil, fmt.Errorf("failed to list IngressControllers: %v", err)
 	}
 
-	return ns, ingressList.Items, nil
+	return ingressList.Items, ns, nil
+}
+
+// computeOperatorStatusVersions computes the operator's current versions.
+func (r *reconciler) computeOperatorStatusVersions(oldVersions []configv1.OperandVersion, allIngressesAvailable bool) []configv1.OperandVersion {
+	// We need to report old version until the operator fully transitions to the new version.
+	// https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#version-reporting-during-an-upgrade
+	if !allIngressesAvailable {
+		return oldVersions
+	}
+
+	return []configv1.OperandVersion{
+		{
+			Name:    OperatorVersionName,
+			Version: r.OperatorReleaseVersion,
+		},
+		{
+			Name:    IngressControllerVersionName,
+			Version: r.IngressControllerImage,
+		},
+	}
 }
 
 // computeOperatorStatusConditions computes the operator's current state.
-func computeOperatorStatusConditions(conditions []configv1.ClusterOperatorStatusCondition, ns *corev1.Namespace,
-	ingresses []operatorv1.IngressController) []configv1.ClusterOperatorStatusCondition {
-	conditions = computeOperatorDegradedCondition(conditions, ns)
-	conditions = computeOperatorProgressingCondition(conditions, ingresses)
-	conditions = computeOperatorAvailableCondition(conditions, ingresses)
+func (r *reconciler) computeOperatorStatusConditions(oldConditions []configv1.ClusterOperatorStatusCondition,
+	ns *corev1.Namespace, allIngressesAvailable bool,
+	curVersions []configv1.OperandVersion) []configv1.ClusterOperatorStatusCondition {
+	var oldDegradedCondition, oldProgressingCondition, oldAvailableCondition *configv1.ClusterOperatorStatusCondition
+	for i := range oldConditions {
+		switch oldConditions[i].Type {
+		case configv1.OperatorDegraded:
+			oldDegradedCondition = &oldConditions[i]
+		case configv1.OperatorProgressing:
+			oldProgressingCondition = &oldConditions[i]
+		case configv1.OperatorAvailable:
+			oldAvailableCondition = &oldConditions[i]
+		}
+	}
+
+	conditions := []configv1.ClusterOperatorStatusCondition{
+		computeOperatorDegradedCondition(oldDegradedCondition, ns),
+		r.computeOperatorProgressingCondition(oldProgressingCondition, allIngressesAvailable, curVersions),
+		computeOperatorAvailableCondition(oldAvailableCondition, allIngressesAvailable),
+	}
 
 	return conditions
 }
 
+// checkAllIngressesAvailable checks if all the ingress controllers are available.
+func checkAllIngressesAvailable(ingresses []operatorv1.IngressController) bool {
+	for _, ing := range ingresses {
+		available := false
+		for _, c := range ing.Status.Conditions {
+			if c.Type == operatorv1.IngressControllerAvailableConditionType && c.Status == operatorv1.ConditionTrue {
+				available = true
+				break
+			}
+		}
+		if !available {
+			return false
+		}
+	}
+
+	return (len(ingresses) != 0)
+}
+
 // computeOperatorDegradedCondition computes the operator's current Degraded status state.
-func computeOperatorDegradedCondition(conditions []configv1.ClusterOperatorStatusCondition, ns *corev1.Namespace) []configv1.ClusterOperatorStatusCondition {
-	degradedCondition := &configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.OperatorDegraded,
-		Status: configv1.ConditionUnknown,
+func computeOperatorDegradedCondition(oldCondition *configv1.ClusterOperatorStatusCondition,
+	ns *corev1.Namespace) configv1.ClusterOperatorStatusCondition {
+	degradedCondition := configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorDegraded,
 	}
 	if ns == nil {
 		degradedCondition.Status = configv1.ConditionTrue
@@ -132,100 +203,80 @@ func computeOperatorDegradedCondition(conditions []configv1.ClusterOperatorStatu
 		degradedCondition.Message = "operand namespace exists"
 	}
 
-	return setOperatorStatusCondition(conditions, degradedCondition)
+	setLastTransitionTime(&degradedCondition, oldCondition)
+	return degradedCondition
 }
 
 // computeOperatorProgressingCondition computes the operator's current Progressing status state.
-func computeOperatorProgressingCondition(conditions []configv1.ClusterOperatorStatusCondition, ingresses []operatorv1.IngressController) []configv1.ClusterOperatorStatusCondition {
+func (r *reconciler) computeOperatorProgressingCondition(oldCondition *configv1.ClusterOperatorStatusCondition,
+	allIngressesAvailable bool, curVersions []configv1.OperandVersion) configv1.ClusterOperatorStatusCondition {
 	// TODO: Update progressingCondition when an ingresscontroller
 	//       progressing condition is created. The Operator's condition
 	//       should be derived from the ingresscontroller's condition.
-	progressingCondition := &configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.OperatorProgressing,
-		Status: configv1.ConditionUnknown,
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorProgressing,
 	}
-	numIngresses := len(ingresses)
-	var ingressesAvailable int
-	for _, ing := range ingresses {
-		for _, c := range ing.Status.Conditions {
-			if c.Type == operatorv1.IngressControllerAvailableConditionType && c.Status == operatorv1.ConditionTrue {
-				ingressesAvailable++
-				break
+
+	messages := []string{}
+	if !allIngressesAvailable {
+		messages = append(messages, "Not all ingress controllers are available.")
+	}
+
+	for _, opv := range curVersions {
+		switch opv.Name {
+		case OperatorVersionName:
+			if opv.Version != r.OperatorReleaseVersion {
+				messages = append(messages, fmt.Sprintf("Moving to release version %q.", r.OperatorReleaseVersion))
+			}
+		case IngressControllerVersionName:
+			if opv.Version != r.IngressControllerImage {
+				messages = append(messages, fmt.Sprintf("Moving to ingress-controller image version %q.", r.IngressControllerImage))
 			}
 		}
 	}
-	if numIngresses == ingressesAvailable {
+
+	if len(messages) == 0 {
 		progressingCondition.Status = configv1.ConditionFalse
 		progressingCondition.Message = ingressesEqualConditionMessage
 	} else {
 		progressingCondition.Status = configv1.ConditionTrue
 		progressingCondition.Reason = "Reconciling"
-		progressingCondition.Message = fmt.Sprintf(
-			"%d ingress controllers available, want %d",
-			ingressesAvailable, numIngresses)
+		progressingCondition.Message = strings.Join(messages, "\n")
 	}
 
-	return setOperatorStatusCondition(conditions, progressingCondition)
+	setLastTransitionTime(&progressingCondition, oldCondition)
+	return progressingCondition
 }
 
 // computeOperatorAvailableCondition computes the operator's current Available status state.
-func computeOperatorAvailableCondition(conditions []configv1.ClusterOperatorStatusCondition,
-	ingresses []operatorv1.IngressController) []configv1.ClusterOperatorStatusCondition {
-	availableCondition := &configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.OperatorAvailable,
-		Status: configv1.ConditionUnknown,
+func computeOperatorAvailableCondition(oldCondition *configv1.ClusterOperatorStatusCondition,
+	allIngressesAvailable bool) configv1.ClusterOperatorStatusCondition {
+	availableCondition := configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorAvailable,
 	}
-	numIngresses := len(ingresses)
-	var ingressesAvailable int
-	for _, ing := range ingresses {
-		for _, c := range ing.Status.Conditions {
-			if c.Type == operatorv1.IngressControllerAvailableConditionType && c.Status == operatorv1.ConditionTrue {
-				ingressesAvailable++
-				break
-			}
-		}
-	}
-	if numIngresses == ingressesAvailable {
+
+	if allIngressesAvailable {
 		availableCondition.Status = configv1.ConditionTrue
 		availableCondition.Message = ingressesEqualConditionMessage
 	} else {
 		availableCondition.Status = configv1.ConditionFalse
 		availableCondition.Reason = "IngressUnavailable"
-		availableCondition.Message = fmt.Sprintf(
-			"%d ingress controllers available, want %d",
-			ingressesAvailable, numIngresses)
+		availableCondition.Message = "Not all ingress controllers are available."
 	}
 
-	return setOperatorStatusCondition(conditions, availableCondition)
+	setLastTransitionTime(&availableCondition, oldCondition)
+	return availableCondition
 }
 
-// setOperatorStatusCondition returns a slice of Operator status conditions as
-// a result of setting the specified condition in the given slice of conditions.
-func setOperatorStatusCondition(oldConditions []configv1.ClusterOperatorStatusCondition, condition *configv1.ClusterOperatorStatusCondition) []configv1.ClusterOperatorStatusCondition {
-	condition.LastTransitionTime = metav1.Now()
-
-	newConditions := []configv1.ClusterOperatorStatusCondition{}
-
-	found := false
-	for _, c := range oldConditions {
-		if condition.Type == c.Type {
-			if condition.Status == c.Status &&
-				condition.Reason == c.Reason &&
-				condition.Message == c.Message {
-				return oldConditions
-			}
-
-			found = true
-			newConditions = append(newConditions, *condition)
-		} else {
-			newConditions = append(newConditions, c)
-		}
+// setLastTransitionTime sets LastTransitionTime for the given condition.
+// If the condition has changed, it will assign a new timestamp otherwise keeps the old timestamp.
+func setLastTransitionTime(condition, oldCondition *configv1.ClusterOperatorStatusCondition) {
+	if oldCondition != nil && condition.Status == oldCondition.Status &&
+		condition.Reason == oldCondition.Reason && condition.Message == oldCondition.Message {
+		condition.LastTransitionTime = oldCondition.LastTransitionTime
+	} else {
+		condition.LastTransitionTime = metav1.Now()
 	}
-	if !found {
-		newConditions = append(newConditions, *condition)
-	}
-
-	return newConditions
 }
 
 // operatorStatusesEqual compares two ClusterOperatorStatus values.  Returns

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -89,7 +89,7 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 		Namespace:              config.Namespace,
 		ManifestFactory:        &manifests.Factory{},
 		DNSManager:             dnsManager,
-		RouterImage:            config.RouterImage,
+		IngressControllerImage: config.IngressControllerImage,
 		OperatorReleaseVersion: config.OperatorReleaseVersion,
 	})
 	if err != nil {


### PR DESCRIPTION
- Always report 'operator' version irrespective of available condition.

- For upgrades, report old versions until the new version is fully applied.