### PR TITLE
Delete registration of client-go GCP auth plug-in

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -19,8 +19,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"


### PR DESCRIPTION
This import was added accidentally.

* `cmd/cluster-ingress-operator/main.go`: Delete import of the client-go GCP auth plug-in.