### PR TITLE
Bug 1701462: deploymentConfigChanged: Fix deleting tolerations

### DIFF
--- a/pkg/operator/controller/controller_router_deployment.go
+++ b/pkg/operator/controller/controller_router_deployment.go
@@ -286,9 +286,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
 	updated.Spec.Template.Spec.Containers[0].Env = expected.Spec.Template.Spec.Containers[0].Env
 	updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
-	if expected.Spec.Template.Spec.Tolerations != nil {
-		updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
-	}
+	updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
 	replicas := int32(1)
 	if expected.Spec.Replicas != nil {
 		replicas = *expected.Spec.Replicas


### PR DESCRIPTION
Always update tolerations if the router deployment has changed,

Before this commit, `deploymentConfigChanged` only updated the tolerations on the deployment if the deployment was expected to have tolerations.  As a result, `deploymentConfigChanged` did not remove tolerations when the deployment had tolerations and was expected not to.

* `pkg/operator/controller/controller_router_deployment.go` (`deploymentConfigChanged`): Delete condition for assignment of tolerations.