### PR TITLE
start-build.sh: Don't patch operator IMAGE env var

### DIFF
--- a/hack/start-build.sh
+++ b/hack/start-build.sh
@@ -16,12 +16,6 @@ then
         "containers": [
           {
             "name": "ingress-operator",
-            "env": [
-              {
-                "name": "IMAGE",
-                "value": "image-registry.openshift-image-registry.svc:5000/openshift-ingress-operator/ingress-operator:latest"
-              }
-            ],
             "image": "image-registry.openshift-image-registry.svc:5000/openshift-ingress-operator/ingress-operator:latest",
             "imagePullPolicy": "Always"
           }


### PR DESCRIPTION
Do not override the `IMAGE` environment variable when patching the operator deployment.  `IMAGE` specifies the operand image, and the patch should only change the operator image.

* `hack/start-build.sh`: Delete the `IMAGE` environment variable from the patch to the operator deployment.