### PR TITLE
Expands IngressController status conditions

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -221,9 +221,6 @@ func computeOperatorDegradedCondition(oldCondition *configv1.ClusterOperatorStat
 // computeOperatorProgressingCondition computes the operator's current Progressing status state.
 func (r *reconciler) computeOperatorProgressingCondition(oldCondition *configv1.ClusterOperatorStatusCondition,
 	allIngressesAvailable bool, oldVersions, curVersions []configv1.OperandVersion) configv1.ClusterOperatorStatusCondition {
-	// TODO: Update progressingCondition when an ingresscontroller
-	//       progressing condition is created. The Operator's condition
-	//       should be derived from the ingresscontroller's condition.
 	progressingCondition := configv1.ClusterOperatorStatusCondition{
 		Type: configv1.OperatorProgressing,
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -44,6 +44,7 @@ const (
 var (
 	defaultAvailableConditions = []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
+		{Type: ingresscontroller.DeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},


### PR DESCRIPTION
- Refactors the `IngressController` `Available` condition to be based on the `Available` status of `IngressController` dependent resources (i.e. `DNS`).
- Adds a `Deployment` status condition.
- Adds unit tests.
- Updates e2e tests.