### PR TITLE
Bug 1705100: TestIngressControllerScale: Re-get between updates

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -490,6 +490,9 @@ func TestIngressControllerScale(t *testing.T) {
 	originalReplicas := *deployment.Spec.Replicas
 	newReplicas := originalReplicas + 1
 
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: name}, ci); err != nil {
+		t.Fatalf("failed to get default ingresscontroller: %v", err)
+	}
 	ci.Spec.Replicas = &newReplicas
 	if err := cl.Update(context.TODO(), ci); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
@@ -512,6 +515,9 @@ func TestIngressControllerScale(t *testing.T) {
 	}
 
 	// Scale back down.
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: name}, ci); err != nil {
+		t.Fatalf("failed to get default ingresscontroller: %v", err)
+	}
 	ci.Spec.Replicas = &originalReplicas
 	if err := cl.Update(context.TODO(), ci); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)


### PR DESCRIPTION
Get the ingress controller from the API in between updates so that that each update uses the latest resource version in order to prevent the following test failure:

    --- FAIL: TestIngressControllerScale (2.62s)
    	operator_test.go:517: failed to update ingresscontroller: Operation cannot be fulfilled on ingresscontrollers.operator.openshift.io "default": the object has been modified; please apply your changes to the latest version and try again

* `test/e2e/operator_test.go` (`TestIngressControllerScale`): Get the ingress controller in between updates to ensure we have the latest resource version for each update.

---

@ironcladlou, it looks like https://github.com/openshift/cluster-ingress-operator/pull/223 was insufficient—I saw the above failure here: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/224/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-operator/850