### PR TITLE
Fix hack/release.sh: Skip ClusterOperator resource creation

### DIFF
--- a/hack/release-local.sh
+++ b/hack/release-local.sh
@@ -32,6 +32,8 @@ fi
 
 cp -R manifests/* $MANIFESTS
 cat manifests/02-deployment.yaml | sed "s~openshift/origin-cluster-ingress-operator:latest~$REPO:$TAG~" > "$MANIFESTS/02-deployment.yaml"
+# To simulate CVO, ClusterOperator resource need to be created by the operator.
+rm $MANIFESTS/03-cluster-operator.yaml
 
 echo "Pushed $REPO:$TAG"
 echo "Install manifests using:"


### PR DESCRIPTION
- As per the spec[1], ClusterOperator resource must be created by the operator.

[1] https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#how-clusterversionoperator-handles-clusteroperator-in-release-imagehttps://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#how-clusterversionoperator-handles-clusteroperator-in-release-image