### PR TITLE
Don't ignore LastTransitionTime when comparing ingress controller status conditions

### DIFF
--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -299,7 +299,6 @@ func setLastTransitionTime(condition, oldCondition *configv1.ClusterOperatorStat
 // for the purpose of determining whether an update is necessary, false otherwise.
 func operatorStatusesEqual(a, b configv1.ClusterOperatorStatus) bool {
 	conditionCmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(configv1.ClusterOperatorStatusCondition{}, "LastTransitionTime"),
 		cmpopts.EquateEmpty(),
 		cmpopts.SortSlices(func(a, b configv1.ClusterOperatorStatusCondition) bool { return a.Type < b.Type }),
 	}

--- a/pkg/operator/controller/status_test.go
+++ b/pkg/operator/controller/status_test.go
@@ -236,8 +236,8 @@ func TestOperatorStatusesEqual(t *testing.T) {
 			},
 		},
 		{
-			description: "condition LastTransitionTime should be ignored",
-			expected:    true,
+			description: "condition LastTransitionTime should not be ignored",
+			expected:    false,
 			a: configv1.ClusterOperatorStatus{
 				Conditions: []configv1.ClusterOperatorStatusCondition{
 					{


### PR DESCRIPTION
- LastTransitionTime field is only changed when there is a change,
so we expect LastTransitionTime to remain the same when there is no change.

- Some refactor related to handling of ingress status conditions and corresponding tests.