### PR TITLE
publishingStrategyTypeForInfra: Add case for Azure

### DIFF
--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -240,7 +240,7 @@ func (r *reconciler) isDomainUnique(domain string) (bool, error) {
 // strategy type for the given infrastructure config.
 func publishingStrategyTypeForInfra(infraConfig *configv1.Infrastructure) operatorv1.EndpointPublishingStrategyType {
 	switch infraConfig.Status.Platform {
-	case configv1.AWSPlatformType:
+	case configv1.AWSPlatformType, configv1.AzurePlatformType:
 		return operatorv1.LoadBalancerServiceStrategyType
 	case configv1.LibvirtPlatformType:
 		return operatorv1.HostNetworkStrategyType


### PR DESCRIPTION
This commit is related to [NE-185](https://jira.coreos.com/browse/NE-185).

* `pkg/operator/controller/controller.go` (`publishingStrategyTypeForInfra`): Use `LoadBalancerServiceStrategyType` for Azure.

---

API change: https://github.com/openshift/api/pull/311