### PR TITLE
Make the ingress operator hostNetwork

### DIFF
--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         tolerationSeconds: 120
       serviceAccountName: ingress-operator
       priorityClassName: system-cluster-critical
+      hostNetwork: true
       containers:
         - name: ingress-operator
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
We're considering blocking access from the pod network to the AWS metadata IP by default. Even if we don't do it in openshift-sdn, there may be other network plugins that implement this behavior. (The 169.254.0.0/16 range is supposed to be "link-local", so it's technically incorrect to route traffic for 169.254.169.254 from br0 to eth0.) So this makes the ingress operator run as hostNetwork. (As seen in https://github.com/openshift/origin/pull/22826, the ingress operator is currently the only OpenShift pod that tries to reach the metadata IP from the pod network.)

It's possible that it depends on being non-hostNetwork in some way in which case this will totally break things? Let's see what e2e-aws says...