### PR TITLE
Add LoadBalancer status reporting on IngressController

### DIFF
--- a/pkg/operator/controller/ingress_status.go
+++ b/pkg/operator/controller/ingress_status.go
@@ -7,10 +7,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // syncIngressControllerStatus computes the current status of ic and
@@ -24,7 +33,24 @@ func (r *reconciler) syncIngressControllerStatus(deployment *appsv1.Deployment, 
 	updated := ic.DeepCopy()
 	updated.Status.AvailableReplicas = deployment.Status.AvailableReplicas
 	updated.Status.Selector = selector.String()
-	updated.Status.Conditions = computeIngressStatusConditions(updated.Status.Conditions, deployment)
+
+	updated.Status.Conditions = []operatorv1.OperatorCondition{}
+	updated.Status.Conditions = append(updated.Status.Conditions, computeIngressStatusConditions(updated.Status.Conditions, deployment)...)
+	updated.Status.Conditions = append(updated.Status.Conditions, r.statusCache.computeLoadBalancerStatus(ic)...)
+
+	for i := range updated.Status.Conditions {
+		newCondition := &updated.Status.Conditions[i]
+		var oldCondition *operatorv1.OperatorCondition
+		for j, possibleOldCondition := range ic.Status.Conditions {
+			if possibleOldCondition.Type == newCondition.Type {
+				old := ic.Status.Conditions[j]
+				oldCondition = &old
+				break
+			}
+		}
+		setIngressLastTransitionTime(newCondition, oldCondition)
+	}
+
 	if !ingressStatusesEqual(updated.Status, ic.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
 			return fmt.Errorf("failed to update ingresscontroller status: %v", err)
@@ -57,7 +83,6 @@ func computeIngressAvailableCondition(oldAvailableCondition *operatorv1.Operator
 		availableCondition.Message = "no Deployment replicas available"
 	}
 
-	setIngressLastTransitionTime(&availableCondition, oldAvailableCondition)
 	return availableCondition
 }
 
@@ -100,4 +125,157 @@ func ingressStatusesEqual(a, b operatorv1.IngressControllerStatus) bool {
 	}
 
 	return true
+}
+
+func isProvisioned(service *corev1.Service) bool {
+	ingresses := service.Status.LoadBalancer.Ingress
+	return len(ingresses) > 0 && (len(ingresses[0].Hostname) > 0 || len(ingresses[0].IP) > 0)
+}
+
+func isPending(service *corev1.Service) bool {
+	return !isProvisioned(service)
+}
+
+func getServiceOwnerIfMatches(service *corev1.Service, matches func(*corev1.Service) bool) []string {
+	if !matches(service) {
+		return []string{}
+	}
+	controller, ok := service.Labels[manifests.OwningIngressControllerLabel]
+	if !ok {
+		return []string{}
+	}
+	return []string{controller}
+}
+
+func indexLoadBalancerControllerByName(obj runtime.Object) []string {
+	c, ok := obj.(*operatorv1.IngressController)
+	if !ok {
+		return []string{}
+	}
+	if c.Status.EndpointPublishingStrategy != nil &&
+		c.Status.EndpointPublishingStrategy.Type == operatorv1.LoadBalancerServiceStrategyType {
+		return []string{c.Name}
+	}
+	return []string{}
+}
+
+func indexProvisionedLoadBalancerServiceByOwner(obj runtime.Object) []string {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		return []string{}
+	}
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return []string{}
+	}
+	return getServiceOwnerIfMatches(service, isProvisioned)
+}
+
+func indexPendingLoadBalancerServiceByOwner(obj runtime.Object) []string {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		return []string{}
+	}
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return []string{}
+	}
+	return getServiceOwnerIfMatches(service, isPending)
+}
+
+// ingressStatusCache knows how to compute status for ingress controllers by
+// querying indexes caches.
+type ingressStatusCache struct {
+	// contains returns true if there are >0 matches on value for the named index
+	// for the given kind.
+	//
+	// listKind must be the List type for the object being indexed.
+	contains func(listKind runtime.Object, name, value string) bool
+}
+
+// serviceIndexers are all the Service indexes supported by the cache.
+var serviceIndexers = map[string]client.IndexerFunc{
+	"pending-for":     indexPendingLoadBalancerServiceByOwner,
+	"provisioned-for": indexProvisionedLoadBalancerServiceByOwner,
+}
+
+// controllerIndexers are all the IngressController indexes supported by the
+// cache.
+var controllerIndexers = map[string]client.IndexerFunc{
+	"wants-load-balancer": indexLoadBalancerControllerByName,
+}
+
+// cacheContains is a contains fuction which knows how to query a cache.Cache.
+func cacheContains(cache cache.Cache, list runtime.Object, name, value string) bool {
+	err := cache.List(context.TODO(), list, client.MatchingField(name, value))
+	if err != nil {
+		return false
+	}
+	// TODO: after rebase, replace with:
+	// meta.LenList(list) > 0
+	items, _ := meta.ExtractList(list)
+	return len(items) > 0
+}
+
+func NewIngressStatusCache(c cache.Cache) *ingressStatusCache {
+	add := func(cache cache.Cache, kind runtime.Object, indexers map[string]client.IndexerFunc) {
+		for name := range indexers {
+			cache.IndexField(kind, name, indexers[name])
+		}
+	}
+	add(c, &operatorv1.IngressController{}, controllerIndexers)
+	add(c, &corev1.Service{}, serviceIndexers)
+	return &ingressStatusCache{
+		contains: func(kind runtime.Object, name, value string) bool {
+			return cacheContains(c, kind, name, value)
+		},
+	}
+}
+
+// computeLoadBalancerStatus returns the complete set of current
+// LoadBalancer-prefixed conditions for the given ingress controller.
+func (c *ingressStatusCache) computeLoadBalancerStatus(ic *operatorv1.IngressController) []operatorv1.OperatorCondition {
+	if !c.contains(&operatorv1.IngressControllerList{}, "wants-load-balancer", ic.Name) {
+		return []operatorv1.OperatorCondition{
+			{
+				Type:    operatorv1.LoadBalancerManagedIngressConditionType,
+				Status:  operatorv1.ConditionFalse,
+				Reason:  "UnsupportedEndpointPublishingStrategy",
+				Message: fmt.Sprintf("The %s endpoint publishing strategy does not support a load balancer", ic.Status.EndpointPublishingStrategy.Type),
+			},
+		}
+	}
+
+	conditions := []operatorv1.OperatorCondition{}
+
+	conditions = append(conditions, operatorv1.OperatorCondition{
+		Type:    operatorv1.LoadBalancerManagedIngressConditionType,
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "HasLoadBalancerEndpointPublishingStrategy",
+		Message: "IngressController has LoadBalancer endpoint publishing strategy",
+	})
+
+	switch {
+	case c.contains(&corev1.ServiceList{}, "pending-for", ic.Name):
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "LoadBalancerPending",
+			Message: "The LoadBalancer service is pending",
+		})
+	case c.contains(&corev1.ServiceList{}, "provisioned-for", ic.Name):
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "LoadBalancerProvisioned",
+			Message: "The LoadBalancer service is provisioned",
+		})
+	default:
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "LoadBalancerNotFound",
+			Message: "The LoadBalancer service resource is missing",
+		})
+	}
+
+	return conditions
 }

--- a/pkg/operator/controller/ingress_status_test.go
+++ b/pkg/operator/controller/ingress_status_test.go
@@ -6,12 +6,199 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	toolscache "k8s.io/client-go/tools/cache"
 )
+
+func pendingLBService(owner string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router-" + owner,
+			Labels: map[string]string{
+				manifests.OwningIngressControllerLabel: owner,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+	}
+}
+
+func provisionedLBservice(owner string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router-" + owner,
+			Labels: map[string]string{
+				manifests.OwningIngressControllerLabel: owner,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "lb.cloudprovider.example.com"},
+				},
+			},
+		},
+	}
+}
+
+func clusterIPservice(name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router-" + name + "internal",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
+func cond(t string, status operatorv1.ConditionStatus, reason string) operatorv1.OperatorCondition {
+	return operatorv1.OperatorCondition{
+		Type:   t,
+		Status: status,
+		Reason: reason,
+	}
+}
+
+func indexerContains(indexer toolscache.Indexer, name, value string) bool {
+	objects, err := indexer.ByIndex(name, value)
+	if err != nil {
+		return false
+	}
+	return len(objects) > 0
+}
+
+func makeIndexers(funcs map[string]client.IndexerFunc) toolscache.Indexers {
+	indexers := map[string]toolscache.IndexFunc{}
+	for name := range funcs {
+		fn := funcs[name]
+		indexers[name] = func(obj interface{}) ([]string, error) {
+			return fn(obj.(runtime.Object)), nil
+		}
+	}
+	return indexers
+}
+
+func TestComputeLoadBalancerStatus(t *testing.T) {
+	tests := []struct {
+		desc       string
+		controller string
+		strat      operatorv1.EndpointPublishingStrategyType
+		services   []*corev1.Service
+		expect     []operatorv1.OperatorCondition
+	}{
+		{
+			desc:       "provisioned/ready",
+			controller: "default",
+			strat:      operatorv1.LoadBalancerServiceStrategyType,
+			services: []*corev1.Service{
+				provisionedLBservice("secondary"),
+				provisionedLBservice("default"),
+				clusterIPservice("default"),
+			},
+			expect: []operatorv1.OperatorCondition{
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "HasLoadBalancerEndpointPublishingStrategy"),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "LoadBalancerProvisioned"),
+			},
+		},
+		{
+			desc:       "pending/unready",
+			controller: "default",
+			strat:      operatorv1.LoadBalancerServiceStrategyType,
+			services: []*corev1.Service{
+				provisionedLBservice("secondary"),
+				pendingLBService("default"),
+				clusterIPservice("default"),
+			},
+			expect: []operatorv1.OperatorCondition{
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "HasLoadBalancerEndpointPublishingStrategy"),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionFalse, "LoadBalancerPending"),
+			},
+		},
+		{
+			desc:       "unmanaged",
+			controller: "default",
+			strat:      operatorv1.HostNetworkStrategyType,
+			services: []*corev1.Service{
+				provisionedLBservice("secondary"),
+				clusterIPservice("default"),
+			},
+			expect: []operatorv1.OperatorCondition{
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionFalse, "UnsupportedEndpointPublishingStrategy"),
+			},
+		},
+		{
+			desc:       "missing",
+			controller: "default",
+			strat:      operatorv1.LoadBalancerServiceStrategyType,
+			services: []*corev1.Service{
+				provisionedLBservice("secondary"),
+				clusterIPservice("default"),
+			},
+			expect: []operatorv1.OperatorCondition{
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "HasLoadBalancerEndpointPublishingStrategy"),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionFalse, "LoadBalancerNotFound"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("evaluating test %s", test.desc)
+		controllers := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, makeIndexers(controllerIndexers))
+		services := toolscache.NewIndexer(toolscache.MetaNamespaceKeyFunc, makeIndexers(serviceIndexers))
+		status := &ingressStatusCache{
+			contains: func(kind runtime.Object, name, value string) bool {
+				switch kind.(type) {
+				case *corev1.ServiceList:
+					return indexerContains(services, name, value)
+				case *operatorv1.IngressControllerList:
+					return indexerContains(controllers, name, value)
+				default:
+					return false
+				}
+			},
+		}
+		controller := &operatorv1.IngressController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: test.controller,
+			},
+			Status: operatorv1.IngressControllerStatus{
+				EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+					Type: test.strat,
+				},
+			},
+		}
+		controllers.Add(controller)
+		for i := range test.services {
+			services.Add(test.services[i])
+		}
+
+		actual := status.computeLoadBalancerStatus(controller)
+		conditionsCmpOpts := []cmp.Option{
+			cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "LastTransitionTime", "Message"),
+			cmpopts.EquateEmpty(),
+			cmpopts.SortSlices(func(a, b operatorv1.OperatorCondition) bool { return a.Type < b.Type }),
+		}
+		if !cmp.Equal(actual, test.expect, conditionsCmpOpts...) {
+			t.Fatalf("expected:\n%#v\ngot:\n%#v", test.expect, actual)
+		}
+	}
+}
 
 func TestComputeIngressStatusConditions(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Compute LoadBalancer* status conditions on IngressController resources. Do so by
introducing some new cache/index capabilities.