### PR TITLE
Bug 1717494: Refactor client and cache handling

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -55,9 +55,10 @@ func main() {
 	// Collect operator configuration.
 	operatorNamespace := os.Getenv("WATCH_NAMESPACE")
 	if len(operatorNamespace) == 0 {
-		log.Error(fmt.Errorf("missing environment variable"), "'WATCH_NAMESPACE' environment variable must be set")
-		os.Exit(1)
+		operatorNamespace = "openshift-ingress-operator"
 	}
+	log.Info("using operator namespace", "namespace", operatorNamespace)
+
 	ingressControllerImage := os.Getenv("IMAGE")
 	if len(ingressControllerImage) == 0 {
 		log.Error(fmt.Errorf("missing environment variable"), "'IMAGE' environment variable must be set")

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -30,7 +30,7 @@ if [ "$WHAT" == "all" ]; then
   oc delete clusterrolebindings/openshift-ingress-operator
   oc delete clusterrolebindings/openshift-ingress-router
   oc delete clusterrolebindings/router-monitoring
-  oc delete customresourcedefinition.apiextensions.k8s.io/ingresscontroller.operator.openshift.io
+  oc delete customresourcedefinition.apiextensions.k8s.io/ingresscontrollers.operator.openshift.io
 fi
 
 oc delete -n openshift-config-managed configmaps/router-ca

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -37,9 +37,9 @@ const (
 
 var log = logf.Logger.WithName(controllerName)
 
-func New(mgr manager.Manager, client client.Client, operatorNamespace string) (runtimecontroller.Controller, error) {
+func New(mgr manager.Manager, operatorNamespace string) (runtimecontroller.Controller, error) {
 	reconciler := &reconciler{
-		client:            client,
+		client:            mgr.GetClient(),
 		recorder:          mgr.GetEventRecorderFor(controllerName),
 		operatorNamespace: operatorNamespace,
 	}

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -23,6 +23,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -40,6 +41,7 @@ var log = logf.Logger.WithName(controllerName)
 func New(mgr manager.Manager, operatorNamespace string) (runtimecontroller.Controller, error) {
 	reconciler := &reconciler{
 		client:            mgr.GetClient(),
+		cache:             mgr.GetCache(),
 		recorder:          mgr.GetEventRecorderFor(controllerName),
 		operatorNamespace: operatorNamespace,
 	}
@@ -55,6 +57,7 @@ func New(mgr manager.Manager, operatorNamespace string) (runtimecontroller.Contr
 
 type reconciler struct {
 	client            client.Client
+	cache             cache.Cache
 	recorder          record.EventRecorder
 	operatorNamespace string
 }
@@ -106,7 +109,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	ingresses := &operatorv1.IngressControllerList{}
-	if err := r.client.List(context.TODO(), ingresses, client.InNamespace(r.operatorNamespace)); err != nil {
+	if err := r.cache.List(context.TODO(), ingresses, client.InNamespace(r.operatorNamespace)); err != nil {
 		errs = append(errs, fmt.Errorf("failed to list ingresscontrollers: %v", err))
 	} else if err := r.ensureRouterCAConfigMap(ca, ingresses.Items); err != nil {
 		errs = append(errs, fmt.Errorf("failed to publish router CA: %v", err))

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -45,9 +45,14 @@ var log = logf.Logger.WithName("controller")
 // The controller will be pre-configured to watch for IngressController resources
 // in the manager namespace.
 func New(mgr manager.Manager, statusCache *ingressStatusCache, config Config) (controller.Controller, error) {
+	liveClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
+	if err != nil {
+		return nil, err
+	}
 	reconciler := &reconciler{
 		Config:      config,
 		client:      mgr.GetClient(),
+		liveClient:  liveClient,
 		recorder:    mgr.GetEventRecorderFor("operator-controller"),
 		statusCache: statusCache,
 	}
@@ -103,6 +108,10 @@ type reconciler struct {
 
 	client   client.Client
 	recorder record.EventRecorder
+	// This is a non-caching client which is currently necessary for working with
+	// cluster-scoped resources. When the MultiNamespaceCache supports
+	// cluster-scoped resources, this client can be removed.
+	liveClient client.Client
 
 	statusCache *ingressStatusCache
 }
@@ -132,17 +141,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if ingress != nil {
 		dnsConfig := &configv1.DNS{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, dnsConfig); err != nil {
+		if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, dnsConfig); err != nil {
 			errs = append(errs, fmt.Errorf("failed to get dns 'cluster': %v", err))
 			dnsConfig = nil
 		}
 		infraConfig := &configv1.Infrastructure{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
+		if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
 			errs = append(errs, fmt.Errorf("failed to get infrastructure 'cluster': %v", err))
 			infraConfig = nil
 		}
 		ingressConfig := &configv1.Ingress{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, ingressConfig); err != nil {
+		if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, ingressConfig); err != nil {
 			errs = append(errs, fmt.Errorf("failed to get ingress 'cluster': %v", err))
 			ingressConfig = nil
 		}
@@ -336,22 +345,22 @@ func (r *reconciler) ensureIngressDeleted(ingress *operatorv1.IngressController,
 // routers generally, including a namespace and all RBAC setup.
 func (r *reconciler) ensureRouterNamespace() error {
 	cr := manifests.RouterClusterRole()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name}, cr); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: cr.Name}, cr); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router cluster role %s: %v", cr.Name, err)
 		}
-		if err := r.client.Create(context.TODO(), cr); err != nil {
+		if err := r.liveClient.Create(context.TODO(), cr); err != nil {
 			return fmt.Errorf("failed to create router cluster role %s: %v", cr.Name, err)
 		}
 		log.Info("created router cluster role", "name", cr.Name)
 	}
 
 	ns := manifests.RouterNamespace()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router namespace %q: %v", ns.Name, err)
 		}
-		if err := r.client.Create(context.TODO(), ns); err != nil {
+		if err := r.liveClient.Create(context.TODO(), ns); err != nil {
 			return fmt.Errorf("failed to create router namespace %s: %v", ns.Name, err)
 		}
 		log.Info("created router namespace", "name", ns.Name)
@@ -369,11 +378,11 @@ func (r *reconciler) ensureRouterNamespace() error {
 	}
 
 	crb := manifests.RouterClusterRoleBinding()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: crb.Name}, crb); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: crb.Name}, crb); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router cluster role binding %s: %v", crb.Name, err)
 		}
-		if err := r.client.Create(context.TODO(), crb); err != nil {
+		if err := r.liveClient.Create(context.TODO(), crb); err != nil {
 			return fmt.Errorf("failed to create router cluster role binding %s: %v", crb.Name, err)
 		}
 		log.Info("created router cluster role binding", "name", crb.Name)
@@ -384,37 +393,42 @@ func (r *reconciler) ensureRouterNamespace() error {
 
 // ensureIngressController ensures all necessary router resources exist for a given ingresscontroller.
 func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure) error {
+	deployment, err := r.ensureRouterDeployment(ci, infraConfig)
+	if err != nil {
+		return fmt.Errorf("failed to ensure router deployment for %s: %v", ci.Name, err)
+	}
+
+	if deployment == nil {
+		log.V(4).Info("no deployment found for ingresscontroller", "ingresscontroller", ci.Name)
+		return nil
+	}
+
 	errs := []error{}
+	trueVar := true
+	deploymentRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       deployment.Name,
+		UID:        deployment.UID,
+		Controller: &trueVar,
+	}
 
-	if deployment, err := r.ensureRouterDeployment(ci, infraConfig); err != nil {
-		errs = append(errs, fmt.Errorf("failed to ensure router deployment for %s: %v", ci.Name, err))
-	} else {
-		trueVar := true
-		deploymentRef := metav1.OwnerReference{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       deployment.Name,
-			UID:        deployment.UID,
-			Controller: &trueVar,
+	if lbService, err := r.ensureLoadBalancerService(ci, deploymentRef, infraConfig); err != nil {
+		errs = append(errs, fmt.Errorf("failed to ensure load balancer service for %s: %v", ci.Name, err))
+	} else if lbService != nil {
+		if err := r.ensureDNS(ci, lbService, dnsConfig); err != nil {
+			errs = append(errs, fmt.Errorf("failed to ensure DNS for %s: %v", ci.Name, err))
 		}
+	}
 
-		if lbService, err := r.ensureLoadBalancerService(ci, deploymentRef, infraConfig); err != nil {
-			errs = append(errs, fmt.Errorf("failed to ensure load balancer service for %s: %v", ci.Name, err))
-		} else if lbService != nil {
-			if err := r.ensureDNS(ci, lbService, dnsConfig); err != nil {
-				errs = append(errs, fmt.Errorf("failed to ensure DNS for %s: %v", ci.Name, err))
-			}
-		}
+	if internalSvc, err := r.ensureInternalIngressControllerService(ci, deploymentRef); err != nil {
+		errs = append(errs, fmt.Errorf("failed to create internal router service for ingresscontroller %s: %v", ci.Name, err))
+	} else if err := r.ensureMetricsIntegration(ci, internalSvc, deploymentRef); err != nil {
+		errs = append(errs, fmt.Errorf("failed to integrate metrics with openshift-monitoring for ingresscontroller %s: %v", ci.Name, err))
+	}
 
-		if internalSvc, err := r.ensureInternalIngressControllerService(ci, deploymentRef); err != nil {
-			errs = append(errs, fmt.Errorf("failed to create internal router service for ingresscontroller %s: %v", ci.Name, err))
-		} else if err := r.ensureMetricsIntegration(ci, internalSvc, deploymentRef); err != nil {
-			errs = append(errs, fmt.Errorf("failed to integrate metrics with openshift-monitoring for ingresscontroller %s: %v", ci.Name, err))
-		}
-
-		if err := r.syncIngressControllerStatus(deployment, ci); err != nil {
-			errs = append(errs, fmt.Errorf("failed to sync ingresscontroller status: %v", err))
-		}
+	if err := r.syncIngressControllerStatus(deployment, ci); err != nil {
+		errs = append(errs, fmt.Errorf("failed to sync ingresscontroller status: %v", err))
 	}
 
 	return utilerrors.NewAggregate(errs)
@@ -436,22 +450,22 @@ func (r *reconciler) ensureMetricsIntegration(ci *operatorv1.IngressController, 
 	}
 
 	cr := manifests.MetricsClusterRole()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name}, cr); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: cr.Name}, cr); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics cluster role %s: %v", cr.Name, err)
 		}
-		if err := r.client.Create(context.TODO(), cr); err != nil {
+		if err := r.liveClient.Create(context.TODO(), cr); err != nil {
 			return fmt.Errorf("failed to create router metrics cluster role %s: %v", cr.Name, err)
 		}
 		log.Info("created router metrics cluster role", "name", cr.Name)
 	}
 
 	crb := manifests.MetricsClusterRoleBinding()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: crb.Name}, crb); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: crb.Name}, crb); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get router metrics cluster role binding %s: %v", crb.Name, err)
 		}
-		if err := r.client.Create(context.TODO(), crb); err != nil {
+		if err := r.liveClient.Create(context.TODO(), crb); err != nil {
 			return fmt.Errorf("failed to create router metrics cluster role binding %s: %v", crb.Name, err)
 		}
 		log.Info("created router metrics cluster role binding", "name", crb.Name)

--- a/pkg/operator/controller/controller_service_monitor.go
+++ b/pkg/operator/controller/controller_service_monitor.go
@@ -9,10 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
-
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,20 +85,6 @@ func (r *reconciler) currentServiceMonitor(ic *operatorv1.IngressController) (*u
 		Version: "v1",
 	})
 	if err := r.client.Get(context.TODO(), IngressControllerServiceMonitorName(ic), sm); err != nil {
-		if meta.IsNoMatchError(err) {
-			// Refresh kube client with latest rest scheme/mapper.
-			kClient, err := operatorclient.NewClient(r.KubeConfig)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create kube client: %v", err)
-			}
-			r.client = kClient
-
-			err = r.client.Get(context.TODO(), IngressControllerServiceMonitorName(ic), sm)
-			if err == nil {
-				return sm, nil
-			}
-		}
-
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -36,10 +36,10 @@ func (r *reconciler) syncOperatorStatus() error {
 	ns := manifests.RouterNamespace()
 
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: IngressClusterOperatorName}}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co); err != nil {
 		if errors.IsNotFound(err) {
 			initializeClusterOperator(co, ns.Name)
-			if err := r.client.Create(context.TODO(), co); err != nil {
+			if err := r.liveClient.Create(context.TODO(), co); err != nil {
 				return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
 			}
 			log.Info("created clusteroperator", "object", co)
@@ -60,7 +60,7 @@ func (r *reconciler) syncOperatorStatus() error {
 		ns, allIngressesAvailable, oldStatus.Versions, co.Status.Versions)
 
 	if !operatorStatusesEqual(*oldStatus, co.Status) {
-		if err := r.client.Status().Update(context.TODO(), co); err != nil {
+		if err := r.liveClient.Status().Update(context.TODO(), co); err != nil {
 			return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
 		}
 	}
@@ -110,7 +110,7 @@ func initializeClusterOperator(co *configv1.ClusterOperator, nsName string) {
 // operator's current state.
 func (r *reconciler) getOperatorState(nsName string) ([]operatorv1.IngressController, *corev1.Namespace, error) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: nsName}, ns); err != nil {
+	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: nsName}, ns); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil, nil
 		}

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -36,10 +36,10 @@ func (r *reconciler) syncOperatorStatus() error {
 	ns := manifests.RouterNamespace()
 
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: IngressClusterOperatorName}}
-	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co); err != nil {
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co); err != nil {
 		if errors.IsNotFound(err) {
 			initializeClusterOperator(co, ns.Name)
-			if err := r.liveClient.Create(context.TODO(), co); err != nil {
+			if err := r.client.Create(context.TODO(), co); err != nil {
 				return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
 			}
 			log.Info("created clusteroperator", "object", co)
@@ -60,7 +60,7 @@ func (r *reconciler) syncOperatorStatus() error {
 		ns, allIngressesAvailable, oldStatus.Versions, co.Status.Versions)
 
 	if !operatorStatusesEqual(*oldStatus, co.Status) {
-		if err := r.liveClient.Status().Update(context.TODO(), co); err != nil {
+		if err := r.client.Status().Update(context.TODO(), co); err != nil {
 			return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
 		}
 	}
@@ -110,7 +110,7 @@ func initializeClusterOperator(co *configv1.ClusterOperator, nsName string) {
 // operator's current state.
 func (r *reconciler) getOperatorState(nsName string) ([]operatorv1.IngressController, *corev1.Namespace, error) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-	if err := r.liveClient.Get(context.TODO(), types.NamespacedName{Name: nsName}, ns); err != nil {
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: nsName}, ns); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil, nil
 		}

--- a/pkg/operator/controller/status.go
+++ b/pkg/operator/controller/status.go
@@ -118,7 +118,7 @@ func (r *reconciler) getOperatorState(nsName string) ([]operatorv1.IngressContro
 	}
 
 	ingressList := &operatorv1.IngressControllerList{}
-	if err := r.client.List(context.TODO(), ingressList, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.cache.List(context.TODO(), ingressList, client.InNamespace(r.Namespace)); err != nil {
 		return nil, nil, fmt.Errorf("failed to list IngressControllers: %v", err)
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -11,6 +11,7 @@ import (
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	operatorutil "github.com/openshift/cluster-ingress-operator/pkg/util"
 	certcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate"
 	certpublishercontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate-publisher"
 
@@ -62,6 +63,7 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 	mgr, err := manager.New(kubeConfig, manager.Options{
 		Namespace: config.Namespace,
 		Scheme:    scheme,
+		MapperProvider: operatorutil.NewDynamicRESTMapper,
 		NewCache: cache.MultiNamespacedCacheBuilder([]string{
 			config.Namespace,
 			"openshift-ingress",

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -67,7 +67,7 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 		NewCache: cache.MultiNamespacedCacheBuilder([]string{
 			config.Namespace,
 			"openshift-ingress",
-			"openshift-config-managed",
+			operatorcontroller.GlobalMachineSpecifiedConfigNamespace,
 		}),
 		// Use a non-caching client everywhere. The default split client does not
 		// promise to invalidate the cache during writes (nor does it promise

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,21 +8,16 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/dns"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	certcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate"
 	certpublishercontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/certificate-publisher"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/client-go/rest"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -30,11 +25,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var (
@@ -60,115 +51,54 @@ type Operator struct {
 	client client.Client
 
 	manager manager.Manager
-	caches  []cache.Cache
 
 	namespace string
 }
 
 // New creates (but does not start) a new operator from configuration.
 func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.Config) (*Operator, error) {
-	kubeClient, err := operatorclient.NewClient(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %v", err)
-	}
-
 	scheme := operatorclient.GetScheme()
 	// Set up an operator manager for the operator namespace.
-	operatorManager, err := manager.New(kubeConfig, manager.Options{
+	mgr, err := manager.New(kubeConfig, manager.Options{
 		Namespace: config.Namespace,
 		Scheme:    scheme,
+		NewCache: cache.MultiNamespacedCacheBuilder([]string{
+			config.Namespace,
+			"openshift-ingress",
+			"openshift-config-managed",
+		}),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create operator manager: %v", err)
 	}
 
-	// Create additional controller event sources from informers in the managed
-	// namespace. Any new managed resources outside the operator's namespace
-	// should be added here.
-	mapper, err := apiutil.NewDiscoveryRESTMapper(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get API Group-Resources")
-	}
-	operandCache, err := cache.New(kubeConfig, cache.Options{Namespace: "openshift-ingress", Scheme: scheme, Mapper: mapper})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create openshift-ingress cache: %v", err)
-	}
-	// This cache is used to work with objects across all operator-managed
-	// namespaced from a single uniform cache. For now, it's used for status
-	// computation.
-	buildGlobalCache := cache.MultiNamespacedCacheBuilder([]string{"openshift-ingress-operator", "openshift-ingress"})
-	globalCache, err := buildGlobalCache(kubeConfig, cache.Options{Scheme: scheme, Mapper: mapper})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build global cache: %v", err)
-	}
-	statusCache := operatorcontroller.NewIngressStatusCache(globalCache)
+	statusCache := operatorcontroller.NewIngressStatusCache(mgr.GetCache())
 
 	// Create and register the operator controller with the operator manager.
-	operatorController, err := operatorcontroller.New(operatorManager, statusCache, operatorcontroller.Config{
-		KubeConfig:             kubeConfig,
+	if _, err := operatorcontroller.New(mgr, statusCache, operatorcontroller.Config{
 		Namespace:              config.Namespace,
 		DNSManager:             dnsManager,
 		IngressControllerImage: config.IngressControllerImage,
 		OperatorReleaseVersion: config.OperatorReleaseVersion,
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("failed to create operator controller: %v", err)
 	}
 
-	// Any types added to the list here will only queue a ingresscontroller if the
-	// resource has the expected label associating the resource with a
-	// ingresscontroller.
-	for _, o := range []runtime.Object{
-		&appsv1.Deployment{},
-		&corev1.Service{},
-	} {
-		// TODO: may not be necessary to copy, but erring on the side of caution for
-		// now given we're in a loop.
-		obj := o.DeepCopyObject()
-		informer, err := operandCache.GetInformer(obj)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get informer for %v: %v", obj, err)
-		}
-		err = operatorController.Watch(&source.Informer{Informer: informer}, &handler.EnqueueRequestsFromMapFunc{
-			ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
-				labels := a.Meta.GetLabels()
-				if ingressName, ok := labels[manifests.OwningIngressControllerLabel]; ok {
-					log.Info("queueing ingress", "name", ingressName, "related", a.Meta.GetSelfLink())
-					return []reconcile.Request{
-						{
-							NamespacedName: types.NamespacedName{
-								Namespace: config.Namespace,
-								Name:      ingressName,
-							},
-						},
-					}
-				} else {
-					return []reconcile.Request{}
-				}
-			}),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create watch for %v: %v", obj, err)
-		}
-	}
-
 	// Set up the certificate controller
-	if _, err := certcontroller.New(operatorManager, kubeClient, config.Namespace); err != nil {
+	if _, err := certcontroller.New(mgr, config.Namespace); err != nil {
 		return nil, fmt.Errorf("failed to create cacert controller: %v", err)
 	}
 
 	// Set up the certificate-publisher controller
-	if _, err := certpublishercontroller.New(operatorManager, operandCache, kubeClient, config.Namespace, "openshift-ingress"); err != nil {
+	if _, err := certpublishercontroller.New(mgr, config.Namespace, "openshift-ingress"); err != nil {
 		return nil, fmt.Errorf("failed to create certificate-publisher controller: %v", err)
 	}
 
 	return &Operator{
-		manager: operatorManager,
-		caches:  []cache.Cache{operandCache, globalCache},
-
+		manager: mgr,
 		// TODO: These are only needed for the default ingress controller stuff, which
 		// should be refactored away.
-		client:    kubeClient,
+		client:    mgr.GetClient(),
 		namespace: config.Namespace,
 	}, nil
 }
@@ -179,6 +109,10 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 func (o *Operator) Start(stop <-chan struct{}) error {
 	// Periodicaly ensure the default controller exists.
 	go wait.Until(func() {
+		if !o.manager.GetCache().WaitForCacheSync(stop) {
+			log.Error(nil, "failed to sync cache before ensuring default ingresscontroller")
+			return
+		}
 		err := o.ensureDefaultIngressController()
 		if err != nil {
 			log.Error(err, "failed to ensure default ingresscontroller")
@@ -186,27 +120,11 @@ func (o *Operator) Start(stop <-chan struct{}) error {
 	}, 1*time.Minute, stop)
 
 	errChan := make(chan error)
-
-	// Start secondary caches.
-	for _, cache := range o.caches {
-		go func() {
-			if err := cache.Start(stop); err != nil {
-				errChan <- err
-			}
-		}()
-		log.Info("waiting for cache to sync")
-		if !cache.WaitForCacheSync(stop) {
-			return fmt.Errorf("failed to sync cache")
-		}
-		log.Info("cache synced")
-	}
-
-	// Secondary caches are all synced, so start the manager.
 	go func() {
 		errChan <- o.manager.Start(stop)
 	}()
 
-	// Wait for the manager to exit or a secondary cache to fail.
+	// Wait for the manager to exit or an explicit stop.
 	select {
 	case <-stop:
 		return nil

--- a/pkg/util/restmapper.go
+++ b/pkg/util/restmapper.go
@@ -19,6 +19,8 @@ type DynamicRESTMapper struct {
 // types at runtime. This is in contrast to controller-manager's default RESTMapper, which
 // only checks resource types at startup, and so can't handle the case of first creating a
 // CRD and then creating an instance of that CRD.
+//
+// https://github.com/kubernetes-sigs/controller-runtime/issues/321
 func NewDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
 	client, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {

--- a/pkg/util/restmapper.go
+++ b/pkg/util/restmapper.go
@@ -1,0 +1,111 @@
+package k8s
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+type DynamicRESTMapper struct {
+	client   discovery.DiscoveryInterface
+	delegate meta.RESTMapper
+}
+
+// NewDynamicRESTMapper returns a RESTMapper that dynamically discovers resource
+// types at runtime. This is in contrast to controller-manager's default RESTMapper, which
+// only checks resource types at startup, and so can't handle the case of first creating a
+// CRD and then creating an instance of that CRD.
+func NewDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	drm := &DynamicRESTMapper{client: client}
+	if err := drm.reload(); err != nil {
+		return nil, err
+	}
+	return drm, nil
+}
+
+func (drm *DynamicRESTMapper) reload() error {
+	gr, err := restmapper.GetAPIGroupResources(drm.client)
+	if err != nil {
+		return err
+	}
+	drm.delegate = restmapper.NewDiscoveryRESTMapper(gr)
+	return nil
+}
+
+// reloadOnError checks if an error indicates that the delegated RESTMapper needs to be
+// reloaded, and if so, reloads it and returns true.
+func (drm *DynamicRESTMapper) reloadOnError(err error) bool {
+	if _, matches := err.(*meta.NoKindMatchError); !matches {
+		return false
+	}
+	err = drm.reload()
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	return err == nil
+}
+
+func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	gvk, err := drm.delegate.KindFor(resource)
+	if drm.reloadOnError(err) {
+		gvk, err = drm.delegate.KindFor(resource)
+	}
+	return gvk, err
+}
+
+func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	gvks, err := drm.delegate.KindsFor(resource)
+	if drm.reloadOnError(err) {
+		gvks, err = drm.delegate.KindsFor(resource)
+	}
+	return gvks, err
+}
+
+func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	gvr, err := drm.delegate.ResourceFor(input)
+	if drm.reloadOnError(err) {
+		gvr, err = drm.delegate.ResourceFor(input)
+	}
+	return gvr, err
+}
+
+func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	gvrs, err := drm.delegate.ResourcesFor(input)
+	if drm.reloadOnError(err) {
+		gvrs, err = drm.delegate.ResourcesFor(input)
+	}
+	return gvrs, err
+}
+
+func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m, err := drm.delegate.RESTMapping(gk, versions...)
+	if drm.reloadOnError(err) {
+		m, err = drm.delegate.RESTMapping(gk, versions...)
+	}
+	return m, err
+}
+
+func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	ms, err := drm.delegate.RESTMappings(gk, versions...)
+	if drm.reloadOnError(err) {
+		ms, err = drm.delegate.RESTMappings(gk, versions...)
+	}
+	return ms, err
+}
+
+func (drm *DynamicRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	s, err := drm.delegate.ResourceSingularizer(resource)
+	if drm.reloadOnError(err) {
+		s, err = drm.delegate.ResourceSingularizer(resource)
+	}
+	return s, err
+}


### PR DESCRIPTION
* Delete custom cache setup, switch exclusively to `MultiNamespacedCache`
* Consolidate client usage and use dynamic discovery (see https://github.com/kubernetes-sigs/controller-runtime/issues/321 — hat tip to @danwinship for https://github.com/openshift/cluster-network-operator/pull/95). Fixes [bz1717494](https://bugzilla.redhat.com/show_bug.cgi?id=1717494).
* Plumb the cache through for indexed lookups