### PR TITLE
Surface service-controller LB provisioning failures through status

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -1,4 +1,6 @@
 # Cluster role for the operator itself.
+# TODO: A lot of these should be replaced by roles in the namespaces for which
+# the operator actually needs access.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -14,15 +16,9 @@ rules:
   - services
   - secrets
   - pods
-  verbs:
-  - "*"
-
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
-  - create
+  - "*"
 
 - apiGroups:
   - apps

--- a/pkg/operator/controller/controller_lb.go
+++ b/pkg/operator/controller/controller_lb.go
@@ -14,7 +14,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -51,12 +50,6 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 	return currentLBService, nil
 }
 
-// TODO: This should take operator config into account so that the operand
-// namespace isn't hard-coded.
-func loadBalancerServiceName(ci *operatorv1.IngressController) types.NamespacedName {
-	return types.NamespacedName{Namespace: "openshift-ingress", Name: "router-" + ci.Name}
-}
-
 // desiredLoadBalancerService returns the desired LB service for a
 // ingresscontroller, or nil if an LB service isn't desired. An LB service is
 // desired if the high availability type is Cloud. An LB service will declare an
@@ -67,7 +60,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 	}
 	service := manifests.LoadBalancerService()
 
-	name := loadBalancerServiceName(ci)
+	name := LoadBalancerServiceName(ci)
 
 	service.Namespace = name.Namespace
 	service.Name = name.Name
@@ -95,7 +88,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 // ingresscontroller.
 func (r *reconciler) currentLoadBalancerService(ci *operatorv1.IngressController) (*corev1.Service, error) {
 	service := &corev1.Service{}
-	if err := r.client.Get(context.TODO(), loadBalancerServiceName(ci), service); err != nil {
+	if err := r.client.Get(context.TODO(), LoadBalancerServiceName(ci), service); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -109,3 +109,7 @@ func IngressControllerServiceMonitorName(ic *operatorv1.IngressController) types
 		Name:      "router-" + ic.Name,
 	}
 }
+
+func LoadBalancerServiceName(ic *operatorv1.IngressController) types.NamespacedName {
+	return types.NamespacedName{Namespace: "openshift-ingress", Name: "router-" + ic.Name}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -84,10 +84,8 @@ func New(config operatorconfig.Config, dnsManager dns.Manager, kubeConfig *rest.
 		return nil, fmt.Errorf("failed to create operator manager: %v", err)
 	}
 
-	statusCache := operatorcontroller.NewIngressStatusCache(mgr.GetCache())
-
 	// Create and register the operator controller with the operator manager.
-	if _, err := operatorcontroller.New(mgr, statusCache, operatorcontroller.Config{
+	if _, err := operatorcontroller.New(mgr, operatorcontroller.Config{
 		Namespace:              config.Namespace,
 		DNSManager:             dnsManager,
 		IngressControllerImage: config.IngressControllerImage,


### PR DESCRIPTION
When an LB is determined to be pending, try and surface more detail by analyzing
events in the operand namespace related to the LB service, and if an LB creation
failure event is detected, propagate the message into IngressController status
and provide a more specific reason.

Replace the use of indexers with simpler inline cache lookups now that the
manager cache is available.

TODO
- [x] Rebase on https://github.com/openshift/cluster-ingress-operator/pull/244
- [x] Make a decision on whether this can be tested in the e2e suite (e.g. synthesize the service-controller event?)
