### PR TITLE
metrics: fix metric registration bug

### DIFF
--- a/pkg/operator/controller/certificate-publisher/controller.go
+++ b/pkg/operator/controller/certificate-publisher/controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	controllerName = "certificate-publisher-controller"
+	controllerName = "certificate_publisher_controller"
 )
 
 var log = logf.Logger.WithName(controllerName)

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	controllerName = "certificate-controller"
+	controllerName = "certificate_controller"
 )
 
 var log = logf.Logger.WithName(controllerName)

--- a/pkg/operator/controller/controller.go
+++ b/pkg/operator/controller/controller.go
@@ -35,6 +35,8 @@ const (
 	// considered for processing; this ensures the operator has a chance to handle
 	// all states.
 	IngressControllerFinalizer = "ingresscontroller.operator.openshift.io/finalizer-ingresscontroller"
+
+	controllerName = "ingress_controller"
 )
 
 var log = logf.Logger.WithName("controller")
@@ -50,9 +52,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		Config:   config,
 		client:   mgr.GetClient(),
 		cache:    mgr.GetCache(),
-		recorder: mgr.GetEventRecorderFor("operator-controller"),
+		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.New("operator-controller", mgr, controller.Options{Reconciler: reconciler})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use a controller name which is always a valid metric name, allowing the
controller-runtime to successfully register all metrics which incorporate
the controller's name.