### PR TITLE
Split ingress and status controllers

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/cluster-ingress-operator/pkg/operator"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
-	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -67,8 +67,8 @@ func main() {
 	}
 	releaseVersion := os.Getenv("RELEASE_VERSION")
 	if len(releaseVersion) == 0 {
-		releaseVersion = controller.UnknownVersionValue
-		log.Info("RELEASE_VERSION environment variable missing", "release version", controller.UnknownVersionValue)
+		releaseVersion = statuscontroller.UnknownVersionValue
+		log.Info("RELEASE_VERSION environment variable missing", "release version", statuscontroller.UnknownVersionValue)
 	}
 
 	// Retrieve the cluster infrastructure config.

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -12,6 +12,7 @@ import (
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +80,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		} else {
 			errs = append(errs, fmt.Errorf("failed to get ingresscontroller: %v", err))
 		}
-	} else if !controller.IsStatusDomainSet(ingress) {
+	} else if !ingresscontroller.IsStatusDomainSet(ingress) {
 		log.Info("ingresscontroller domain not set; reconciliation will be skipped", "request", request)
 	} else {
 		deployment := &appsv1.Deployment{}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"
@@ -35,10 +35,10 @@ const (
 	controllerName = "ingress_controller"
 )
 
-var log = logf.Logger.WithName("controller")
+var log = logf.Logger.WithName(controllerName)
 
-// New creates the operator controller from configuration. This is the
-// controller that handles all the logic for implementing ingress based on
+// New creates the ingress controller from configuration. This is the controller
+// that handles all the logic for implementing ingress based on
 // IngressController resources.
 //
 // The controller will be pre-configured to watch for IngressController resources
@@ -94,7 +94,6 @@ func enqueueRequestForOwningIngressController(namespace string) handler.EventHan
 type Config struct {
 	Namespace              string
 	IngressControllerImage string
-	OperatorReleaseVersion string
 }
 
 // reconciler handles the actual ingress reconciliation logic in response to
@@ -179,11 +178,6 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 				}
 			}
 		}
-	}
-
-	// TODO: Should this be another controller?
-	if err := r.syncOperatorStatus(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to sync operator status: %v", err))
 	}
 
 	return result, utilerrors.NewAggregate(errs)

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"fmt"

--- a/pkg/operator/controller/ingress/dns.go
+++ b/pkg/operator/controller/ingress/dns.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	iov1 "github.com/openshift/cluster-ingress-operator/pkg/api/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -71,7 +72,7 @@ func desiredWildcardRecord(ic *operatorv1.IngressController, service *corev1.Ser
 		return nil
 	}
 
-	name := WildcardDNSRecordName(ic)
+	name := controller.WildcardDNSRecordName(ic)
 	domain := fmt.Sprintf("*.%s", ic.Status.Domain)
 	var target string
 	var recordType string
@@ -114,7 +115,7 @@ func desiredWildcardRecord(ic *operatorv1.IngressController, service *corev1.Ser
 
 func (r *reconciler) currentWildcardDNSRecord(ic *operatorv1.IngressController) (*iov1.DNSRecord, error) {
 	current := &iov1.DNSRecord{}
-	err := r.client.Get(context.TODO(), WildcardDNSRecordName(ic), current)
+	err := r.client.Get(context.TODO(), controller.WildcardDNSRecordName(ic), current)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
@@ -125,7 +126,7 @@ func (r *reconciler) currentWildcardDNSRecord(ic *operatorv1.IngressController) 
 }
 
 func (r *reconciler) deleteWildcardDNSRecord(ic *operatorv1.IngressController) error {
-	name := WildcardDNSRecordName(ic)
+	name := controller.WildcardDNSRecordName(ic)
 	record := &iov1.DNSRecord{}
 	record.Namespace = name.Namespace
 	record.Name = name.Name

--- a/pkg/operator/controller/ingress/dns_test.go
+++ b/pkg/operator/controller/ingress/dns_test.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"testing"

--- a/pkg/operator/controller/ingress/internal_service.go
+++ b/pkg/operator/controller/ingress/internal_service.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -40,7 +41,7 @@ func (r *reconciler) ensureInternalIngressControllerService(ic *operatorv1.Ingre
 
 func (r *reconciler) currentInternalIngressControllerService(ic *operatorv1.IngressController) (*corev1.Service, error) {
 	current := &corev1.Service{}
-	err := r.client.Get(context.TODO(), InternalIngressControllerServiceName(ic), current)
+	err := r.client.Get(context.TODO(), controller.InternalIngressControllerServiceName(ic), current)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
@@ -53,7 +54,7 @@ func (r *reconciler) currentInternalIngressControllerService(ic *operatorv1.Ingr
 func desiredInternalIngressControllerService(ic *operatorv1.IngressController, deploymentRef metav1.OwnerReference) *corev1.Service {
 	s := manifests.InternalIngressControllerService()
 
-	name := InternalIngressControllerServiceName(ic)
+	name := controller.InternalIngressControllerServiceName(ic)
 
 	s.Namespace = name.Namespace
 	s.Name = name.Name
@@ -67,7 +68,7 @@ func desiredInternalIngressControllerService(ic *operatorv1.IngressController, d
 		ServingCertSecretAnnotation: fmt.Sprintf("router-metrics-certs-%s", ic.Name),
 	}
 
-	s.Spec.Selector = IngressControllerDeploymentPodSelector(ic).MatchLabels
+	s.Spec.Selector = controller.IngressControllerDeploymentPodSelector(ic).MatchLabels
 
 	s.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
 

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/slice"
 
 	corev1 "k8s.io/api/core/v1"
@@ -88,7 +89,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 	}
 	service := manifests.LoadBalancerService()
 
-	name := LoadBalancerServiceName(ci)
+	name := controller.LoadBalancerServiceName(ci)
 
 	service.Namespace = name.Namespace
 	service.Name = name.Name
@@ -99,7 +100,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 	service.Labels["router"] = name.Name
 	service.Labels[manifests.OwningIngressControllerLabel] = ci.Name
 
-	service.Spec.Selector = IngressControllerDeploymentPodSelector(ci).MatchLabels
+	service.Spec.Selector = controller.IngressControllerDeploymentPodSelector(ci).MatchLabels
 
 	isInternal := ci.Status.EndpointPublishingStrategy.LoadBalancer == nil || ci.Status.EndpointPublishingStrategy.LoadBalancer.Scope == operatorv1.InternalLoadBalancer
 
@@ -125,7 +126,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 // ingresscontroller.
 func (r *reconciler) currentLoadBalancerService(ci *operatorv1.IngressController) (*corev1.Service, error) {
 	service := &corev1.Service{}
-	if err := r.client.Get(context.TODO(), LoadBalancerServiceName(ci), service); err != nil {
+	if err := r.client.Get(context.TODO(), controller.LoadBalancerServiceName(ci), service); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/operator/controller/ingress/monitoring.go
+++ b/pkg/operator/controller/ingress/monitoring.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -34,7 +35,7 @@ func (r *reconciler) ensureServiceMonitor(ic *operatorv1.IngressController, svc 
 }
 
 func desiredServiceMonitor(ic *operatorv1.IngressController, svc *corev1.Service, deploymentRef metav1.OwnerReference) *unstructured.Unstructured {
-	name := IngressControllerServiceMonitorName(ic)
+	name := controller.IngressControllerServiceMonitorName(ic)
 	sm := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -84,7 +85,7 @@ func (r *reconciler) currentServiceMonitor(ic *operatorv1.IngressController) (*u
 		Kind:    "ServiceMonitor",
 		Version: "v1",
 	})
-	if err := r.client.Get(context.TODO(), IngressControllerServiceMonitorName(ic), sm); err != nil {
+	if err := r.client.Get(context.TODO(), controller.IngressControllerServiceMonitorName(ic), sm); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"context"

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1,4 +1,4 @@
-package controller
+package ingress
 
 import (
 	"fmt"

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -15,25 +15,18 @@ const (
 	// CA certificate in this namespace.
 	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 
-	// caCertSecretName is the name of the secret that holds the CA certificate
-	// that the operator will use to create default certificates for
-	// ingresscontrollers.
-	caCertSecretName = "router-ca"
-
-	// caCertConfigMapName is the name of the config map with the public key
-	// for the CA certificate, which the operator publishes for other
-	// operators to use.
-	caCertConfigMapName = "router-ca"
-
-	// routerCertsGlobalSecretName is the name of the secret with the
-	// default certificates and their keys, which the operator publishes for
-	// other operators to use.
-	routerCertsGlobalSecretName = "router-certs"
-
-	// controllerDeploymentLabel identifies a deployment as an ingress controller
+	// ControllerDeploymentLabel identifies a deployment as an ingress controller
 	// deployment, and the value is the name of the owning ingress controller.
-	controllerDeploymentLabel = "ingresscontroller.operator.openshift.io/deployment-ingresscontroller"
+	ControllerDeploymentLabel = "ingresscontroller.operator.openshift.io/deployment-ingresscontroller"
 )
+
+// IngressClusterOperatorName returns the namespaced name of the ClusterOperator
+// resource for the operator.
+func IngressClusterOperatorName() types.NamespacedName {
+	return types.NamespacedName{
+		Name: "ingress",
+	}
+}
 
 // RouterDeploymentName returns the namespaced name for the router deployment.
 func RouterDeploymentName(ci *operatorv1.IngressController) types.NamespacedName {
@@ -44,27 +37,33 @@ func RouterDeploymentName(ci *operatorv1.IngressController) types.NamespacedName
 }
 
 // RouterCASecretName returns the namespaced name for the router CA secret.
+// This secret holds the CA certificate that the operator will use to create
+// default certificates for ingresscontrollers.
 func RouterCASecretName(operatorNamespace string) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: operatorNamespace,
-		Name:      caCertSecretName,
+		Name:      "router-ca",
 	}
 }
 
 // RouterCAConfigMapName returns the namespaced name for the router CA configmap.
+// The operator uses this configmap to publish the public key for the CA
+// certificate, so that other operators can include it into their trust bundles.
 func RouterCAConfigMapName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: GlobalMachineSpecifiedConfigNamespace,
-		Name:      caCertConfigMapName,
+		Name:      "router-ca",
 	}
 }
 
 // RouterCertsGlobalSecretName returns the namespaced name for the router certs
-// secret.
+// secret.  The operator uses this secret to publish the default certificates and
+// their keys, so that the authentication operator can configure the OAuth server
+// to use the same certificates.
 func RouterCertsGlobalSecretName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: GlobalMachineSpecifiedConfigNamespace,
-		Name:      routerCertsGlobalSecretName,
+		Name:      "router-certs",
 	}
 }
 
@@ -93,7 +92,7 @@ func IngressControllerDeploymentLabel(ic *operatorv1.IngressController) string {
 func IngressControllerDeploymentPodSelector(ic *operatorv1.IngressController) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			controllerDeploymentLabel: IngressControllerDeploymentLabel(ic),
+			ControllerDeploymentLabel: IngressControllerDeploymentLabel(ic),
 		},
 	}
 }

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -1,4 +1,4 @@
-package controller
+package status
 
 import (
 	"testing"


### PR DESCRIPTION
Move the ingress controller into its own package, and extract a separate status controller to create and update the `ClusterOperator` resource.

Fix a nil pointer dereference in case the namespace does not exist at the time that the `ClusterOperator` resource's `status` is computed.

Update references to the "operator controller", which is now more properly called the "ingress controller".

* `cmd/ingress-operator/main.go` (`main`): Update references to `UnknownVersionValue`, which is now in the `status` controller package.
* `pkg/operator/controller/certificate/controller.go` (`Reconcile`): Update reference to `IsStatusDomainSet`, which is now in the `ingress` controller package.
* `pkg/operator/controller/controller.go`: Rename...
* `pkg/operator/controller/ingress/controller.go`: ...to this.  Use the correct controller name for logging.
(`Config`): Delete `OperatorReleaseVersion`.
(`Reconcile`): Delete call to `syncOperatorStatus`.
* `pkg/operator/controller/deployment.go`: Rename...
* `pkg/operator/controller/ingress/deployment.go`: ...to this.  Update references to functions in `pkg/operator/controller/names.go`.
* `pkg/operator/controller/deployment_test.go`: Rename...
* `pkg/operator/controller/ingress/deployment_test.go`: ...to this.
* `pkg/operator/controller/dns.go`: Rename...
* `pkg/operator/controller/ingress/dns.go`: ...to this.  Update references to functions in `pkg/operator/controller/names.go`.
* `pkg/operator/controller/dns_test.go`: Rename...
* `pkg/operator/controller/ingress/dns_test.go`: ...to this.
* `pkg/operator/controller/internal_service.go`: Rename...
* `pkg/operator/controller/ingress/internal_service.go`: ...to this.  Update references to functions in `pkg/operator/controller/names.go`.
* `pkg/operator/controller/load_balancer_service.go`: Rename...
* `pkg/operator/controller/ingress/load_balancer_service.go`: ...to this.  Update references to functions in `pkg/operator/controller/names.go`.
* `pkg/operator/controller/monitoring.go`: Rename...
* `pkg/operator/controller/ingress/monitoring.go`: ...to this.  Update references to functions in `pkg/operator/controller/names.go`.
* `pkg/operator/controller/ingress_status.go`: Rename...
* `pkg/operator/controller/ingress/status.go`: ...to this.
* `pkg/operator/controller/ingress_status_test.go`: Rename...
* `pkg/operator/controller/ingress/status_test.go`: ...to this.
* `pkg/operator/controller/names.go` (`caCertSecretName`, `caCertConfigMapName`, `routerCertsGlobalSecretName`): Deleted.
(`controllerDeploymentLabel`): Renamed...
(`ControllerDeploymentLabel`): ...to this.
(`IngressClusterOperatorName`): Moved from `pkg/operator/controller/status.go`. Change type to namespaced name.
(`RouterCASecretName`, `RouterCAConfigMapName`, `RouterCertsGlobalSecretName`): Replace named consts that were only used in these functions with string literals.
* `pkg/operator/controller/status.go`: Rename...
* `pkg/operator/controller/status/controller.go`: ...to this.
(`IngressClusterOperatorName`): Moved to `pkg/operator/controller/names.go`.
(`controllerName`): New constant.
(`log`): New logger.
(`New`): New method.  Create a new status controller, which watches `IngressController` resources and creates and updates `ClusterOperator`.
(`Config`): New type.  Hold configuration for the status controller.
(`reconciler`): New type.  Hold state for the status controller.
(`syncOperatorStatus`): Rename...
(`Reconcile`): ...to this.  Add logging, request parameter, and reconcile result value.  Update reference to `IngressClusterOperatorName`, which is now a function that returns a namespaced name.  Fix a nil pointer dereference if the namespace is not found.
* `pkg/operator/controller/status_test.go`: Rename...
* `pkg/operator/controller/status/controller_test.go`: ...to this.
* `pkg/operator/operator.go`: Update to create both ingress and status controllers.
* `test/e2e/operator_test.go` (`conditionsMatchExpected`): Update reference to `IngressClusterOperatorName`, which is now a function that returns a namespaced name.