### PR TITLE
Introduce concept of ingresscontroller admission status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release-local:
 
 .PHONY: test-e2e
 test-e2e:
-	$(GO) test -count 1 -v -tags e2e -run "$(TEST)" ./...
+	$(GO) test -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
 
 .PHONY: clean
 clean:

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+IMAGE=$(oc get -n openshift-ingress-operator deployments/ingress-operator -o json | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="IMAGE").value')
+RELEASE_VERSION=$(oc get clusterversion/version -o json | jq -r '.status.desired.version')
+
+IMAGE="$IMAGE" RELEASE_VERSION="$RELEASE_VERSION" ./ingress-operator

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -74,6 +74,10 @@ type DNSRecordList struct {
 	Items           []DNSRecord `json:"items"`
 }
 
+const (
+	IngressControllerAdmittedConditionType = "Admitted"
+)
+
 func init() {
 	SchemeBuilder.Register(&DNSRecord{}, &DNSRecordList{})
 }


### PR DESCRIPTION
Add an ingresscontroller `Admitted` status condition which indicates that the
ingresscontroller has been defaulted, validated, and marked safe to process.

A rejected ingresscontroller will have a reason indicating why admission failed.

Refactor the controller loop in terms of distinct defaulting, validation, and
admission steps to both implement the admission concept and reduce branching
complexity.

Add an e2e test for admission, and refactor the other tests to reduce boilerplate.