### PR TITLE
controller: fix AWS internal loadbalancer annotation

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -198,9 +198,11 @@ func (m *Provider) getLBHostedZone(name string) (string, error) {
 	var id string
 	fn := func(resp *elb.DescribeLoadBalancersOutput, lastPage bool) (shouldContinue bool) {
 		for _, lb := range resp.LoadBalancerDescriptions {
-			log.V(2).Info("found load balancer", "name", aws.StringValue(lb.LoadBalancerName), "dns name", aws.StringValue(lb.DNSName), "hosted zone ID", aws.StringValue(lb.CanonicalHostedZoneNameID))
-			if aws.StringValue(lb.CanonicalHostedZoneName) == name {
-				id = aws.StringValue(lb.CanonicalHostedZoneNameID)
+			dnsName := aws.StringValue(lb.DNSName)
+			zoneID := aws.StringValue(lb.CanonicalHostedZoneNameID)
+			log.V(2).Info("found load balancer", "name", aws.StringValue(lb.LoadBalancerName), "dns name", dnsName, "hosted zone ID", zoneID)
+			if dnsName == name {
+				id = zoneID
 				return false
 			}
 		}

--- a/pkg/operator/controller/load_balancer_service.go
+++ b/pkg/operator/controller/load_balancer_service.go
@@ -30,9 +30,9 @@ var (
 	// that the load balancer is internal.
 	//
 	// https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-	internalLBAnnotations = map[configv1.PlatformType]map[string]string{
+	InternalLBAnnotations = map[configv1.PlatformType]map[string]string{
 		configv1.AWSPlatformType: {
-			"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
+			"service.beta.kubernetes.io/aws-load-balancer-internal": "0.0.0.0/0",
 		},
 		configv1.AzurePlatformType: {
 			"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
@@ -110,7 +110,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 		service.Annotations[awsLBProxyProtocolAnnotation] = "*"
 	}
 	if isInternal {
-		annotation := internalLBAnnotations[infraConfig.Status.Platform]
+		annotation := InternalLBAnnotations[infraConfig.Status.Platform]
 		for name, value := range annotation {
 			service.Annotations[name] = value
 		}


### PR DESCRIPTION
Use the correct annotation for AWS internal load balancers. Before this
change, the Internal endpoint publishing strategy scope was not correctly
honored on AWS.