### PR TITLE
Bug 1724498: add selector to servicemonitor

### DIFF
--- a/pkg/operator/controller/controller_service_monitor.go
+++ b/pkg/operator/controller/controller_service_monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -54,7 +55,11 @@ func desiredServiceMonitor(ci *operatorv1.IngressController, svc *corev1.Service
 						"openshift-ingress",
 					},
 				},
-				"selector": map[string]interface{}{},
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						manifests.OwningIngressControllerLabel: ci.Name,
+					},
+				},
 				"endpoints": []map[string]interface{}{
 					{
 						"bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",


### PR DESCRIPTION
I'd like to backport https://github.com/openshift/cluster-ingress-operator/pull/242 to fix https://bugzilla.redhat.com/show_bug.cgi?id=1724498.