### PR TITLE
Delete metrics port from operator pod spec

### DIFF
--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -37,9 +37,6 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
           imagePullPolicy: IfNotPresent
           image: openshift/origin-cluster-ingress-operator:latest
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - ingress-operator
           env:


### PR DESCRIPTION
* `manifests/02-deployment.yaml`: Delete the metrics port since we are not exposing it at this time.