### PR TITLE
Bug 1726453: manifests: add version information

### DIFF
--- a/manifests/03-cluster-operator.yaml
+++ b/manifests/03-cluster-operator.yaml
@@ -5,3 +5,7 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: ingress
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"


### PR DESCRIPTION
Add version info to manifest so the CVO can identify the operator's
version keys in the clusteroperator status.