### PR TITLE
Bug 1734414: getPlatformStatus: Fix platform upgrading from 4.1

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -202,7 +202,7 @@ func getPlatformStatus(client client.Client, infra *configv1.Infrastructure) (*c
 		return nil, fmt.Errorf("invalid install-config: %v\njson:\n%s", err, data)
 	}
 	return &configv1.PlatformStatus{
-		Type: configv1.AWSPlatformType,
+		Type: infra.Status.Platform,
 		AWS: &configv1.AWSPlatformStatus{
 			Region: ic.Platform.AWS.Region,
 		},


### PR DESCRIPTION
Use the deprecated `status.platform` field from the cluster infrastructure config to determine the platform if the `status.platformStatus` field is nil. In particular, `platformStatus` will be nil on a cluster that is being upgraded from 4.1.

* `cmd/ingress-operator/main.go` (`getPlatformStatus`): Use the `status.platform` field from the cluster infrastructure config as the platform type if `status.platformStatus is nil.`