### PR TITLE
pkg/dns/azure: fix dns record trimming to create relative records for DNS queries

### DIFF
--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -72,7 +72,7 @@ func (m *provider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		return errors.Wrap(err, "failed to parse zoneID")
 	}
 
-	ARecordName, err := getARecordName(record.Spec.DNSName, "."+targetZone.Name)
+	ARecordName, err := getARecordName(record.Spec.DNSName, targetZone.Name)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		return errors.Wrap(err, "failed to parse zoneID")
 	}
 
-	ARecordName, err := getARecordName(record.Spec.DNSName, "."+targetZone.Name)
+	ARecordName, err := getARecordName(record.Spec.DNSName, targetZone.Name)
 	if err != nil {
 		return err
 	}
@@ -123,5 +123,5 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 // getARecordName extracts the ARecord subdomain name from the full domain string.
 // azure defines the ARecord Name as the subdomain name only.
 func getARecordName(recordDomain string, zoneName string) (string, error) {
-	return strings.TrimSuffix(recordDomain, zoneName), nil
+	return strings.TrimSuffix(strings.TrimSuffix(recordDomain, "."), "."+zoneName), nil
 }


### PR DESCRIPTION
Azure only accpets relative records for a DNS zone and so make sure the DNS record required is correctlty trimmed of the zone name, The DNS record must first be trimmed of any trailing `.` as Azure DNS zone names
cannot have trailing dots `.`

This prevents errors like:
```
The DNS provider failed to ensure the record: failed to update dns
        a record: *.apps.adahiya-1.installer-azure.devcluster.openshift.com..adahiya-1.installer-azure.devcluster.openshift.com:
        dns.RecordSetsClient#CreateOrUpdate: Failure responding to request: StatusCode=400
        -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest"
        Message="The resource records'' relative name ''*.apps.adahiya-1.installer-azure.devcluster.openshift.com.''
        must not end with a dot."
```

This error was introduced in https://github.com/openshift/cluster-ingress-operator/pull/274/files#diff-812ac76222452adcda3e374d185812bb where addition of the trailing dot, caused the trim to fail and keep the cluster-domain in the record.

/cc @Miciah @ironcladlou 