### PR TITLE
dns/azure: Use absolute domain name in unit tests

### DIFF
--- a/pkg/dns/azure/dns_test.go
+++ b/pkg/dns/azure/dns_test.go
@@ -34,7 +34,7 @@ func TestEnsureDNS(t *testing.T) {
 	ARecordName := "subdomain"
 	record := iov1.DNSRecord{
 		Spec: iov1.DNSRecordSpec{
-			DNSName:    "subdomain.dnszone.io",
+			DNSName:    "subdomain.dnszone.io.",
 			RecordType: iov1.ARecordType,
 			Targets:    []string{"55.11.22.33"},
 		},
@@ -75,7 +75,7 @@ func TestDeleteDNS(t *testing.T) {
 	ARecordName := "subdomain"
 	record := iov1.DNSRecord{
 		Spec: iov1.DNSRecordSpec{
-			DNSName:    "subdomain.dnszone.io",
+			DNSName:    "subdomain.dnszone.io.",
 			RecordType: iov1.ARecordType,
 			Targets:    []string{"55.11.22.33"},
 		},


### PR DESCRIPTION
Use an absolute domain name in unit tests since the ingress controller now defines records using absolute domain names.

Follow-up to https://github.com/openshift/cluster-ingress-operator/pull/274 and https://github.com/openshift/cluster-ingress-operator/pull/278.

* `pkg/dns/azure/dns_test.go` (`TestEnsureDNS`, `TestDeleteDNS`): Add trailing period to domain names to make them absolute.