### PR TITLE
Bug 1709958: Avoid dropping traffic during upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.2.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.15.72
+	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -9,6 +9,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,14 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	deployment, err := desiredRouterDeployment(ci, ingressControllerImage, infraConfig, ingressConfig, apiConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
+	}
+
+	expectedHash := deploymentHash(deployment)
+	actualHash, haveHashLabel := deployment.Spec.Template.Labels[controller.ControllerDeploymentHashLabel]
+	if !haveHashLabel {
+		t.Error("router Deployment is missing hash label")
+	} else if actualHash != expectedHash {
+		t.Errorf("router Deployment has wrong hash; expected: %s, got: %s", expectedHash, actualHash)
 	}
 
 	namespaceSelector := ""
@@ -215,6 +224,13 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
 	}
+	expectedHash = deploymentHash(deployment)
+	actualHash, haveHashLabel = deployment.Spec.Template.Labels[controller.ControllerDeploymentHashLabel]
+	if !haveHashLabel {
+		t.Error("router Deployment is missing hash label")
+	} else if actualHash != expectedHash {
+		t.Errorf("router Deployment has wrong hash; expected: %s, got: %s", expectedHash, actualHash)
+	}
 	if deployment.Spec.Template.Spec.HostNetwork != false {
 		t.Error("expected host network to be false")
 	}
@@ -307,6 +323,10 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	deployment, err = desiredRouterDeployment(ci, ingressControllerImage, infraConfig, ingressConfig, apiConfig)
 	if err != nil {
 		t.Errorf("invalid router Deployment: %v", err)
+	}
+	actualHash, haveHashLabel = deployment.Spec.Template.Labels[controller.ControllerDeploymentHashLabel]
+	if haveHashLabel {
+		t.Errorf("router Deployment has unexpected hash label: %s", actualHash)
 	}
 	if len(deployment.Spec.Template.Spec.NodeSelector) != 1 ||
 		deployment.Spec.Template.Spec.NodeSelector["xyzzy"] != "quux" {
@@ -439,6 +459,13 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			expect: false,
 		},
 		{
+			description: "if the deployment hash changes",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Labels[controller.ControllerDeploymentHashLabel] = "2"
+			},
+			expect: false,
+		},
+		{
 			description: "if .spec.template.spec.volumes is set to empty",
 			mutate: func(deployment *appsv1.Deployment) {
 				deployment.Spec.Template.Spec.Volumes = []corev1.Volume{}
@@ -566,11 +593,41 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the deployment template affinity is changed",
+			description: "if the deployment template affinity is deleted",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchExpressions[0].Key = "new-label"
+				deployment.Spec.Template.Spec.Affinity = nil
 			},
 			expect: true,
+		},
+		{
+			description: "if the deployment template anti-affinity is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchExpressions[1].Values = []string{"xyz"}
+			},
+			expect: true,
+		},
+		{
+			description: "if the deployment template affinity label selector expressions change ordering",
+			mutate: func(deployment *appsv1.Deployment) {
+				exprs := deployment.Spec.Template.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.LabelSelector.MatchExpressions
+				exprs[0], exprs[1] = exprs[1], exprs[0]
+			},
+			expect: false,
+		},
+		{
+			description: "if the deployment template anti-affinity label selector expressions change ordering",
+			mutate: func(deployment *appsv1.Deployment) {
+				exprs := deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchExpressions
+				exprs[0], exprs[1] = exprs[1], exprs[0]
+			},
+			expect: false,
+		},
+		{
+			description: "if the hash in the deployment template affinity is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.LabelSelector.MatchExpressions[0].Values = []string{"2"}
+			},
+			expect: false,
 		},
 	}
 
@@ -599,6 +656,11 @@ func TestDeploymentConfigChanged(t *testing.T) {
 					},
 				},
 				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							controller.ControllerDeploymentHashLabel: "1",
+						},
+					},
 					Spec: corev1.PodSpec{
 						Volumes: []corev1.Volume{
 							{
@@ -639,6 +701,30 @@ func TestDeploymentConfigChanged(t *testing.T) {
 							},
 						},
 						Affinity: &corev1.Affinity{
+							PodAffinity: &corev1.PodAffinity{
+								PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+									{
+										Weight: int32(100),
+										PodAffinityTerm: corev1.PodAffinityTerm{
+											TopologyKey: "kubernetes.io/hostname",
+											LabelSelector: &metav1.LabelSelector{
+												MatchExpressions: []metav1.LabelSelectorRequirement{
+													{
+														Key:      controller.ControllerDeploymentHashLabel,
+														Operator: metav1.LabelSelectorOpNotIn,
+														Values:   []string{"1"},
+													},
+													{
+														Key:      controller.ControllerDeploymentLabel,
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"default"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 							PodAntiAffinity: &corev1.PodAntiAffinity{
 								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 									{
@@ -646,9 +732,14 @@ func TestDeploymentConfigChanged(t *testing.T) {
 										LabelSelector: &metav1.LabelSelector{
 											MatchExpressions: []metav1.LabelSelectorRequirement{
 												{
-													Key:      "label",
+													Key:      controller.ControllerDeploymentHashLabel,
 													Operator: metav1.LabelSelectorOpIn,
-													Values:   []string{"value"},
+													Values:   []string{"1"},
+												},
+												{
+													Key:      controller.ControllerDeploymentLabel,
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"default"},
 												},
 											},
 										},

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -483,6 +483,14 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the tolerations change ordering",
+			mutate: func(deployment *appsv1.Deployment) {
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				tolerations[1], tolerations[0] = tolerations[0], tolerations[1]
+			},
+			expect: false,
+		},
+		{
 			description: "if ROUTER_CANONICAL_HOSTNAME changes",
 			mutate: func(deployment *appsv1.Deployment) {
 				envs := deployment.Spec.Template.Spec.Containers[0].Env
@@ -569,6 +577,13 @@ func TestDeploymentConfigChanged(t *testing.T) {
 	for _, tc := range testCases {
 		nineteen := int32(19)
 		fourTwenty := int32(420) // = 0644 octal.
+		otherToleration := corev1.Toleration{
+			Key:      "xyz",
+			Value:    "bar",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+		}
+
 		original := appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "router-original",
@@ -641,6 +656,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 								},
 							},
 						},
+						Tolerations: []corev1.Toleration{toleration, otherToleration},
 					},
 				},
 				Replicas: &nineteen,

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -18,6 +18,13 @@ const (
 	// ControllerDeploymentLabel identifies a deployment as an ingress controller
 	// deployment, and the value is the name of the owning ingress controller.
 	ControllerDeploymentLabel = "ingresscontroller.operator.openshift.io/deployment-ingresscontroller"
+
+	// ControllerDeploymentHashLabel identifies an ingress controller
+	// deployment's generation.  This label is used for affinity, to
+	// colocate replicas of different generations of the same ingress
+	// controller, and for anti-affinity, to prevent colocation of replicas
+	// of the same generation of the same ingress controller.
+	ControllerDeploymentHashLabel = "ingresscontroller.operator.openshift.io/hash"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,6 +349,7 @@ k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/intstr
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/fields
@@ -360,7 +361,6 @@ k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/naming
-k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/util/net


### PR DESCRIPTION
#### `TestDeploymentConfigChanged`: tolerations ordering

* `pkg/operator/controller/ingress/deployment_test.go` (`TestDeploymentConfigChanged`): Add test case that verifies that the ordering of tolerations is ignored.


#### Add `davecgh/go-spew` dependency.


#### Avoid dropping traffic during upgrade

Omit the affinity policy when using host network.  The scheduler already prevents colocation of pods that use host networking and request the same ports, so the affinity policy is superfluous in this case.

Change the affinity policy and deployment strategy when using the load-balancer or private endpoint publishing strategy as follows.  First, configure affinity for replicas of different generations of same controller.  Second, configure anti-affinity for replicas of same generation of same controller.  Finally, configure the deployment strategy to surge.

The intention of the changes for the load-balancer and private endpoint publishing strategies is to avoid dropping traffic during rolling updates of an ingress controller's deployment.  If a node loses local endpoints for the deployment, then the service proxy will drop traffic to that node for that ingress controller, and it may take some time for the load balancer to stop sending traffic to that node.  These changes, combined with a change to the ReplicaSet controller, will ensure that a node that has local endpoints for an ingress controller at the start of a rollout will continue to have local endpoints during and at completion of the rollout, thus preventing traffic from being dropped.

* `pkg/operator/controller/controller_router_deployment.go` (`desiredRouterDeployment`): Set the deployment's pod selector to a copy of the pod template's labels, so that subsequently mutating labels does not mutate the selector.  If the ingress controller uses the host network, do not set any affinity policy.  If the ingress controller uses the load-balancer or private endpoint publishing strategy, add a "hash" label to identify the deployment's generation, configure affinity for replicas of different generations of the same ingress controller, configure anti-affinity for the same generation of the same ingress controller, and configure the deployment strategy to surge.
(`deploymentHash`): New function.  Return a stringified hash value for the given deployment, using only the fields that, if changed, should trigger an update.
(`hashableDeployment`): New function.  Return a copy of the given deployment with fields that should be used for computing its hash copied over, fields that are slices sorted, and fields that should be ignored zeroed.
(`deepHashObject`): New function.  Hash the given object.
(`deploymentConfigChanged`): Compare hashes of the current and expected deployments instead of comparing fields directly.  Set labels during an update.
(`cmpEnvs`, `cmpVolumes`, `cmpSecretVolumeSource`, `cmpTolerations`): Deleted.
* `pkg/operator/controller/controller_router_deployment_test.go` (`TestDesiredRouterDeployment`): Verify that the hash label is set when it should be and that it has the right hash value.
(`TestDeploymentConfigChanged`): Add test cases to verify that the hash is ignored in the deployment labels and affinity.  Add a test case to verify that deleting the affinity policy is not ignored.  Add test cases to verify that ordering of the label selector expressions in affinity terms is ignored.
* `pkg/operator/controller/names.go` (`ControllerDeploymentHashLabel`): New constant.

