### PR TITLE
status: compute ingresscontroller availability from deployment conditions

### DIFF
--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -182,16 +182,40 @@ func TestComputeLoadBalancerStatus(t *testing.T) {
 	}
 }
 
-func TestComputeIngressStatusConditions(t *testing.T) {
+func TestComputeIngressAvailableCondition(t *testing.T) {
 	testCases := []struct {
-		description     string
-		availRepl, repl int32
-		condType        string
-		condStatus      operatorv1.ConditionStatus
+		description string
+		deployment  []appsv1.DeploymentCondition
+		expect      operatorv1.OperatorCondition
 	}{
-		{"0/2 deployment replicas available", 0, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionFalse},
-		{"1/2 deployment replicas available", 1, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionTrue},
-		{"2/2 deployment replicas available", 2, 2, operatorv1.OperatorStatusTypeAvailable, operatorv1.ConditionTrue},
+		{
+			description: "deployment available",
+			deployment: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+		},
+		{
+			description: "deployment not available",
+			deployment: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "deployment availability unknown",
+			deployment: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionUnknown},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "deployment availability not present",
+			deployment: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionUnknown},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -200,25 +224,17 @@ func TestComputeIngressStatusConditions(t *testing.T) {
 				Name: fmt.Sprintf("ingress-controller-%d", i+1),
 			},
 			Status: appsv1.DeploymentStatus{
-				Replicas:          tc.repl,
-				AvailableReplicas: tc.availRepl,
+				Conditions: tc.deployment,
 			},
 		}
 
-		expected := []operatorv1.OperatorCondition{
-			{
-				Type:   tc.condType,
-				Status: tc.condStatus,
-			},
-		}
-		actual := computeIngressStatusConditions(deploy)
+		actual := computeIngressAvailableCondition(deploy)
 		conditionsCmpOpts := []cmp.Option{
 			cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "LastTransitionTime", "Reason", "Message"),
 			cmpopts.EquateEmpty(),
-			cmpopts.SortSlices(func(a, b operatorv1.OperatorCondition) bool { return a.Type < b.Type }),
 		}
-		if !cmp.Equal(actual, expected, conditionsCmpOpts...) {
-			t.Fatalf("%q: expected %#v, got %#v", tc.description, expected, actual)
+		if !cmp.Equal(actual, tc.expect, conditionsCmpOpts...) {
+			t.Fatalf("%q: expected %#v, got %#v", tc.description, tc.expect, actual)
 		}
 	}
 }

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -184,34 +184,34 @@ func TestComputeLoadBalancerStatus(t *testing.T) {
 
 func TestComputeIngressAvailableCondition(t *testing.T) {
 	testCases := []struct {
-		description string
-		deployment  []appsv1.DeploymentCondition
-		expect      operatorv1.OperatorCondition
+		description          string
+		deploymentConditions []appsv1.DeploymentCondition
+		expect               operatorv1.OperatorCondition
 	}{
 		{
 			description: "deployment available",
-			deployment: []appsv1.DeploymentCondition{
+			deploymentConditions: []appsv1.DeploymentCondition{
 				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
 			},
 			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
 		},
 		{
 			description: "deployment not available",
-			deployment: []appsv1.DeploymentCondition{
+			deploymentConditions: []appsv1.DeploymentCondition{
 				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse},
 			},
 			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
 		},
 		{
 			description: "deployment availability unknown",
-			deployment: []appsv1.DeploymentCondition{
+			deploymentConditions: []appsv1.DeploymentCondition{
 				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionUnknown},
 			},
 			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
 		},
 		{
 			description: "deployment availability not present",
-			deployment: []appsv1.DeploymentCondition{
+			deploymentConditions: []appsv1.DeploymentCondition{
 				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionUnknown},
 			},
 			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
@@ -224,7 +224,7 @@ func TestComputeIngressAvailableCondition(t *testing.T) {
 				Name: fmt.Sprintf("ingress-controller-%d", i+1),
 			},
 			Status: appsv1.DeploymentStatus{
-				Conditions: tc.deployment,
+				Conditions: tc.deploymentConditions,
 			},
 		}
 


### PR DESCRIPTION
Before this change, ingresscontroller availability was determined based on
deployment available replicas from status. Now, consider the ingresscontroller
available if the deployment has an `Available=True` condition. Available
replicas is a weak proxy for deployment availability. The condition takes into
account the complex availability rules of a deployment and also provides
additional context as to why the condition is in a certain state.