### PR TITLE
Fix admission to log rejections and not retry

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -166,13 +166,13 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		if err := r.admit(ingress, ingressConfig, infraConfig); err != nil {
 			switch err := err.(type) {
 			case *admissionRejection:
-				log.Info("rejected ingresscontroller", "ingresscontroller", ingress, "reason", err.Reason)
+				r.recorder.Event(ingress, "Warning", "Rejected", err.Reason)
 				return reconcile.Result{}, nil
 			default:
 				return reconcile.Result{}, fmt.Errorf("failed to admit ingresscontroller: %v", err)
 			}
 		}
-		log.Info("admitted ingresscontroller", "ingresscontroller", ingress)
+		r.recorder.Event(ingress, "Normal", "Admitted", "ingresscontroller passed validation")
 		// Just re-queue for simplicity
 		return reconcile.Result{Requeue: true}, nil
 	}


### PR DESCRIPTION
#### Fix admission to log rejections and not retry

When processing an ingresscontroller for admission, distinguish between error values that indicate that admission processing could not be completed and error values that indicate that the processing did complete and the ingresscontroller was rejected.  Do not update the "Admitted" condition in the first case.  Log the rejection and do not retry reconciliation in the latter case.

* `pkg/operator/controller/ingress/controller.go` (`admissionRejected`): New type for admission rejections.
(`Error`): New method for the new `admissionRejected` type.
(`Reconcile`): When admission rejects the ingresscontroller, log the rejection and do not retry.
(`admit`): Only set the "Admitted" condition if validation rejected the ingresscontroller.  Return the error value from `validate` if it is not nil.
(`validate`): Return an `admissionRejected` value if the ingresscontroller is determined to be invalid.

#### Replace admission log messages with events

* `pkg/operator/controller/ingress/controller.go` (`Reconcile`): Instead of logging admission or rejection, emit events.

----

I noticed in CI logs that the `TestUniqueDomainRejection` test causes the operator to log "admitted ingresscontroller" repeatedly even though the ingresscontroller is being rejected.  It is obvious to me that the log message needs to be changed, but I am not so sure whether or not we should retry admission (in case the conflicting ingresscontroller is deleted in between retries).  @ironcladlou, what do you think?