### PR TITLE
Bug 1740441: manifests: make credentialsrequest names consistent

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -26,7 +26,7 @@ kind: CredentialsRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: azure-openshift-ingress
+  name: openshift-ingress-azure
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:
@@ -44,7 +44,7 @@ kind: CredentialsRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: gcp-openshift-ingress
+  name: openshift-ingress-gcp
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:


### PR DESCRIPTION
Use consistent naming for credentialsrequests.