### PR TITLE
Bug 1740595: ensureServiceMonitor: Update resource if needed

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -41,6 +41,7 @@ rules:
   verbs:
   - create
   - get
+  - update
 
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/pkg/operator/controller/ingress/metrics.go
+++ b/pkg/operator/controller/ingress/metrics.go
@@ -74,7 +74,7 @@ func (r *reconciler) ensureMetricsIntegration(ci *operatorv1.IngressController, 
 		log.Info("created router metrics role binding", "name", mrb.Name)
 	}
 
-	if _, err := r.ensureServiceMonitor(ci, svc, deploymentRef); err != nil {
+	if _, _, err := r.ensureServiceMonitor(ci, svc, deploymentRef); err != nil {
 		return fmt.Errorf("failed to ensure servicemonitor for %s: %v", ci.Name, err)
 	}
 

--- a/pkg/operator/controller/ingress/monitoring_test.go
+++ b/pkg/operator/controller/ingress/monitoring_test.go
@@ -1,0 +1,47 @@
+package ingress
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestServiceMonitorChanged(t *testing.T) {
+	trueVar := true
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-default",
+			Namespace: "openshift-ingress",
+		},
+	}
+	deploymentRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "router-default",
+		UID:        "1",
+		Controller: &trueVar,
+	}
+	sm1 := desiredServiceMonitor(ic, svc, deploymentRef)
+	sm2 := desiredServiceMonitor(ic, svc, deploymentRef)
+	if changed, _ := serviceMonitorChanged(sm1, sm2); changed {
+		t.Fatal("expected changed to be false for two servicemonitors defined for the same ingresscontroller and service")
+	}
+	if err := unstructured.SetNestedField(sm2.Object, nil, "spec", "selector"); err != nil {
+		t.Fatalf("failed to mutate servicemonitor: %v", err)
+	}
+	if changed, sm3 := serviceMonitorChanged(sm1, sm2); !changed {
+		t.Fatal("expected changed to be true after clearing servicemonitor's selector")
+	} else if changedAgain, _ := serviceMonitorChanged(sm2, sm3); changedAgain {
+		t.Fatal("serviceMonitorChanged does not behave as a fixed-point function")
+	}
+}


### PR DESCRIPTION
If a servicemonitor already exists but is not the same as the desired servicemonitor, update the current servicemonitor.

https://github.com/openshift/cluster-ingress-operator/pull/242 added a selector to the servicemonitor that `desiredServiceMonitor` returns, so the operator must update any servicemonitors created by older versions of the operator.

* `manifests/00-cluster-role.yaml`: Allow updating servicemonitors.
* `pkg/operator/controller/ingress/monitoring.go` (`ensureServiceMonitor`): Add godoc.  If a servicemonitor is needed and none exists, use `createServiceMonitor` to create it.  If a servicemonitor already exists, update it if needed using `updateServiceMonitor`.  Finally, return a Boolean value indicating whether a servicemonitor exists.
(`desiredServiceMonitor`): Add godoc.  Fix the type of the "endpoints" field, and add a comment why it is important to use the right type.
(`currentServiceMonitor`): Add godoc.  Add a Boolean return value indicating whether a servicemonitor exists.
(`createServiceMonitor`, `updateServiceMonitor`): New methods, used by `ensureServiceMonitor`.
(`serviceMonitorChanged`): New function, used by `updateServiceMonitor`. Compare the specs of the given servicemonitors and return a Boolean value indicating whether an update is needed and, if so, an updated servicemonitor definition.
* `pkg/operator/controller/ingress/metrics.go` (`ensureMetricsIntegration`): Ignore the Boolean return value from `ensureServiceMonitor`.
* `pkg/operator/controller/ingress/monitoring_test.go` (`TestServiceMonitorChanged`): New test.
