### PR TITLE
Have HAProxy use modern SSL ciphers

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -130,6 +130,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 				Key: "statsPassword",
 			},
 		}},
+		{Name: "ROUTER_CIPHERS", Value: "modern"},
 	}
 
 	// Enable prometheus metrics


### PR DESCRIPTION
for Jira COMPLY-67. Do not use TLS <1.2

I have tested this on my cluster and it gives the correct results.

/cc @jaybeeunix 