### PR TITLE
disableNamespaceOwnershipCheck: Add optional router configuration

### DIFF
--- a/manifests/00-custom-resource-definition.yaml
+++ b/manifests/00-custom-resource-definition.yaml
@@ -418,6 +418,15 @@ spec:
                     TODO: Add other useful fields. apiVersion, kind, uid?'
                   type: string
               type: object
+            disableNamespaceOwnershipCheck:
+              description: "disableNamespaceOwnershipCheck disables the namespace
+                ownership checks for a route host with different paths or for overlapping
+                host names in the case of wildcard routes. Please be aware that if
+                namespace ownership checks are disabled, routes in a different namespace
+                can use this mechanism to 'steal' sub-paths for existing domains.
+                This is only safe if route creation privileges are restricted, or
+                if all the users can be trusted. \n If unset, the default is false"
+              type: boolean
             domain:
               description: "domain is a DNS name serviced by the ingress controller
                 and is used to configure multiple features: \n * For the LoadBalancerService

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -218,6 +218,10 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		env = append(env, corev1.EnvVar{Name: "ROUTE_LABELS", Value: routeSelector.String()})
 	}
 
+	if ci.Spec.DisableNamespaceOwnershipCheck != nil && *ci.Spec.DisableNamespaceOwnershipCheck {
+		env = append(env, corev1.EnvVar{Name: "ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", Value: "true"})
+	}
+
 	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, env...)
 
 	deployment.Spec.Template.Spec.Containers[0].Image = ingressControllerImage


### PR DESCRIPTION
To enable multiple routes in different namespace to share the same domain,
the router will need to be configured to allow admission of multiple
routes from different namespaces.
This is supported in the openshift router and in OpenShift 3, and prevents migration for customers.

This commit fixes issue #285.

https://github.com/openshift/cluster-ingress-operator/issues/285

openshift/api crd change: https://github.com/openshift/api/pull/416

TODO: Update PR with go.mod after #416 is merged.