### PR TITLE
Bug 1747840: dns: add explicit TTL to all wildcard records

### DIFF
--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -8,4 +8,7 @@ oc scale --replicas 0 -n openshift-ingress-operator deployments ingress-operator
 IMAGE=$(oc get -n openshift-ingress-operator deployments/ingress-operator -o json | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="IMAGE").value')
 RELEASE_VERSION=$(oc get clusterversion/version -o json | jq -r '.status.desired.version')
 
-IMAGE="$IMAGE" RELEASE_VERSION="$RELEASE_VERSION" ./ingress-operator
+echo "Image: ${IMAGE}"
+echo "Release version: ${RELEASE_VERSION}"
+
+IMAGE="${IMAGE}" RELEASE_VERSION="${RELEASE_VERSION}" ./ingress-operator

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -84,6 +84,7 @@ func (m *provider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		client.ARecord{
 			Address: record.Spec.Targets[0],
 			Name:    ARecordName,
+			TTL:     record.Spec.RecordTTL,
 		})
 
 	if err == nil {
@@ -111,6 +112,7 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		client.ARecord{
 			Address: record.Spec.Targets[0],
 			Name:    ARecordName,
+			TTL:     record.Spec.RecordTTL,
 		})
 
 	if err == nil {

--- a/pkg/dns/azure/dns_test.go
+++ b/pkg/dns/azure/dns_test.go
@@ -37,6 +37,7 @@ func TestEnsureDNS(t *testing.T) {
 			DNSName:    "subdomain.dnszone.io.",
 			RecordType: iov1.ARecordType,
 			Targets:    []string{"55.11.22.33"},
+			RecordTTL:  120,
 		},
 	}
 	dnsZone := configv1.DNSZone{

--- a/pkg/dns/gcp/provider.go
+++ b/pkg/dns/gcp/provider.go
@@ -72,6 +72,6 @@ func resourceRecordSet(record *iov1.DNSRecord) *gdnsv1.ResourceRecordSet {
 		Name:    record.Spec.DNSName,
 		Rrdatas: record.Spec.Targets,
 		Type:    record.Spec.RecordType,
-		Ttl:     300,
+		Ttl:     record.Spec.RecordTTL,
 	}
 }

--- a/pkg/operator/controller/ingress/dns_test.go
+++ b/pkg/operator/controller/ingress/dns_test.go
@@ -57,6 +57,7 @@ func TestDesiredWildcardDNSRecord(t *testing.T) {
 				DNSName:    "*.apps.openshift.example.com.",
 				RecordType: iov1.CNAMERecordType,
 				Targets:    []string{"lb.cloud.example.com"},
+				RecordTTL:  defaultRecordTTL,
 			},
 		},
 		{
@@ -70,6 +71,7 @@ func TestDesiredWildcardDNSRecord(t *testing.T) {
 				DNSName:    "*.apps.openshift.example.com.",
 				RecordType: iov1.ARecordType,
 				Targets:    []string{"192.0.2.1"},
+				RecordTTL:  defaultRecordTTL,
 			},
 		},
 	}


### PR DESCRIPTION
Before this commit, wildcard DNS resource record TTLs were inconsistent:

* AWS alias record TTLs are not user-configurable.
* Azure records TTLs were zero (which is essentially undefined and so causes
unpredictable client behavior)
* GCP record TTLs were 120 seconds.

After this commit, all DNS records default to 30 seconds for any provider which
supports setting a TTL for the record type (Azure and GCP at this time). This
brings some consistency, and most importantly, eliminates the possibility of
zero TTLs.