### PR TITLE
Enable debug support when building/running ingress-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@ MAIN_PACKAGE=$(PACKAGE)/cmd/ingress-operator
 
 BIN=$(lastword $(subst /, ,$(MAIN_PACKAGE)))
 
+ifneq ($(DELVE),)
+GO_GCFLAGS ?= -gcflags=all="-N -l"
+endif
+
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
-GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build -o $(BIN) $(MAIN_PACKAGE)
+GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build -o $(BIN) $(GO_GCFLAGS) $(MAIN_PACKAGE)
 
 TEST ?= .*
 
@@ -72,3 +76,7 @@ verify-gosec:
 .PHONY: uninstall
 uninstall:
 	hack/uninstall.sh
+
+.PHONY: run-local
+run-local:
+	hack/run-local.sh

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -11,4 +11,4 @@ RELEASE_VERSION=$(oc get clusterversion/version -o json | jq -r '.status.desired
 echo "Image: ${IMAGE}"
 echo "Release version: ${RELEASE_VERSION}"
 
-IMAGE="${IMAGE}" RELEASE_VERSION="${RELEASE_VERSION}" ./ingress-operator
+IMAGE="${IMAGE}" RELEASE_VERSION="${RELEASE_VERSION}" ${DELVE:-} ./ingress-operator


### PR DESCRIPTION
- Allow ingress-operator binary to be built with debug support
- Allow ingress-operator binary to be invoked via delve

If the environment variable `DELVE` is set then build the
ingress-operator binary with debug flags enabled. The default flags
passed to the compiler will disable optimisations and inlining for the
whole program.

Specifically, the GCFLAGS are:
- `-N` - disable optimizations
- `-l` - disable inlining

Running `hack/run-local.sh` will invoke the ingress-operator binary
under the auspices of the debugger (but only when the environment
variable `DELVE` is set):

```console
$ ./hack/run-local.sh
deployment.extensions/cluster-version-operator scaled
deployment.extensions/ingress-operator scaled
Image: openshift/origin-haproxy-router:v4.0
Release version: 4.2.0-0.okd-2019-09-23-102648
Type 'help' for list of commands.
(dlv) c
2019-09-25T09:51:00.164+0100	INFO	operator	log/log.go:26	started zapr logger
```

For convenience I extended the Makefile to add a `run-local` target
which invokes `hack/run-local.sh`. This yields a convenient dev cycle:

    make build run-local

I enable/manage all of this using direnv[1]. In my `.envrc` I have:

```
layout go
export DELVE='dlv exec --'
```

If `DELVE` is unset then things remain as they were:

```console
$ make build run-local
CGO_ENABLED=0 GO111MODULE=on GOFLAGS=-mod=vendor go build -o ingress-operator  github.com/openshift/cluster-ingress-operator/cmd/ingress-operator
hack/run-local.sh
deployment.extensions/cluster-version-operator scaled
deployment.extensions/ingress-operator scaled
Image: openshift/origin-haproxy-router:v4.0
Release version: 4.2.0-0.okd-2019-09-23-102648
2019-09-25T09:49:14.472+0100	INFO	operator	log/log.go:26	started zapr logger
```

[1] https://direnv.net/