### PR TITLE
dns/aws: Do not include record in error messages

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -252,7 +252,7 @@ func (m *Provider) change(record *iov1.DNSRecord, zone configv1.DNSZone, action 
 
 	zoneID, err := m.getZoneID(zone)
 	if err != nil {
-		return fmt.Errorf("failed to find hosted zone for record %v: %v", record, err)
+		return fmt.Errorf("failed to find hosted zone for record: %v", err)
 	}
 
 	// Find the target hosted zone of the load balancer attached to the service.


### PR DESCRIPTION
Do not include the DNSRecord resource in the error message that the AWS DNS provider returns in the case of a zone-lookup failure.

The DNS controller incorporates the error message from the DNS provider into the DNSRecord resource's "Failed" status condition message, which caused problems in the case of repeated zone-lookup failures.  Before this commit, such a failure would cause the controller to update the status condition message to include the DNSRecord from the previous failure, which would have a status condition message with the DNSRecord from the second previous failure, which would have a status condition message with the DNSRecord from the third previous failure, and so on.  As a result, the DNS controller was making many spurious updates with increasingly long status condition messages, to the point that etcd began rejecting updates with "request is too large".

* `pkg/dns/aws/dns.go` (`change`): Omit the DNSRecord from the error message for zone-lookup failure.