### PR TITLE
WIP: NE-150: Use observedGeneration in admission control

### DIFF
--- a/manifests/00-custom-resource-definition.yaml
+++ b/manifests/00-custom-resource-definition.yaml
@@ -414,6 +414,10 @@ spec:
               required:
               - type
               type: object
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed.
+              format: int64
+              type: integer
             selector:
               description: selector is a label selector, in string format, for ingress
                 controller pods corresponding to the IngressController. The number

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -130,6 +130,9 @@ func computeIngressDegradedCondition(deployment *appsv1.Deployment) operatorv1.O
 // if the provided values should be considered equal for the purpose of determining
 // whether an update is necessary, false otherwise.
 func ingressStatusesEqual(a, b operatorv1.IngressControllerStatus) bool {
+	if a.ObservedGeneration != b.ObservedGeneration {
+		return false
+	}
 	if !conditionsEqual(a.Conditions, b.Conditions) || a.AvailableReplicas != b.AvailableReplicas ||
 		a.Selector != b.Selector {
 		return false

--- a/vendor/github.com/openshift/api/operator/v1/types_ingress.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_ingress.go
@@ -332,6 +332,10 @@ type IngressControllerStatus struct {
 	//     * DNS records have been successfully created.
 	//   - False if any of those conditions are unsatisfied.
 	Conditions []OperatorCondition `json:"conditions,omitempty"`
+
+	// observedGeneration is the most recent generation observed.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Update `status.observedGeneration` when processing an ingresscontroller for
admission, and reprocess an ingresscontroller if its `generation` differs
from its `status.observedGeneration` in order to ensure that it is
revalidated if it is mutated.

https://jira.coreos.com/browse/NE-150

* `pkg/operator/controller/ingress/controller.go` (`Reconcile`): Call `needsReadmission`, and reprocess the ingresscontroller if needed.
(`admit`): Update the ingresscontroller's `status.observedGeneration` field when updating its "Admitted" status condition.
(`needsReadmission`): New function.  Return a Boolean value indicating whether the given ingresscontroller needs to be reprocessed for admission, based on its current generation and last observed generation.
* `pkg/operator/controller/ingress/status.go` (`ingressStatusesEqual`): Compare observed generation.