### PR TITLE
Bug 1740374: status: Set Degraded using other status conditions

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -75,7 +75,8 @@ type DNSRecordList struct {
 }
 
 const (
-	IngressControllerAdmittedConditionType = "Admitted"
+	IngressControllerAdmittedConditionType           = "Admitted"
+	IngressControllerDeploymentDegradedConditionType = "DeploymentDegraded"
 )
 
 func init() {

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -9,6 +9,7 @@ import (
 	iov1 "github.com/openshift/cluster-ingress-operator/pkg/api/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	retryable "github.com/openshift/cluster-ingress-operator/pkg/util/retryableerror"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/slice"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -185,9 +186,14 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// The ingresscontroller is safe to process, so ensure it.
 	if err := r.ensureIngressController(ingress, dnsConfig, infraConfig, ingressConfig, apiConfig); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to ensure ingresscontroller: %v", err)
+		switch e := err.(type) {
+		case retryable.Error:
+			log.Error(e, "got retryable error; requeueing", "after", e.After())
+			return reconcile.Result{RequeueAfter: e.After()}, nil
+		default:
+			return reconcile.Result{}, err
+		}
 	}
-
 	return reconcile.Result{}, nil
 }
 
@@ -496,7 +502,10 @@ func (r *reconciler) ensureIngressDeleted(ingress *operatorv1.IngressController)
 	return nil
 }
 
-// ensureIngressController ensures all necessary router resources exist for a given ingresscontroller.
+// ensureIngressController ensures all necessary router resources exist for a
+// given ingresscontroller.  Any error values are collected into either a
+// retryable.Error value, if any of the error values are retryable, or else an
+// Aggregate error value.
 func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer) error {
 	// Before doing anything at all with the controller, ensure it has a finalizer
 	// so we can clean up later.
@@ -567,7 +576,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to sync ingresscontroller status: %v", err))
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return retryable.NewMaybeRetryableAggregate(errs)
 }
 
 // IsStatusDomainSet checks whether status.domain of ingress is set.

--- a/pkg/util/retryableerror/retryableerror.go
+++ b/pkg/util/retryableerror/retryableerror.go
@@ -1,0 +1,59 @@
+package retryableerror
+
+import (
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// Error represents an error for an operation that should be retried after the
+// specified duration.
+type Error interface {
+	error
+	// After is the time period after which the operation that caused the
+	// error should be retried.
+	After() time.Duration
+}
+
+// New returns a new RetryableError with the given error and time period.
+func New(err error, after time.Duration) Error {
+	return retryableError{err, after}
+}
+
+type retryableError struct {
+	error
+	after time.Duration
+}
+
+// After returns the time period after which the operation that caused the error
+// should be retried.
+func (r retryableError) After() time.Duration {
+	return r.after
+}
+
+// NewMaybeRetryableAggregate converts a slice of errors into a single error
+// value.  Nil values will be filtered from the slice.  If the filtered slice is
+// empty, the return value will be nil.  Else, if any values are non-retryable
+// errors, the result will be an Aggregate interface.  Else, if all errors are
+// retryable, the result will be a retryable Error interface, with After() equal
+// to the minimum of all the errors' After() values.
+func NewMaybeRetryableAggregate(errs []error) error {
+	aggregate := utilerrors.NewAggregate(errs)
+	if aggregate == nil {
+		return nil
+	}
+	afterHasInitialValue := false
+	var after time.Duration
+	for _, err := range aggregate.Errors() {
+		switch e := err.(type) {
+		case Error:
+			if !afterHasInitialValue || e.After() < after {
+				after = e.After()
+			}
+			afterHasInitialValue = true
+		default:
+			return aggregate
+		}
+	}
+	return New(aggregate, after)
+}

--- a/pkg/util/retryableerror/retryableerror_test.go
+++ b/pkg/util/retryableerror/retryableerror_test.go
@@ -1,0 +1,58 @@
+package retryableerror
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func TestRetryableError(t *testing.T) {
+	tests := []struct {
+		name            string
+		errors          []error
+		expectRetryable bool
+		expectAggregate bool
+		expectAfter     time.Duration
+	}{
+		{
+			name: "empty list",
+		},
+		{
+			name:            "non-retryable errors",
+			errors:          []error{errors.New("foo"), errors.New("bar")},
+			expectAggregate: true,
+		},
+		{
+			name: "mix of retryable and non-retryable errors",
+			errors: []error{
+				errors.New("foo"),
+				errors.New("bar"),
+				New(errors.New("baz"), time.Second*15),
+				New(errors.New("quux"), time.Minute),
+			},
+			expectAggregate: true,
+		},
+		{
+			name: "only retryable errors",
+			errors: []error{
+				New(errors.New("baz"), time.Second*15),
+				New(errors.New("quux"), time.Minute),
+			},
+			expectRetryable: true,
+			expectAfter:     time.Second * 15,
+		},
+	}
+	for _, test := range tests {
+		err := NewMaybeRetryableAggregate(test.errors)
+		if retryable, gotRetryable := err.(Error); gotRetryable != test.expectRetryable {
+			t.Errorf("%q: expected retryable %T, got %T: %v", test.name, test.expectRetryable, gotRetryable, err)
+		} else if gotRetryable && retryable.After() != test.expectAfter {
+			t.Errorf("%q: expected after %v, got %v: %v", test.name, test.expectAfter, retryable.After(), err)
+		}
+		if _, gotAggregate := err.(utilerrors.Aggregate); gotAggregate != test.expectAggregate {
+			t.Errorf("%q: expected aggregate %T, got %T: %v", test.name, test.expectAggregate, gotAggregate, err)
+		}
+	}
+}


### PR DESCRIPTION
#### status: Set Degraded using other status conditions

Add a `DeploymentDegraded` status condition for ingresscontrollers.  Use the `Admitted`, `DeploymentDegraded`, `LoadBalancerReady`, and `DNSReady` status conditions to compute the status of the `Degraded` status condition.

* `pkg/api/v1/types.go` (`IngressControllerDeploymentDegradedConditionType`): New constant.
* `pkg/operator/controller/ingress/controller.go` (`Reconcile`): Requeue after the duration that `ensureIngressController` returns, if that duration is non-zero.
(`ensureIngressController`): Add a duration return value.  Return the duration value that `syncIngressControllerStatus` returns.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Call `computeDeploymentDegradedCondition`.  Adjust call to `computeIngressDegradedCondition`.  Add a duration return value to indicate if and when the ingresscontroller should be requeued for reconciliation so that the operator will update its status conditions.  Return the duration value from `computeIngressDegradedCondition`.
(`computeDeploymentDegradedCondition`): New function, based on the old definition of `computeIngressDegradedCondition`.  Compute and return the `DeploymentDegraded` status condition.
(`computeIngressDegradedCondition`): Delete the deployment parameter, and add a conditions parameter.  Compute the `Degraded` status condition from the ingresscontroller's other status conditions.  Return the status condition and a duration value to indicate if and when the status conditions should be recomputed.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputeIngressDegradedCondition`): New test.


#### status: Compute `DeploymentDegraded` from `Unavailable`

Compute the ingresscontroller's `DeploymentDegraded` status condition from the deployment's desired replicas, maximum unavailable, and current unavailable values.

* `pkg/operator/controller/ingress/status.go` (`computeDeploymentDegradedCondition`): Use current and max unavailable to compute the status condition.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputeDeploymentDegradedCondition`): New test.