### PR TITLE
Bug 1763605: Fixes tls security policy cipher handling

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +38,14 @@ const (
 	controllerName = "ingress_controller"
 )
 
-var log = logf.Logger.WithName(controllerName)
+var (
+	log = logf.Logger.WithName(controllerName)
+	// tlsVersion13Ciphers is a list of TLS v1.3 cipher suites as specified by
+	// https://www.openssl.org/docs/man1.1.1/man1/ciphers.html
+	tlsVersion13Ciphers = sets.NewString("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+		"TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256", "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256")
+)
 
 // New creates the ingress controller from configuration. This is the controller
 // that handles all the logic for implementing ingress based on
@@ -350,7 +358,6 @@ func tlsProfileSpecForSecurityProfile(profile *configv1.TLSSecurityProfile) *con
 		} else if spec, ok := configv1.TLSProfiles[profile.Type]; ok {
 			// TODO remove when haproxy is built with an openssl version that supports tls v1.3.
 			if profile.Type == configv1.TLSProfileModernType {
-				log.Info("converted modern tls security profile to intermediate")
 				return configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 			}
 			return spec
@@ -455,6 +462,10 @@ func validateTLSSecurityProfile(ic *operatorv1.IngressController) error {
 		if len(invalidCiphers) != 0 {
 			errs = append(errs, fmt.Errorf("security profile has invalid ciphers: %s", strings.Join(invalidCiphers, ", ")))
 		}
+		filteredCiphers := filterTLS13Ciphers(spec.Ciphers)
+		if len(filteredCiphers) == 0 {
+			errs = append(errs, fmt.Errorf("security profile contains only tls v1.3 cipher suites"))
+		}
 	}
 
 	if _, ok := validTLSVersions[spec.MinTLSVersion]; !ok {
@@ -462,6 +473,22 @@ func validateTLSSecurityProfile(ic *operatorv1.IngressController) error {
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// filterTLS13Ciphers filters any TLS v1.3 cipher suites from ciphers returning
+// a filtered list of cipher suites.
+func filterTLS13Ciphers(ciphers []string) []string {
+	filteredCiphers := []string{}
+	for i := 0; i < len(ciphers); i++ {
+		exist := false
+		if tlsVersion13Ciphers.Has(ciphers[i]) {
+			exist = true
+		}
+		if !exist {
+			filteredCiphers = append(filteredCiphers, ciphers[i])
+		}
+	}
+	return filteredCiphers
 }
 
 // ensureIngressDeleted tries to delete ingress, and if successful, will remove

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -47,13 +47,15 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 			valid:        true,
 			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
 		},
+		// TODO: Update test case to use Modern cipher suites when haproxy is
+		//  built with an openssl version that supports tls v1.3.
 		{
 			description: "modern",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
 			},
 			valid:        true,
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
 		},
 		{
 			description: "custom, nil profile",
@@ -241,6 +243,30 @@ func TestTLSProfileSpecForIngressController(t *testing.T) {
 			icProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
 			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
 			expectedSpec: &configv1.TLSProfileSpec{},
+		},
+		// TODO: Update test cases to use Modern cipher suites when haproxy is
+		//  built with an openssl version that supports tls v1.3.
+		{
+			description:  "modern, nil -> intermediate",
+			icProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			description:  "nil, modern -> intermediate",
+			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			description:  "modern, empty -> intermediate",
+			icProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			apiProfile:   &configv1.TLSSecurityProfile{},
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			description:  "empty, modern -> intermediate",
+			icProfile:    &configv1.TLSSecurityProfile{},
+			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
 		},
 	}
 

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -12,6 +12,10 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 	invalidTLSVersion := configv1.TLSProtocolVersion("abc")
 	invalidCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384", "invalid cipher"}
 	validCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384"}
+	tlsVersion13Ciphers := []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+		"TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256", "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256"}
+	tlsVersion1213Ciphers := []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "ECDHE-ECDSA-AES256-GCM-SHA384"}
 	testCases := []struct {
 		description  string
 		profile      *configv1.TLSSecurityProfile
@@ -84,6 +88,32 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 				},
 			},
 			valid: false,
+		},
+		{
+			description: "custom, invalid tls v1.3 only ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       tlsVersion13Ciphers,
+						MinTLSVersion: configv1.VersionTLS10,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			description: "custom, mixed tls v1.2 and v1.3 ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       tlsVersion1213Ciphers,
+						MinTLSVersion: configv1.VersionTLS10,
+					},
+				},
+			},
+			valid: true,
 		},
 		{
 			description: "custom, invalid minimum security protocol version",

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -396,8 +396,8 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		minTLSVersion = "TLSv1.1"
 	case configv1.VersionTLS12:
 		minTLSVersion = "TLSv1.2"
-	case configv1.VersionTLS13:
-		minTLSVersion = "TLSv1.3"
+	// TODO: Add TLS 1.3 support when haproxy is built with an openssl
+	//  version that supports tls v1.3.
 	default:
 		minTLSVersion = "TLSv1.2"
 	}
@@ -462,8 +462,7 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 		minTLSVersion = configv1.VersionTLS11
 	case "TLSv1.2":
 		minTLSVersion = configv1.VersionTLS12
-	case "TLSv1.3":
-		minTLSVersion = configv1.VersionTLS13
+	// TODO: Add TLS 1.3 support when haproxy is built with openssl 1.1.1.
 	default:
 		minTLSVersion = configv1.VersionTLS12
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -296,7 +296,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 			break
 		}
 	}
-	expectedTLSMinVersion = "TLSv1.3"
+	// TODO: Update when haproxy is built with an openssl version that supports tls v1.3.
+	expectedTLSMinVersion = "TLSv1.2"
 	if tlsMinVersion != expectedTLSMinVersion {
 		t.Errorf("router Deployment has unexpected minimum TLS version: expected %q, got %q", expectedTLSMinVersion, tlsMinVersion)
 	}


### PR DESCRIPTION
Converts `Modern` tls security profiles to `Intermediate`. Remove after haproxy is upgraded to an openssl version that supports tls v1.3.

/assign @Miciah 