### PR TITLE
Bug 1763639: Fixes minTLSVersion for Old profile

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -394,7 +394,9 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 
 	var minTLSVersion string
 	switch tlsProfileSpec.MinTLSVersion {
-	// TLS 1.0 is not supported.
+	// TLS 1.0 is not supported, convert to TLS 1.1.
+	case configv1.VersionTLS10:
+		minTLSVersion = "TLSv1.1"
 	case configv1.VersionTLS11:
 		minTLSVersion = "TLSv1.1"
 	case configv1.VersionTLS12:


### PR DESCRIPTION
Sets `minTLSVersion` to 1.1. Note that openshift/api defines `minTLSVersion` as TLS v1.0 for the Old profile, but this version is not supported for ingress. The oldest available TLS version for ingress is 1.1.

/assign @Miciah @ironcladlou 