### PR TITLE
Support multiple addresses or DNS names on LBs

### DIFF
--- a/pkg/dns/aws/dns_test.go
+++ b/pkg/dns/aws/dns_test.go
@@ -1,0 +1,214 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/route53"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	iov1 "github.com/openshift/api/operatoringress/v1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"testing"
+)
+
+func buildFakeResponses(record iov1.DNSRecord, dnsZone configv1.DNSZone) []interface{} {
+	var elbDescriptions []*elb.LoadBalancerDescription
+	var responses []interface{}
+
+	for _, target := range record.Spec.Targets {
+		elbDescription := &elb.LoadBalancerDescription{
+			DNSName:                   aws.String(target),
+			CanonicalHostedZoneNameID: aws.String(dnsZone.ID),
+		}
+		elbDescriptions = append(elbDescriptions, elbDescription)
+	}
+
+	for i := 0; i < len(record.Spec.Targets); i++ {
+		elbResponse := &elb.DescribeLoadBalancersOutput{
+			LoadBalancerDescriptions: elbDescriptions,
+		}
+
+		responses = append(responses, elbResponse)
+	}
+
+	route53Response := &route53.ChangeResourceRecordSetsInput{}
+	responses = append(responses, route53Response)
+
+	return responses
+}
+
+func fakeAWSProvider(record iov1.DNSRecord, dnsZone configv1.DNSZone) *Provider {
+	resps := buildFakeResponses(record, dnsZone)
+
+	reqNum := 0
+	sess := session.Must(session.NewSession(&aws.Config{
+		DisableSSL: aws.Bool(true),
+	}))
+	sess.Handlers.Send.Clear()
+	sess.Handlers.Unmarshal.Clear()
+	sess.Handlers.UnmarshalMeta.Clear()
+	sess.Handlers.ValidateResponse.Clear()
+	sess.Handlers.Unmarshal.PushBack(func(r *request.Request) {
+		r.Data = resps[reqNum]
+		reqNum++
+	})
+
+	config := &aws.Config{
+		MaxRetries: aws.Int(1),
+		Region:     aws.String("ap-southeast-2"),
+	}
+
+	route53Config := sess.ClientConfig("route53", config)
+	route53 := &route53.Route53{
+		Client: client.New(
+			*route53Config.Config,
+			metadata.ClientInfo{
+				ServiceName:   "route53",
+				ServiceID:     "Route 53",
+				SigningName:   "",
+				SigningRegion: route53Config.SigningRegion,
+				Endpoint:      route53Config.Endpoint + "/route53",
+				APIVersion:    "2013-04-01",
+				JSONVersion:   "1.1",
+				TargetPrefix:  "MockServer",
+			},
+			route53Config.Handlers,
+		),
+	}
+
+	elbConfig := sess.ClientConfig("elasticloadbalancing", config)
+	elb := &elb.ELB{
+		Client: client.New(
+			*elbConfig.Config,
+			metadata.ClientInfo{
+				ServiceName:   "elasticloadbalancing",
+				ServiceID:     "Elastic Load Balancing",
+				SigningName:   "",
+				SigningRegion: elbConfig.SigningRegion,
+				Endpoint:      elbConfig.Endpoint + "/elb",
+				APIVersion:    "2012-06-01",
+				JSONVersion:   "1.1",
+				TargetPrefix:  "MockServer",
+			},
+			elbConfig.Handlers,
+		),
+	}
+
+	taggingConfig := sess.ClientConfig("resourcegroupstaggingapi", config)
+	tagging := &resourcegroupstaggingapi.ResourceGroupsTaggingAPI{
+		Client: client.New(
+			*taggingConfig.Config,
+			metadata.ClientInfo{
+				ServiceName:   "tagging",
+				ServiceID:     "Resource Groups Tagging API",
+				SigningName:   "",
+				SigningRegion: taggingConfig.SigningRegion,
+				Endpoint:      taggingConfig.Endpoint + "/tagging",
+				APIVersion:    "2017-01-26",
+				JSONVersion:   "1.1",
+				TargetPrefix:  "ResourceGroupsTaggingAPI_20170126",
+			},
+			taggingConfig.Handlers,
+		),
+	}
+
+	return &Provider{
+		elb:            elb,
+		route53:        route53,
+		tags:           tagging,
+		idsToTags:      map[string]map[string]string{},
+		lbZones:        map[string]string{},
+		updatedRecords: sets.NewString(),
+	}
+}
+
+func TestEnsureAWSDNS(t *testing.T) {
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.CNAMERecordType,
+			Targets:    []string{"afcfa1e69205711e99e9906f0636dbcb-2044172706.ap-southeast-2.elb.amazonaws.com"},
+			RecordTTL:  120,
+		},
+	}
+
+	dnsZone := configv1.DNSZone{
+		ID: "Z1GM3OXH4ZPM65",
+	}
+
+	mgr := fakeAWSProvider(record, dnsZone)
+
+	if err := mgr.Ensure(&record, dnsZone); err != nil {
+		t.Fatalf("unexpected error from Ensure: %v", err)
+	}
+}
+
+func TestEnsureAWSDNSWithMultipleTargets(t *testing.T) {
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.CNAMERecordType,
+			Targets:    []string{"afcfa1e69205711e99e9906f0636dbcb-2044172707.ap-southeast-2.elb.amazonaws.com", "afcfa1e69205711e99e9906f0636dbcb-2044172708.ap-southeast-2.elb.amazonaws.com"},
+			RecordTTL:  120,
+		},
+	}
+
+	dnsZone := configv1.DNSZone{
+		ID: "Z1GM3OXH4ZPM66",
+	}
+
+	mgr := fakeAWSProvider(record, dnsZone)
+
+	if err := mgr.Ensure(&record, dnsZone); err != nil {
+		t.Fatalf("unexpected error from Ensure: %v", err)
+	}
+}
+
+func TestDeleteAWSDNS(t *testing.T) {
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.CNAMERecordType,
+			Targets:    []string{"afcfa1e69205711e99e9906f0636dbcb-2044172706.ap-southeast-2.elb.amazonaws.com"},
+			RecordTTL:  120,
+		},
+	}
+
+	dnsZone := configv1.DNSZone{
+		ID: "Z1GM3OXH4ZPM65",
+	}
+
+	mgr := fakeAWSProvider(record, dnsZone)
+
+	if err := mgr.Delete(&record, dnsZone); err != nil {
+		t.Fatalf("unexpected error from Delete: %v", err)
+	}
+}
+
+func TestDeleteAWSDNSWithMultipleTargets(t *testing.T) {
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.CNAMERecordType,
+			Targets:    []string{"afcfa1e69205711e99e9906f0636dbcb-2044172707.ap-southeast-2.elb.amazonaws.com", "afcfa1e69205711e99e9906f0636dbcb-2044172708.ap-southeast-2.elb.amazonaws.com"},
+			RecordTTL:  120,
+		},
+	}
+
+	dnsZone := configv1.DNSZone{
+		ID: "Z1GM3OXH4ZPM66",
+	}
+
+	mgr := fakeAWSProvider(record, dnsZone)
+
+	if err := mgr.Delete(&record, dnsZone); err != nil {
+		t.Fatalf("unexpected error from Delete: %v", err)
+	}
+}

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -75,14 +75,13 @@ func (m *provider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		return err
 	}
 
-	// TODO: handle >0 targets
 	err = m.client.Put(
 		context.TODO(),
 		*targetZone,
 		client.ARecord{
-			Address: record.Spec.Targets[0],
-			Name:    ARecordName,
-			TTL:     record.Spec.RecordTTL,
+			Addresses: record.Spec.Targets,
+			Name:      ARecordName,
+			TTL:       record.Spec.RecordTTL,
 		})
 
 	if err == nil {
@@ -103,14 +102,13 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		return err
 	}
 
-	// TODO: handle >0 targets
 	err = m.client.Delete(
 		context.TODO(),
 		*targetZone,
 		client.ARecord{
-			Address: record.Spec.Targets[0],
-			Name:    ARecordName,
-			TTL:     record.Spec.RecordTTL,
+			Addresses: record.Spec.Targets,
+			Name:      ARecordName,
+			TTL:       record.Spec.RecordTTL,
 		})
 
 	if err == nil {

--- a/pkg/dns/azure/dns_test.go
+++ b/pkg/dns/azure/dns_test.go
@@ -27,7 +27,7 @@ func TestEnsureDNS(t *testing.T) {
 	fc, _ := client.NewFake(c)
 	mgr, err := fakeManager(fc)
 	if err != nil {
-		t.Error("failed to steup the manager under test")
+		t.Error("failed to setup the manager under test")
 	}
 	rg := "test-rg"
 	zone := "dnszone.io"
@@ -45,32 +45,23 @@ func TestEnsureDNS(t *testing.T) {
 	}
 	err = mgr.Ensure(&record, dnsZone)
 	if err != nil {
-		t.Fatal("failed to ensure dns")
-		return
+		t.Fatalf("unexpected error from Ensure: %v", err)
 	}
 
 	recordedCall, _ := fc.RecordedCall(rg, zone, ARecordName)
 
 	if recordedCall != "PUT" {
-		t.Fatalf("expected the dns client 'Delete' func to be called, but found %s instead", recordedCall)
+		t.Fatalf("expected the dns client Put' func to be called, but found %q instead", recordedCall)
 	}
 }
 
 func TestDeleteDNS(t *testing.T) {
 	c := client.Config{}
-	fc, err := client.NewFake(c)
+	fc, _ := client.NewFake(c)
+	mgr, err := fakeManager(fc)
 	if err != nil {
-		t.Error("failed to create manager")
-		return
+		t.Fatalf("failed to setup the manager under test: %v", err)
 	}
-
-	cfg := azure.Config{}
-	mgr, err := azure.NewFakeProvider(cfg, fc)
-	if err != nil {
-		t.Error("failed to create manager")
-		return
-	}
-
 	rg := "test-rg"
 	zone := "dnszone.io"
 	ARecordName := "subdomain"
@@ -86,13 +77,79 @@ func TestDeleteDNS(t *testing.T) {
 	}
 	err = mgr.Delete(&record, dnsZone)
 	if err != nil {
-		t.Error("failed to ensure dns")
-		return
+		t.Fatalf("unexpected error from Delete: %v", err)
 	}
 
 	recordedCall, _ := fc.RecordedCall(rg, zone, ARecordName)
 
 	if recordedCall != "DELETE" {
-		t.Fatalf("expected the dns client 'Delete' func to be called, but found %s instead", recordedCall)
+		t.Fatalf("expected the dns client 'Delete' func to be called, but found %q instead", recordedCall)
+	}
+}
+
+func TestDeleteDNSWithMultipleAddresses(t *testing.T) {
+	c := client.Config{}
+	fc, _ := client.NewFake(c)
+	mgr, err := fakeManager(fc)
+	if err != nil {
+		t.Fatalf("failed to setup the manager under test: %v", err)
+	}
+	rg := "test-rg"
+	zone := "dnszone.io"
+	ARecordName := "subdomain"
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.ARecordType,
+			Targets:    []string{"55.11.22.33", "55.11.22.34"},
+		},
+	}
+	dnsZone := configv1.DNSZone{
+		ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io",
+	}
+
+	err = mgr.Delete(&record, dnsZone)
+	if err != nil {
+		t.Fatalf("unexpected error from Delete: %v", err)
+	}
+
+	recordedCall, _ := fc.RecordedCall(rg, zone, ARecordName)
+
+	if recordedCall != "DELETE" {
+		t.Fatalf("expected the dns client 'Delete' func to be called, but found %q instead", recordedCall)
+	}
+}
+
+func TestEnsureDNSWithMultipleAddresses(t *testing.T) {
+	c := client.Config{}
+	fc, _ := client.NewFake(c)
+	mgr, err := fakeManager(fc)
+	if err != nil {
+		t.Fatalf("failed to setup the manager under test: %v", err)
+	}
+	rg := "test-rg"
+	zone := "dnszone.io"
+	ARecordName := "subdomain"
+	record := iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "subdomain.dnszone.io.",
+			RecordType: iov1.ARecordType,
+			Targets:    []string{"55.11.22.33", "55.11.22.34"},
+			RecordTTL:  120,
+		},
+	}
+	dnsZone := configv1.DNSZone{
+		ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io",
+	}
+
+	err = mgr.Ensure(&record, dnsZone)
+	if err != nil {
+		t.Fatalf("unexpected error from Ensure: %v", err)
+	}
+
+	recordedCall, _ := fc.RecordedCall(rg, zone, ARecordName)
+
+	if recordedCall != "PUT" {
+		t.Fatalf("expected the dns client 'Put' func to be called, but found %q instead", recordedCall)
 	}
 }


### PR DESCRIPTION
Modify the ingress operator's ingress_controller and DNS provider implementations to publish DNS records for all of the IP addresses or DNS names that are reported in a Service resource's status.loadBalancer.ingress field.

https://jira.coreos.com/browse/NE-225