### PR TITLE
Always publish router-ca configmap

### DIFF
--- a/pkg/operator/controller/certificate/publish_ca.go
+++ b/pkg/operator/controller/certificate/publish_ca.go
@@ -54,10 +54,6 @@ func (r *reconciler) ensureRouterCAConfigMap(secret *corev1.Secret, ingresses []
 
 // desiredRouterCAConfigMap returns the desired router CA configmap.
 func desiredRouterCAConfigMap(secret *corev1.Secret, ingresses []operatorv1.IngressController) (*corev1.ConfigMap, error) {
-	if !shouldPublishRouterCA(ingresses) {
-		return nil, nil
-	}
-
 	name := controller.RouterCAConfigMapName()
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
It seems likely we will always have a need for the `router-ca`, given several of the bugs we have been dealing with.  Is there any negative in always publishing this CA?  

/assign @Miciah 

/cc @spadgett @deads2k 
per ongoing conversations