### PR TITLE
publish a router-ca that can be used to verify routes in golang clients

### DIFF
--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -63,6 +63,16 @@ func RouterCAConfigMapName() types.NamespacedName {
 	}
 }
 
+// DefaultIngressCertConfigMapName returns the namespaced name for the default ingress cert configmap.
+// The operator uses this configmap to publish the public key that golang clients can use to trust
+// the default ingress wildcard serving cert.
+func DefaultIngressCertConfigMapName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: GlobalMachineSpecifiedConfigNamespace,
+		Name:      "default-ingress-cert",
+	}
+}
+
 // RouterCertsGlobalSecretName returns the namespaced name for the router certs
 // secret.  The operator uses this secret to publish the default certificates and
 // their keys, so that the authentication operator can configure the OAuth server


### PR DESCRIPTION
An explanation in code of how to fill in the router-ca.

Immediate mission: allow the default-ingress-ca to always contain a ca-bundle.crt that golang clients can use to validate the ingress wildcard certificate for the default ingresscontroller.  To do this
 1. if you are not `oc get -n openshift-ingress-operator ingresscontroller/default`, do not publish
 2. if the spec.DefaultCertificate.Name is set, use the `.data["tls.crt "]` value in that secret to the `router-ca.data["ca-bundle.crt"]`
 3. if it is not set, use the `ensureRouterCASecret` secret's `.data.["tls.crt"]`

If we can agree to this approach to solve the immediate 4.1, 4.2, and 4.3 problem, then we can update the enhancement.


Future mission: it may be useful to have a ca bundle that can terminate any ingress wildcard.  This seems simple, but it has security repercussions that would effectively be elevating privilege for every ingress-controller.  We have to decide if this ingress-controllers are system trusted or not.  Those that are not may not update this configmap.  I suspect this is already a security hole.

