### PR TITLE
Bug 1781948: Do not wrap errors from syncIngressControllerStatus

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -610,9 +610,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to list events in namespace %q: %v", "openshift-ingress", err))
 	}
 
-	if err := r.syncIngressControllerStatus(ci, deployment, lbService, operandEvents.Items, wildcardRecord, dnsConfig); err != nil {
-		errs = append(errs, fmt.Errorf("failed to sync ingresscontroller status: %v", err))
-	}
+	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, lbService, operandEvents.Items, wildcardRecord, dnsConfig))
 
 	return retryable.NewMaybeRetryableAggregate(errs)
 }

--- a/pkg/util/retryableerror/retryableerror_test.go
+++ b/pkg/util/retryableerror/retryableerror_test.go
@@ -20,6 +20,10 @@ func TestRetryableError(t *testing.T) {
 			name: "empty list",
 		},
 		{
+			name:   "nil error",
+			errors: []error{nil},
+		},
+		{
 			name:            "non-retryable errors",
 			errors:          []error{errors.New("foo"), errors.New("bar")},
 			expectAggregate: true,
@@ -39,6 +43,7 @@ func TestRetryableError(t *testing.T) {
 			errors: []error{
 				New(errors.New("baz"), time.Second*15),
 				New(errors.New("quux"), time.Minute),
+				nil,
 			},
 			expectRetryable: true,
 			expectAfter:     time.Second * 15,


### PR DESCRIPTION
An error value from `syncIngressControllerStatus` may represent a failure to update status, in which case `syncIngressControllerStatus` itself adds a clear error message and wrapping it is therefore unnecessary; or the error value may represent a retryable error, in which case wrapping the error value loses the retryable error type and adds an inaccurate error message.

* `pkg/operator/controller/ingress/controller.go` (`ensureIngressController`): Do not wrap the error value from `syncIngressControllerStatus` when adding it to the list of returned error values.
* `pkg/util/retryableerror/retryableerror_test.go` (`TestRetryableError`): Add a test case with a nil error value, and add a nil error value to the "only retryable errors" test case to verify that nil error values are ignored.