### PR TITLE
cmd/start: add option to configure shutdown trigger file

### DIFF
--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -11,4 +11,4 @@ RELEASE_VERSION=$(oc get clusterversion/version -o json | jq -r '.status.desired
 echo "Image: ${IMAGE}"
 echo "Release version: ${RELEASE_VERSION}"
 
-IMAGE="${IMAGE}" RELEASE_VERSION="${RELEASE_VERSION}" ${DELVE:-} ./ingress-operator
+IMAGE="${IMAGE}" RELEASE_VERSION="${RELEASE_VERSION}" ${DELVE:-} ./ingress-operator start $@


### PR DESCRIPTION
Add an option to configure the trusted CA bundle location, as the hard-coded
default location is hostile to local development environments.

Update the local run script to allow passing through options to the start
command to make it easier to use the new option.