### PR TITLE
Bug 1789687: the env ROUTER_IP_V4_V6_MODE should uses v6 instead v6_only

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -425,7 +425,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	if usingIPv6 {
 		mode := "v4v6"
 		if !usingIPv4 {
-			mode = "v6_only"
+			mode = "v6"
 		}
 		env = append(env, corev1.EnvVar{Name: "ROUTER_IP_V4_V6_MODE", Value: mode})
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -435,7 +435,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	}
 	if !foundIPv4V6Mode {
 		t.Error("router Deployment is missing ROUTER_IP_V4_V6_MODE setting")
-	} else if ipv4v6Mode != "v6_only" {
+	} else if ipv4v6Mode != "v6" {
 		t.Errorf("router Deployment has unexpected ROUTER_IP_V4_V6_MODE setting: %q", ipv4v6Mode)
 	}
 }


### PR DESCRIPTION
fix Bug https://bugzilla.redhat.com/show_bug.cgi?id=1789687.

The router template uses "v6" to match the env. 
```
    {{- else if eq "v6" $router_ip_v4_v6_mode }}
  bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v6only
```
see: https://github.com/openshift/router/blob/8af16cfb1e7bb1a0acf89f96c4e18529d591ec4d/images/router/haproxy/conf/haproxy-config.template#L152