### PR TITLE
Bug 1793541: Only initialize DNS providers if DNS config is present

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -207,6 +207,18 @@ func start(opts *StartOptions) error {
 // createDNSManager creates a DNS manager compatible with the given cluster
 // configuration.
 func createDNSProvider(cl client.Client, operatorConfig operatorconfig.Config, dnsConfig *configv1.DNS, platformStatus *configv1.PlatformStatus) (dns.Provider, error) {
+	// If no DNS configuration is provided, don't try to set up provider clients.
+	// TODO: the provider configuration can be refactored into the provider
+	// implementations themselves, so this part of the code won't need to
+	// know anything about the provider setup beyond picking the right implementation.
+	// Then, it would be safe to always use the appropriate provider for the platform
+	// and let the provider surface configuration errors if DNS records are actually
+	// created to exercise the provider.
+	if dnsConfig.Spec.PrivateZone == nil && dnsConfig.Spec.PublicZone == nil {
+		log.Info("using fake DNS provider because no public or private zone is defined in the cluster DNS configuration")
+		return &dns.FakeProvider{}, nil
+	}
+
 	var dnsProvider dns.Provider
 	userAgent := fmt.Sprintf("OpenShift/%s (ingress-operator)", operatorConfig.OperatorReleaseVersion)
 


### PR DESCRIPTION
If no DNS configuration is provided, don't try to set up provider clients.

This prevents an operator crash if DNS configuration is not provided on
platforms where managed DNS is expected to be supported (e.g. AWS).

In a followup, the provider configuration can be refactored into the provider
implementations themselves, so this part of the code won't need to know anything
about the provider setup beyond picking the right implementation. Then, it would
be safe to always use the appropriate provider for the platform and let the
provider surface configuration errors if DNS records are actually created to
exercise the provider.