### PR TITLE
Add ProxyProtocol flag to enable PROXY_PROTOCOl on ingress routers

### DIFF
--- a/manifests/00-custom-resource-definition.yaml
+++ b/manifests/00-custom-resource-definition.yaml
@@ -616,6 +616,12 @@ spec:
                     type: object
                   type: array
               type: object
+            proxyprotocol:
+              description: proxyprotocol is a flag used to indicate whether the ingress
+                routers should be configured to accept the PROXY Protocol or not.
+                If unset, defaults to false, unless the Infrastructure platform is
+                of type AWS, which it is enabled by default.
+              type: boolean
             replicas:
               description: replicas is the desired number of ingress controller replicas.
                 If unset, defaults to 2.

--- a/vendor/github.com/openshift/api/operator/v1/types_ingress.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_ingress.go
@@ -64,6 +64,13 @@ type IngressControllerSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+
+	// proxyprotocol is a flag used to indicate whether the ingress routers should be configured to accept the PROXY Protocol or not.
+	// If unset, defaults to false, unless the Infrastructure platform is of type AWS, which it is enabled by default.
+	//
+	// +optional
+	ProxyProtocolEnabled bool `json:"proxyprotocol,omitempty"`
+
 	// endpointPublishingStrategy is used to publish the ingress controller
 	// endpoints to other networks, enable load balancer integrations, etc.
 	//


### PR DESCRIPTION
This is enabled by default when the platform is AWS, but there is no reason
why it should not be available on others.  This is a GAP between OCP3 and OCP4, and is important for any customers who are not using AWS.