### PR TITLE
Bug 1801410: Set affinity for "NodePortService"

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -114,7 +114,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		// use host networking and specify the same port to the same
 		// node.  Thus no affinity policy is required when using
 		// HostNetwork.
-	case operatorv1.PrivateStrategyType, operatorv1.LoadBalancerServiceStrategyType:
+	case operatorv1.PrivateStrategyType, operatorv1.LoadBalancerServiceStrategyType, operatorv1.NodePortServiceStrategyType:
 		// To avoid downtime during a rolling update, we need two
 		// things: a deployment strategy and affinity policy.  First,
 		// the deployment strategy: During a rolling update, we want the


### PR DESCRIPTION
Configure the same deployment strategy and affinity policy on the deployment for an `IngressController` that uses the "NodePortService" endpoint publishing strategy type as we do for an `IngressController` that uses the "LoadBalancerService" or "Private" strategy type.

Follow-up to #343.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Configure deployment strategy and affinity policy the same for "NodePortService" as for "LoadBalancerService" and "Private".