### PR TITLE
Delete cluster DNS config from DNS provider config

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -232,7 +232,6 @@ func createDNSProvider(cl client.Client, operatorConfig operatorconfig.Config, d
 		provider, err := awsdns.NewProvider(awsdns.Config{
 			AccessID:  string(creds.Data["aws_access_key_id"]),
 			AccessKey: string(creds.Data["aws_secret_access_key"]),
-			DNS:       dnsConfig,
 			Region:    platformStatus.AWS.Region,
 		}, operatorConfig.OperatorReleaseVersion)
 		if err != nil {
@@ -251,7 +250,6 @@ func createDNSProvider(cl client.Client, operatorConfig operatorconfig.Config, d
 			ClientSecret:   string(creds.Data["azure_client_secret"]),
 			TenantID:       string(creds.Data["azure_tenant_id"]),
 			SubscriptionID: string(creds.Data["azure_subscription_id"]),
-			DNS:            dnsConfig,
 		}, operatorConfig.OperatorReleaseVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Azure DNS manager: %v", err)

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -71,8 +71,6 @@ type Config struct {
 	AccessKey string
 	// Region is the AWS region ELBs are created in.
 	Region string
-	// DNS is public and private DNS zone configuration for the cluster.
-	DNS *configv1.DNS
 }
 
 func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error) {

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -32,8 +32,6 @@ type Config struct {
 	TenantID string
 	// SubscriptionID is the azure identity's subscription ID.
 	SubscriptionID string
-	// DNS is public and private DNS zone configuration for the cluster.
-	DNS *configv1.DNS
 }
 
 type provider struct {


### PR DESCRIPTION
Remove references to the cluster DNS configuration object from the configuration objects for the AWS and Azure DNS providers.

#121 added a reference to the cluster DNS configuration in the AWS provider configuration, and #231 added a similar reference in the Azure provider configuration, but neither provider ever used the reference.

* `cmd/ingress-operator/start.go`: Do not set the `DNS` field in the config argument to `NewProvider`.
* `pkg/dns/aws/dns.go` (`Config`):
* `pkg/dns/azure/dns.go` (`Config`): Delete the `DNS` field.

----

This is just a clean-up; no functional change.