### PR TITLE
Router should deploy with a very long grace period

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -87,6 +87,10 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	deployment.Spec.Selector = controller.IngressControllerDeploymentPodSelector(ci)
 	deployment.Spec.Template.Labels = controller.IngressControllerDeploymentPodSelector(ci).MatchLabels
 
+	// the router should have a very long grace period by default (1h)
+	gracePeriod := int64(60 * 60)
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+
 	volumes := deployment.Spec.Template.Spec.Volumes
 	routerVolumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
 


### PR DESCRIPTION
In order to allow routers to be tuned to shutdown when a variable
length of connections have completed, the grace period needs to be
set fairly high. For now, set it to 1 hour until we determine what
tunable limits we should allow. In general few transactions will
take 1 hour to complete.