### PR TITLE
Delete iksLBProxyRegionAnnotations, rename iksLBProxyProtocolAnnotations

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -25,8 +25,6 @@ const (
 	awsLBProxyProtocolAnnotation = "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"
 
 	iksLBProxyProtocolAnnotations = "service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type"
-
-	iksLBProxyRegionAnnotations = "service.kubernetes.io/ibm-load-balancer-cloud-provider-zone"
 )
 
 var (

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -24,7 +24,7 @@ const (
 	// https://kubernetes.io/docs/concepts/services-networking/service/#proxy-protocol-support-on-aws
 	awsLBProxyProtocolAnnotation = "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"
 
-	iksLBProxyProtocolAnnotations = "service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type"
+	iksLBScopeAnnotation = "service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type"
 )
 
 var (
@@ -57,7 +57,7 @@ var (
 		// vSphere does not support load balancers as of 2019-06-17.
 		configv1.VSpherePlatformType: nil,
 		configv1.IBMCloudPlatformType: {
-			iksLBProxyProtocolAnnotations: "private",
+			iksLBScopeAnnotation: "private",
 		},
 	}
 )
@@ -125,7 +125,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 	// GCP load balancers are not customizable and are set to (3 fail @ 8s interval, 1 healthy)
 
 	if infraConfig.Status.Platform == configv1.IBMCloudPlatformType {
-		service.Annotations[iksLBProxyProtocolAnnotations] = "public"
+		service.Annotations[iksLBScopeAnnotation] = "public"
 	}
 
 	if isInternal {


### PR DESCRIPTION
#### Delete unused IBM Cloud zone annotation declaration

Delete the declaration of the unused constant for the `service.kubernetes.io/ibm-load-balancer-cloud-provider-zone` annotation.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`iksLBProxyRegionAnnotations`): Delete.


#### Rename constant for IBM Cloud LB type annotation

Rename the `iksLBProxyProtocolAnnotations` constant, which has nothing to do with PROXY protocol, but rather specifies the scope of the load balancer (public or private).

* `pkg/operator/controller/ingress/load_balancer_service.go` (`iksLBProxyProtocolAnnotations`): Rename...
(`iksLBScopeAnnotation`): ...to this.