### PR TITLE
Fix Bugzilla link and add GitHub issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+- name: File a Bugzilla report
+  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Routing
+  about: Please use Bugzilla to report issues.
+- name: Ingress Operator in OpenShift Container Platform
+  url: https://docs.openshift.com/container-platform/latest/networking/ingress-operator.html
+  about: Refer to the OpenShift Container Platform documentation for information about the Ingress Operator in OpenShift Container Platform.
+- name: Ingress Operator in OKD
+  url: https://docs.okd.io/latest/networking/ingress-operator.html
+  about: Refer to the OKD documentation for information about the Ingress Operator in OKD.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,6 @@ $ oc describe --namespace=openshift-ingress-operator ingresscontroller/<name>
 
 ## Contributing
 
-Report issues in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&version=4.0.0&component=Routing).
+Report issues in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Routing).
 
 See [HACKING.md](HACKING.md) for development topics.


### PR DESCRIPTION
#### Omit version in the Bugzilla link

Delete the version, which was "4.0.0", which does not exist; it is better not to specify a default version anyway as we cannot know the version against which the user is reporting an issue.

* `README.md`: Fix Bugzilla link.


#### Add GitHub issue template configuration

* `.github/ISSUE_TEMPLATE/config.yml`: New file.  Add links to Bugzilla and documentation.