### PR TITLE
Add a dependency verification script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,17 +39,8 @@ bindata:
 crd:
 	hack/update-generated-crd.sh
 
-.PHONY: verify-bindata
-verify-bindata:
-	hack/verify-generated-bindata.sh
-
-# Do not write the CRDs, only compare and return (code 1 if dirty).
-.PHONY: verify-crd
-verify-crd:
-	hack/verify-generated-crd.sh
-
 .PHONY: test
-test: verify
+test:
 	$(GO) test ./...
 
 .PHONY: release-local
@@ -66,8 +57,11 @@ clean:
 	rm -f $(BIN)
 
 .PHONY: verify
-verify: verify-crd verify-bindata
+verify:
 	hack/verify-gofmt.sh
+	hack/verify-generated-crd.sh
+	hack/verify-generated-bindata.sh
+	hack/verify-deps.sh
 
 .PHONY: uninstall
 uninstall:

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There appear to be uncommitted changes to go.mod. Please run 'go tidy' and 'go vendor'."
+  exit 1
+}
+
+go mod vendor
+go mod tidy
+
+test -z "$(git status --porcelain)" || print_failure


### PR DESCRIPTION
Add a `verify` target and decouple from `test` because verification is only required as a presubmit check once https://github.com/openshift/release/pull/8016 merges.