### PR TITLE
Bug 1834989: hashableDeployment: Fix liveness/readiness probes

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
@@ -738,10 +740,12 @@ func (r *reconciler) updateRouterDeployment(current, desired *appsv1.Deployment)
 		return nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return fmt.Errorf("failed to update router deployment %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
-	log.Info("updated router deployment", "namespace", updated.Namespace, "name", updated.Name)
+	log.Info("updated router deployment", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return nil
 }
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -833,6 +833,38 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: false,
 		},
+		{
+			description: "if probe values are set to default values",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Scheme = "HTTP"
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds = int32(1)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds = int32(10)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.SuccessThreshold = int32(1)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold = int32(3)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme = "HTTP"
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = int32(1)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds = int32(10)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.SuccessThreshold = int32(1)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold = int32(3)
+			},
+			expect: false,
+		},
+		{
+			description: "if probe values are set to non-default values",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Scheme = "HTTPS"
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds = int32(2)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds = int32(20)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.SuccessThreshold = int32(2)
+				deployment.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold = int32(30)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Scheme = "HTTPS"
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = int32(2)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds = int32(20)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.SuccessThreshold = int32(2)
+				deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold = int32(30)
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -899,6 +931,26 @@ func TestDeploymentConfigChanged(t *testing.T) {
 									},
 								},
 								Image: "openshift/origin-cluster-ingress-operator:v4.0",
+								LivenessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/healthz",
+											Port: intstr.IntOrString{
+												IntVal: int32(1936),
+											},
+										},
+									},
+								},
+								ReadinessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/healthz/ready",
+											Port: intstr.IntOrString{
+												IntVal: int32(1936),
+											},
+										},
+									},
+								},
 							},
 						},
 						Affinity: &corev1.Affinity{


### PR DESCRIPTION
#### `updateRouterDeployment`: Add diff to log message

* `pkg/operator/controller/ingress/deployment.go` (`updateRouterDeployment`): Add the diff of the previous and updated deployments to the "updated router deployment" log message.


#### `hashableDeployment`: Fix liveness/readiness probes

When comparing deployments to determine whether an update is required, treat implicit and explicit default values as equal.

Before this commit, the update logic would keep trying to revert the default values that the API set for probe parameters.

* `pkg/operator/controller/ingress/deployment.go` (`hashableDeployment`): Use the new `hashableProbe` function so that two deployments have the same hash if the only difference between them is that one does not specify liveness or readiness probe parameters and the other specifies the default parameter values.
(`hashableProbe`): New function.  Return a copy of the given probe, copying exactly the fields that should be used for computing a deployment's hash, and zeroing out any fields where the values are equal to their defaults.