### PR TITLE
Bug 1826113: status: Improve LoadBalancerManaged=false wording

### DIFF
--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -323,8 +323,8 @@ func computeLoadBalancerStatus(ic *operatorv1.IngressController, service *corev1
 			{
 				Type:    operatorv1.LoadBalancerManagedIngressConditionType,
 				Status:  operatorv1.ConditionFalse,
-				Reason:  "UnsupportedEndpointPublishingStrategy",
-				Message: fmt.Sprintf("The endpoint publishing strategy does not support a load balancer"),
+				Reason:  "EndpointPublishingStrategyExcludesManagedLoadBalancer",
+				Message: fmt.Sprintf("The configured endpoint publishing strategy does not include a managed load balancer"),
 			},
 		}
 	}

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -346,7 +346,7 @@ func TestComputeLoadBalancerStatus(t *testing.T) {
 			name:       "unmanaged",
 			controller: ingressController("default", operatorv1.HostNetworkStrategyType),
 			expect: []operatorv1.OperatorCondition{
-				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionFalse, "UnsupportedEndpointPublishingStrategy", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionFalse, "EndpointPublishingStrategyExcludesManagedLoadBalancer", clock.Now()),
 			},
 		},
 		{


### PR DESCRIPTION
Reword the `LoadBalancerManaged` status condition's reason and message to avoid using phrases such as "unsupported" or "does not support" when the endpoint publishing strategy does not include managing a load balancer.

* `pkg/operator/controller/ingress/status.go` (`computeLoadBalancerStatus`): Change reason and message strings for the `LoadBalanacerManaged` status condition.