### PR TITLE
Bug 1835025: TestRouteAdmissionPolicy: Wait for rolling update

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -767,7 +767,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// Update the ingresscontroller to a different route admission policy
 	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", ic)
+		t.Fatalf("failed to get ingresscontroller: %v", err)
 	}
 	ic.Spec.RouteAdmission.NamespaceOwnership = operatorv1.InterNamespaceAllowedOwnershipCheck
 	if err := kclient.Update(context.TODO(), ic); err != nil {
@@ -812,7 +812,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// Update the ingresscontroller wildcard policy to WildcardsAllowed.
 	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", ic)
+		t.Fatalf("failed to get ingresscontroller: %v", err)
 	}
 	ic.Spec.RouteAdmission.WildcardPolicy = operatorv1.WildcardPolicyAllowed
 	if err := kclient.Update(context.TODO(), ic); err != nil {


### PR DESCRIPTION
#### `TestRouteAdmissionPolicy`: Log error if `Get` fails

Fix test code to output the error value if a client `Get` call fails.

* `test/e2e/operator_test.go` (`TestRouteAdmissionPolicy`): Log errors from `Get`.


#### `TestRouteAdmissionPolicy`: Wait for rolling update

Poll the ingress controller's deployment after changing the route admission policy to make sure that the deployment is updated and rolled out before checking that the new policy is in effect.

* `test/e2e/operator_test.go` (`TestRouteAdmissionPolicy`): Add polling to make sure that the ingress controller deployment is updated and rolled out.

---

@danehans