### PR TITLE
Makefile: Adds build target as a dep of run-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,5 @@ uninstall:
 	hack/uninstall.sh
 
 .PHONY: run-local
-run-local:
+run-local: build
 	hack/run-local.sh


### PR DESCRIPTION
This PR causes a `build` before locally running the operator. I did not include `build` in the `test-e2e` target because the operator may be deployed in the cluster via `release-local`.