### PR TITLE
pkg/operator/controller/status: AsExpected reason for Available and Progressing

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -317,6 +317,7 @@ func computeOperatorProgressingCondition(allIngressesAvailable bool, oldVersions
 		progressingCondition.Reason = "Reconciling"
 	} else {
 		progressingCondition.Status = configv1.ConditionFalse
+		progressingCondition.Reason = "AsExpected"
 	}
 	progressingCondition.Message = ingressesEqualConditionMessage
 	if len(messages) > 0 {
@@ -334,6 +335,7 @@ func computeOperatorAvailableCondition(allIngressesAvailable bool) configv1.Clus
 
 	if allIngressesAvailable {
 		availableCondition.Status = configv1.ConditionTrue
+		availableCondition.Reason = "AsExpected"
 		availableCondition.Message = ingressesEqualConditionMessage
 	} else {
 		availableCondition.Status = configv1.ConditionFalse


### PR DESCRIPTION
We've used a message without a reason for `Progressing=False` since 7b6339ed6b (#229) and for Availabe=True since 28d343900d (#201).  But if we feel like we have a message we want to set to help humans understand the condition, we should be setting a reason string for machines too.  `AsExpected` follows [the library-go precedent][1].

[1]: https://github.com/openshift/library-go/blob/94c59dec54be25c8527e51e8c0a885712aeb01b5/pkg/operator/status/condition.go#L67