### PR TITLE
Bug 1842742: nodePortServiceChanged: Fix for session affinity

### DIFF
--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -137,6 +137,7 @@ func nodePortServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 		// have modified.
 		cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort"),
 		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ExternalIPs", "HealthCheckNodePort"),
+		cmp.Comparer(cmpServiceAffinity),
 		cmpopts.EquateEmpty(),
 	}
 	if cmp.Equal(current.Spec, expected.Spec, serviceCmpOpts...) {
@@ -160,4 +161,14 @@ func nodePortServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 	}
 
 	return true, updated
+}
+
+func cmpServiceAffinity(a, b corev1.ServiceAffinity) bool {
+	if len(a) == 0 {
+		a = corev1.ServiceAffinityNone
+	}
+	if len(b) == 0 {
+		b = corev1.ServiceAffinityNone
+	}
+	return a == b
 }

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -128,6 +128,20 @@ func TestNodePortServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if .spec.sessionAffinity is defaulted",
+			mutate: func(service *corev1.Service) {
+				service.Spec.SessionAffinity = corev1.ServiceAffinityNone
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.sessionAffinity is set to a non-default value",
+			mutate: func(service *corev1.Service) {
+				service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+			},
+			expect: true,
+		},
+		{
 			description: "if .spec.type changes",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.Type = corev1.ServiceTypeLoadBalancer


### PR DESCRIPTION
When comparing services to determine whether an update is required, treat implicit and explicit default values as equal.

Before this commit, the update logic would keep trying to revert the default value that the API set for the service's session affinity.

* `pkg/operator/controller/ingress/nodeport_service.go` (`nodePortServiceChanged`): Use the new `cmpServiceAffinity` function so that two services are considered equal if the only difference between them is that one does not specify the session affinity and the other service has the default value.
(`cmpServiceAffinity`): New function.
* `pkg/operator/controller/ingress/nodeport_service_test.go` (`TestNodePortServiceChanged`): Verify that `nodePortServiceChanged` returns false if the only mutation is that the session affinity has been updated from empty to the default value.