### PR TITLE
Implement HTTP header/cookie capture APIs

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -218,6 +218,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", false, "")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", false, "")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "foo:bar:baz")
 
@@ -232,6 +233,9 @@ func TestDesiredRouterDeployment(t *testing.T) {
 				Container: &operatorv1.ContainerLoggingDestinationParameters{},
 			},
 			HttpLogFormat: "%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV",
+			HTTPCaptureCookies: []operatorv1.IngressControllerCaptureHTTPCookie{
+				{MatchType: "Prefix", NamePrefix: "foo"},
+			},
 		},
 	}
 	ci.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
@@ -282,6 +286,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "debug")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", true, "/var/lib/rsyslog/rsyslog.sock")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", true, `"%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV"`)
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", true, "foo:256")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "quux")
 
@@ -313,6 +318,9 @@ func TestDesiredRouterDeployment(t *testing.T) {
 					{Name: "Content-length", MaxLength: 9},
 					{Name: "Location", MaxLength: 15},
 				},
+			},
+			HTTPCaptureCookies: []operatorv1.IngressControllerCaptureHTTPCookie{
+				{MatchType: "Exact", Name: "foo", MaxLength: 15},
 			},
 		},
 	}
@@ -384,6 +392,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS", true, "Host:15,Referer:15")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", true, "Content-length:9,Location:15")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", true, "foo=:15")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_IP_V4_V6_MODE", true, "v6")
 	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, true, "true")

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -216,6 +216,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS", false, "")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", false, "")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "foo:bar:baz")
 
@@ -302,6 +304,16 @@ func TestDesiredRouterDeployment(t *testing.T) {
 					Facility: "local2",
 				},
 			},
+			HTTPCaptureHeaders: operatorv1.IngressControllerCaptureHTTPHeaders{
+				Request: []operatorv1.IngressControllerCaptureHTTPHeader{
+					{Name: "Host", MaxLength: 15},
+					{Name: "Referer", MaxLength: 15},
+				},
+				Response: []operatorv1.IngressControllerCaptureHTTPHeader{
+					{Name: "Content-length", MaxLength: 9},
+					{Name: "Location", MaxLength: 15},
+				},
+			},
 		},
 	}
 	ci.Spec.NodePlacement = &operatorv1.NodePlacement{
@@ -370,6 +382,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "debug")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", true, "1.2.3.4:12345")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS", true, "Host:15,Referer:15")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", true, "Content-length:9,Location:15")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_IP_V4_V6_MODE", true, "v6")
 	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, true, "true")

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1157,6 +1157,140 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 	}
 }
 
+func TestHTTPHeaderCapture(t *testing.T) {
+	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "headercapture"}
+	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
+	ic := newNodePortController(icName, domain)
+	ic.Spec.Logging = &operatorv1.IngressControllerLogging{
+		Access: &operatorv1.AccessLogging{
+			Destination: operatorv1.LoggingDestination{
+				Type:      operatorv1.ContainerLoggingDestinationType,
+				Container: &operatorv1.ContainerLoggingDestinationParameters{},
+			},
+			HTTPCaptureHeaders: operatorv1.IngressControllerCaptureHTTPHeaders{
+				Request: []operatorv1.IngressControllerCaptureHTTPHeader{
+					{Name: "X-Test-Header-1", MaxLength: 15},
+					{Name: "X-Test-Header-2", MaxLength: 15},
+				},
+				Response: []operatorv1.IngressControllerCaptureHTTPHeader{
+					{Name: "Content-type", MaxLength: 9},
+				},
+			},
+		},
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+	conditions := []operatorv1.OperatorCondition{
+		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+	}
+	if err := waitForIngressControllerCondition(kclient, 5*time.Minute, icName, conditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	// Get the deployment's pods.  We will use these to curl a route and to
+	// scan access logs.
+	deployment := &appsv1.Deployment{}
+	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
+		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		t.Fatalf("router deployment has invalid spec.selector: %v", err)
+	}
+	podList := &corev1.PodList{}
+	if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		t.Fatalf("failed to list pods for ingresscontroller: %v", err)
+	}
+	if len(podList.Items) < 1 {
+		t.Fatalf("found no pods for ingresscontroller: %v", err)
+	}
+
+	// Make a request to the console route.
+	routeName := types.NamespacedName{Namespace: "openshift-console", Name: "console"}
+	route := &routev1.Route{}
+	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
+		t.Fatalf("failed to get the console route: %v", err)
+	}
+	clientPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "headertest",
+			Namespace: podList.Items[0].Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "curl",
+					Image:   podList.Items[0].Spec.Containers[0].Image,
+					Command: []string{"/bin/curl"},
+					Args: []string{
+						"-k",
+						"-o", "/dev/null", "-s",
+						"-H", "x-test-header-1:foo",
+						"-H", "x-test-header-2:bar",
+						"--resolve",
+						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
+						"https://" + route.Spec.Host,
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+		}
+	}()
+
+	// Scan the access logs to make sure the expected headers were captured
+	// and logged.
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		t.Fatalf("failed to get kube config: %v", err)
+	}
+	client, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to create kube client: %v", err)
+	}
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		for _, pod := range podList.Items {
+			readCloser, err := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: "logs",
+				Follow:    false,
+			}).Stream(context.TODO())
+			if err != nil {
+				t.Errorf("failed to read logs from pod %s: %v", pod.Name, err)
+				continue
+			}
+			scanner := bufio.NewScanner(readCloser)
+			var found bool
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.Contains(line, "{foo|bar} {text/html}") {
+					t.Logf("found log message for request in pod %s logs: %s", pod.Name, line)
+					found = true
+					break
+				}
+			}
+			if err := readCloser.Close(); err != nil {
+				t.Errorf("failed to close logs reader for pod %s: %v", pod.Name, err)
+			}
+			return found, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe the expected log message: %v", err)
+	}
+}
+
 func newLoadBalancerController(name types.NamespacedName, domain string) *operatorv1.IngressController {
 	repl := int32(1)
 	return &operatorv1.IngressController{


### PR DESCRIPTION
#### Implement HTTP header capture API

This change is related to [NE-320](https://issues.redhat.com/browse/NE-320).

* `pkg/operator/controller/ingress/deployment.go` (`RouterCaptureHTTPRequestHeaders`, `RouterCaptureHTTPResponseHeaders`): New constants with the names of the related environment variables.
(`desiredRouterDeployment`): Set the `ROUTER_CAPTURE_HTTP_REQUEST_HEADERS` and `ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS` environment variables as appropriate.
(`accessLoggingForIngressController`): Set `HTTPCaptureHeaders`.
(`serializeCaptureHeaders`): New function.  Serialize HTTP header capture configuration into values suitable for the environment variables.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Verify that `spec.logging.access.httpCaptureHeaders` has the expected effect.
* `test/e2e/operator_test.go` (`TestHTTPHeaderCapture`): New test.

#### Implement HTTP cookie capture API

* `pkg/operator/controller/ingress/deployment.go` (`RouterCaptureHTTPCookies`): New constant with the name of the related environment variable.
(`desiredRouterDeployment`): Set the `ROUTER_CAPTURE_HTTP_COOKIE` environment variable as appropriate.
(`accessLoggingForIngressController`): Set `HTTPCaptureCookies`.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Verify that `spec.logging.access.httpCaptureCookies` has the expected effect.
* `test/e2e/operator_test.go` (`TestHTTPCookieCapture`): New test.

---

Implements the following enhancement: https://github.com/openshift/enhancements/pull/370

Depends on the following router changes: https://github.com/openshift/router/pull/139, https://github.com/openshift/router/pull/147

Depends on the following API changes: https://github.com/openshift/api/pull/686. https://github.com/openshift/api/pull/687