### PR TITLE
Fix ensureWildcardDNSRecord & ensureLoadBalancerService

### DIFF
--- a/pkg/operator/controller/ingress/dns_test.go
+++ b/pkg/operator/controller/ingress/dns_test.go
@@ -95,15 +95,15 @@ func TestDesiredWildcardDNSRecord(t *testing.T) {
 			service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, ingress)
 		}
 
-		actual := desiredWildcardRecord(controller, service)
+		haveWC, actual := desiredWildcardDNSRecord(controller, service)
 		switch {
-		case test.expect != nil && actual != nil:
+		case test.expect != nil && haveWC:
 			if !cmp.Equal(actual.Spec, *test.expect) {
 				t.Errorf("expected:\n%s\n\nactual:\n%s", toYaml(test.expect), toYaml(actual.Spec))
 			}
-		case test.expect == nil && actual != nil:
+		case test.expect == nil && haveWC:
 			t.Errorf("expected nil record, got:\n%s", toYaml(actual))
-		case test.expect != nil && actual == nil:
+		case test.expect != nil && !haveWC:
 			t.Errorf("expected record but got nil:\n%s", toYaml(test.expect))
 		}
 	}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -49,12 +49,12 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 			},
 		}
 
-		svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig)
+		haveSvc, svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig)
 		if err != nil {
 			t.Errorf("unexpected error from desiredLoadBalancerService for endpoint publishing strategy type %v: %v", tc.strategyType, err)
-		} else if tc.expect && svc == nil {
+		} else if tc.expect && !haveSvc {
 			t.Errorf("expected desiredLoadBalancerService to return a service for endpoint publishing strategy type %v, got nil", tc.strategyType)
-		} else if !tc.expect && svc != nil {
+		} else if !tc.expect && haveSvc {
 			t.Errorf("expected desiredLoadBalancerService to return nil service for endpoint publishing strategy type %v, got %#v", tc.strategyType, svc)
 		}
 	}


### PR DESCRIPTION
Add a `wantFoo` boolean to `ensureWildcardDNSRecord` &
`ensureLoadBalancerService` for consistency. Fixes a bug
accidentally introduced in #408.

Also fixes a small comment typo for `desiredWildcardDNSRecord`, as well as updates the necessary unit tests.