### PR TITLE
Bug 1828618: Improve e2e test polling loops

### DIFF
--- a/test/e2e/certificate_publisher_test.go
+++ b/test/e2e/certificate_publisher_test.go
@@ -36,7 +36,7 @@ func TestCreateIngressControllerThenSecret(t *testing.T) {
 	conditions := []operatorv1.OperatorCondition{
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
 	}
-	err := waitForIngressControllerCondition(kclient, 5*time.Minute, name, conditions...)
+	err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, conditions...)
 	if err != nil {
 		t.Errorf("failed to observe expected conditions: %v", err)
 	}

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -113,7 +113,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 	}
-	if err := waitForIngressControllerCondition(kclient, 5*time.Minute, icName, conditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -210,7 +210,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 	}
-	if err := waitForIngressControllerCondition(kclient, 5*time.Minute, icName, conditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -279,7 +279,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 	}
-	if err := waitForIngressControllerCondition(kclient, 5*time.Minute, icName, conditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -349,7 +349,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 	}
-	if err := waitForIngressControllerCondition(kclient, 5*time.Minute, icName, conditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 


### PR DESCRIPTION
Make sure errs in the `wait.PollImmediate()` operator e2e test loops
are reported to prevent unnecessary retries and provide more precise
failure messages.