### PR TITLE
Adds Support for AWS Custom Endpoints

### DIFF
--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	SchemeHTTPS = "https"
+)
+
+// URI validates uri as being a http(s) valid url and returns the url scheme.
+func URI(uri string) (string, error) {
+	parsed, err := url.ParseRequestURI(uri)
+	if err != nil {
+		return "", err
+	}
+	if port := parsed.Port(); len(port) != 0 {
+		intPort, err := strconv.Atoi(port)
+		if err != nil {
+			return "", fmt.Errorf("failed converting port to integer for URI %q: %v", uri, err)
+		}
+		if err := Port(intPort); err != nil {
+			return "", fmt.Errorf("failed to validate port for URL %q: %v", uri, err)
+		}
+	}
+
+	return parsed.Scheme, nil
+}
+
+// Port validates if port is a valid port number between 1-65535.
+func Port(port int) error {
+	invalidPorts := validation.IsValidPortNum(port)
+	if invalidPorts != nil {
+		return fmt.Errorf("invalid port number: %d", port)
+	}
+
+	return nil
+}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -1,0 +1,112 @@
+package k8s
+
+import (
+	"testing"
+)
+
+// URI validates uri as being a valid http(s) uri and returns the uri scheme.
+func TestURI(t *testing.T) {
+	testCases := []struct {
+		description string
+		uri, scheme string
+		expected    bool
+	}{
+		{
+			description: "valid http uri with IP host and no port",
+			uri:         "http://1.2.3.4",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with IP host and backslash with no port",
+			uri:         "http://1.2.3.4/",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with IP host and port",
+			uri:         "http://1.2.3.4:80",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with IP host, port and backslash",
+			uri:         "http://1.2.3.4:80/",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with hostname",
+			uri:         "http://redhat",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with underscore in hostname",
+			uri:         "http://red_hat.com",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with FQDN",
+			uri:         "http://www.redhat.com",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid http uri with capitalized FQDN",
+			uri:         "http://WWW.REDHAT.COM",
+			scheme:      "http",
+			expected:    true,
+		},
+		{
+			description: "valid https uri with IP host and no port",
+			uri:         "https://1.2.3.4",
+			scheme:      "https",
+			expected:    true,
+		},
+		{
+			description: "valid https uri with mixed capitalization, port and bckslash",
+			uri:         "https://EXAMPLe.com:8080/",
+			scheme:      "https",
+			expected:    true,
+		},
+		{
+			description: "http uri with invalid port number",
+			uri:         "http://1.2.3.4:8080808080",
+			scheme:      "http",
+			expected:    false,
+		},
+		{
+			description: "http uri with port number higher that the accepted range",
+			uri:         "http://5.6.7.8:65536",
+			scheme:      "http",
+			expected:    false,
+		},
+		{
+			description: "http uri with port number lower that the accepted range",
+			uri:         "http://5.6.7.8:0",
+			scheme:      "http",
+			expected:    false,
+		},
+		{
+			description: "missing uri scheme",
+			uri:         "redhat.com",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		scheme, err := URI(tc.uri)
+		switch {
+		case err != nil && tc.expected:
+			t.Errorf("test %s failed: %v", tc.description, err)
+		case err == nil && !tc.expected:
+			t.Errorf("test %s expected to fail, but passed", tc.description)
+		case err == nil && tc.expected:
+			if scheme != tc.scheme {
+				t.Errorf("unexpected scheme %s for test %s, expected scheme %s", scheme, tc.description, tc.scheme)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds support for using custom endpoints with AWS DNS provider clients.

Supports [NE-350](https://issues.redhat.com/browse/NE-350)

/assign @Miciah 
/cc @frobware @sgreene570 