### PR TITLE
Bug 1830271: status: Replace "DeploymentDegraded" condition

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -41,8 +41,10 @@ const (
 
 // TODO: consider moving these to openshift/api
 const (
-	IngressControllerAdmittedConditionType           = "Admitted"
-	IngressControllerDeploymentDegradedConditionType = "DeploymentDegraded"
+	IngressControllerAdmittedConditionType                       = "Admitted"
+	IngressControllerDeploymentAvailableConditionType            = "DeploymentAvailable"
+	IngressControllerDeploymentReplicasMinAvailableConditionType = "DeploymentReplicasMinAvailable"
+	IngressControllerDeploymentReplicasAllAvailableConditionType = "DeploymentReplicasAllAvailable"
 )
 
 var (


### PR DESCRIPTION
Delete the `DeploymentDegraded` status condition, add `DeploymentAvailable`, `DeploymentReplicasMinAvailable`, and `DeploymentReplicasAllAvailable` status conditions, and use the new conditions to compute the ingresscontroller's `Degraded` status condition.

The old `DeploymentDegraded` status condition was based on the deployment's `Available` status condition, but the deployment may report `Available=True` before the deployment's minimum availability is met, so relying on the deployment's `Available` condition alone is insufficient to determine if the ingresscontroller's deployment is degraded.

* `pkg/operator/controller/ingress/controller.go` (`IngressControllerDeploymentDegradedConditionType`): Delete the `DeploymentDegraded` condition type.
(`IngressControllerDeploymentAvailableConditionType`, `IngressControllerDeploymentReplicasMinAvailableConditionType`, `IngressControllerDeploymentReplicasAllAvailableConditionType`): New constants for the `DeploymentAvailable`, `DeploymentReplicasMinAvailable`, and `DeploymentReplicasAllAvailable` condition types.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Delete use of `computeDeploymentDegradedCondition`.  Add calls to `computeDeploymentAvailableCondition`, `computeDeploymentReplicasMinAvailableCondition`, and `computeDeploymentReplicasAllAvailableCondition`.
(`computeDeploymentDegradedCondition`): Rename...
(`computeDeploymentAvailableCondition`): ...to this.  Add a note that the deployment may report `Available=True` without meeting minimum availability. Replace the `DeploymentDegraded` condition type with `DeploymentAvailable`, and invert the condition status.
(`computeDeploymentReplicasMinAvailableCondition`): New function.  Compute the `DeploymentReplicasMinAvailable` condition from the deployment's reported available replicas and maximum unavailable replicas.
(`computeDeploymentReplicasAllAvailableCondition`): New function.  Compute the `DeploymentReplicasAllAvailable` condition from the deployment's reported available replicas.
(`computeIngressDegradedCondition`): Replace `DeploymentDegraded` with `DeploymentAvailable` with the expected status inverted.  Add `DeploymentReplicasMinAvailable` and `DeploymentReplicasAllAvailable` with status `True` to the set of expected conditions.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputeIngressDegradedCondition`): Update to check `DeploymentAvailable`, `DeploymentReplicasMinAvailable`, and `DeploymentReplicasAllAvailable` instead of `DeploymentDegraded`.
(`TestComputeDeploymentDegradedCondition`): Rename...
(`TestComputeDeploymentAvailableCondition`): ...to this.  Replace `DeploymentDegraded` with `DeploymentAvailable` with the expected status inverted.
(`TestComputeDeploymentReplicasMinAvailableCondition`, `TestComputeDeploymentReplicasAllAvailableCondition`): New tests.