### PR TITLE
dns: Improve logging of reconciliation and updates

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -274,9 +274,9 @@ func (m *Provider) change(record *iov1.DNSRecord, zone configv1.DNSZone, action 
 	}
 	switch action {
 	case upsertAction:
-		log.Info("upserted DNS record", "record", record)
+		log.Info("upserted DNS record", "record", record.Spec, "zone", zone)
 	case deleteAction:
-		log.Info("deleted DNS record", "record", record)
+		log.Info("deleted DNS record", "record", record.Spec, "zone", zone)
 	}
 	return nil
 }

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -86,7 +86,7 @@ func (m *provider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		})
 
 	if err == nil {
-		log.Info("upserted DNS record", "record", record)
+		log.Info("upserted DNS record", "record", record.Spec, "zone", zone)
 	}
 
 	return err
@@ -114,7 +114,7 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 		})
 
 	if err == nil {
-		log.Info("deleted DNS record", "record", record)
+		log.Info("deleted DNS record", "record", record.Spec, "zone", zone)
 	}
 
 	return err


### PR DESCRIPTION
Improve the logging in the DNS controller and DNS provider implementations to improve visibility into the controller's operation and to avoid printing old and possibly misleading status during reconciliation.

* `pkg/dns/aws/dns.go` (`change`):
* `pkg/dns/azure/dns.go` (`Ensure`, `Delete`): Log the dnsrecord's spec but not its status because the controller only updates the status after ensuring or deleting the dnsrecord.  Log the zone along with the dnsrecord's spec.
* `pkg/operator/controller/dns/controller.go` (`Reconcile`): Log when beginning reconciliation.  When updating the status, log the updated dnsrecord rather than the old dnsrecord (with the old status), and always log when updating (not only when the update fails).
(`publishRecordToZones`): Log when skipping a zone.  Log the dnsrecord's spec but not its status because the controller only updates the status after publishRecordToZones returns.


----

Inspired by trying to diagnose https://github.com/openshift/cluster-ingress-operator/pull/417#issuecomment-649891569.