### PR TITLE
Bug 1853711: Invert http/2 kill switch logic

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -96,12 +96,11 @@ func HTTP2IsEnabledByAnnotation(m map[string]string) (bool, bool) {
 	return false, false
 }
 
-// HTTP2IsEnabled returns true if the ingress controller disables
-// http/2 via the RouterDisableHTTP2Annotation, or if the ingress
-// config disables http/2. It will return false for the case where the
-// ingress config has been disabled but the ingress controller
-// explicitly overrides that by having the annotation present (even if
-// its value is "false").
+// HTTP2IsEnabled returns true if the ingress controller enables
+// http/2, or if the ingress config enables http/2. It will return
+// false for the case where the ingress config has been disabled but
+// the ingress controller explicitly overrides that by having the
+// annotation present (even if its value is "false").
 func HTTP2IsEnabled(ic *operatorv1.IngressController, ingressConfig *configv1.Ingress) bool {
 	controllerHasHTTP2Annotation, controllerHasHTTP2Enabled := HTTP2IsEnabledByAnnotation(ic.Annotations)
 	_, configHasHTTP2Enabled := HTTP2IsEnabledByAnnotation(ingressConfig.Annotations)

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -40,8 +40,8 @@ const (
 	RouterSyslogFormatEnvName   = "ROUTER_SYSLOG_FORMAT"
 	RouterSyslogFacilityEnvName = "ROUTER_LOG_FACILITY"
 
-	RouterDisableHTTP2EnvName    = "ROUTER_DISABLE_HTTP2"
-	RouterDisableHTTP2Annotation = "ingress.operator.openshift.io/unsupported-disable-http2"
+	RouterDisableHTTP2EnvName          = "ROUTER_DISABLE_HTTP2"
+	RouterDefaultEnableHTTP2Annotation = "ingress.operator.openshift.io/default-enable-http2"
 )
 
 // ensureRouterDeployment ensures the router deployment exists for a given
@@ -85,32 +85,32 @@ func (r *reconciler) ensureRouterDeleted(ci *operatorv1.IngressController) error
 	return nil
 }
 
-// HTTP2IsDisabledByAnnotation returns true if the map m has the key
+// HTTP2IsEnabledByAnnotation returns true if the map m has the key
 // RouterDisableHTTP2Annotation present and true|false depending on
 // the annotation's value that is parsed by strconv.ParseBool.
-func HTTP2IsDisabledByAnnotation(m map[string]string) (bool, bool) {
-	if val, ok := m[RouterDisableHTTP2Annotation]; ok {
+func HTTP2IsEnabledByAnnotation(m map[string]string) (bool, bool) {
+	if val, ok := m[RouterDefaultEnableHTTP2Annotation]; ok {
 		v, _ := strconv.ParseBool(val)
 		return true, v
 	}
 	return false, false
 }
 
-// HTTP2IsDisabled returns true if the ingress controller disables
+// HTTP2IsEnabled returns true if the ingress controller disables
 // http/2 via the RouterDisableHTTP2Annotation, or if the ingress
 // config disables http/2. It will return false for the case where the
 // ingress config has been disabled but the ingress controller
 // explicitly overrides that by having the annotation present (even if
 // its value is "false").
-func HTTP2IsDisabled(ic *operatorv1.IngressController, ingressConfig *configv1.Ingress) bool {
-	controllerHasHTTP2Annotation, controllerHasHTTP2Disabled := HTTP2IsDisabledByAnnotation(ic.Annotations)
-	_, configHasHTTP2Disabled := HTTP2IsDisabledByAnnotation(ingressConfig.Annotations)
+func HTTP2IsEnabled(ic *operatorv1.IngressController, ingressConfig *configv1.Ingress) bool {
+	controllerHasHTTP2Annotation, controllerHasHTTP2Enabled := HTTP2IsEnabledByAnnotation(ic.Annotations)
+	_, configHasHTTP2Enabled := HTTP2IsEnabledByAnnotation(ingressConfig.Annotations)
 
 	if controllerHasHTTP2Annotation {
-		return controllerHasHTTP2Disabled
+		return controllerHasHTTP2Enabled
 	}
 
-	return configHasHTTP2Disabled
+	return configHasHTTP2Enabled
 }
 
 // desiredRouterDeployment returns the desired router deployment.
@@ -530,7 +530,9 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		env = append(env, corev1.EnvVar{Name: WildcardRouteAdmissionPolicy, Value: "false"})
 	}
 
-	if HTTP2IsDisabled(ci, ingressConfig) {
+	if HTTP2IsEnabled(ci, ingressConfig) {
+		env = append(env, corev1.EnvVar{Name: RouterDisableHTTP2EnvName, Value: "false"})
+	} else {
 		env = append(env, corev1.EnvVar{Name: RouterDisableHTTP2EnvName, Value: "true"})
 	}
 

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -98,7 +98,7 @@ func HTTP2IsEnabledByAnnotation(m map[string]string) (bool, bool) {
 
 // HTTP2IsEnabled returns true if the ingress controller enables
 // http/2, or if the ingress config enables http/2. It will return
-// false for the case where the ingress config has been disabled but
+// false for the case where the ingress config has been enabled but
 // the ingress controller explicitly overrides that by having the
 // annotation present (even if its value is "false").
 func HTTP2IsEnabled(ic *operatorv1.IngressController, ingressConfig *configv1.Ingress) bool {

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -372,7 +372,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_IP_V4_V6_MODE", true, "v6")
-	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, false, "")
+	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, true, "true")
 }
 
 func TestInferTLSProfileSpecFromDeployment(t *testing.T) {

--- a/test/e2e/http2_disable_test.go
+++ b/test/e2e/http2_disable_test.go
@@ -189,13 +189,13 @@ func http2GetIngressConfig(t *testing.T, client client.Client, timeout time.Dura
 	return &ingressConfig, nil
 }
 
-func waitForRouterDeploymentHTTP2Enabled(client client.Client, timeout time.Duration, c *operatorv1.IngressController, expectedDisabledStatus bool) error {
+func waitForRouterDeploymentHTTP2Enabled(client client.Client, timeout time.Duration, c *operatorv1.IngressController, enabledState bool) error {
 	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		deployment := &appsv1.Deployment{}
 		if err := client.Get(context.TODO(), controller.RouterDeploymentName(c), deployment); err != nil {
 			return false, nil
 		}
-		return http2IsDisabledInEnv(deployment.Spec.Template.Spec.Containers[0].Env) == expectedDisabledStatus, nil
+		return !http2IsDisabledInEnv(deployment.Spec.Template.Spec.Containers[0].Env) == enabledState, nil
 	})
 }
 

--- a/test/e2e/http2_disable_test.go
+++ b/test/e2e/http2_disable_test.go
@@ -39,12 +39,12 @@ func TestRouteHTTP2EnableAndDisableIngressController(t *testing.T) {
 		t.Fatalf("failed to get ingress controller: %v", err)
 	}
 
-	// By default the router should not have http/2 disabled
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, false); err != nil {
-		t.Fatalf("expected router deployment to have http/2 enabled: %v", err)
+	// By default the router should not have http/2 enabled
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, false); err != nil {
+		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
 	}
 
-	if err := setHTTP2DisabledForIngressController(t, kclient, 1*time.Minute, true, ic); err != nil {
+	if err := setHTTP2EnabledForIngressController(t, kclient, 1*time.Minute, true, ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 
@@ -52,16 +52,16 @@ func TestRouteHTTP2EnableAndDisableIngressController(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, true); err != nil {
-		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, true); err != nil {
+		t.Fatalf("expected router deployment to have http/2 enabled: %v", err)
 	}
 
-	if err := setHTTP2DisabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
+	if err := setHTTP2EnabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, false); err != nil {
-		t.Fatalf("expected router deployment to have http/2 enabled: %v", err)
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, false); err != nil {
+		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
 	}
 }
 
@@ -75,8 +75,8 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 		t.Fatalf("failed to get ingress controller: %v", err)
 	}
 
-	if err := setHTTP2DisabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
-		t.Fatalf("failed to update ingress config: %v", err)
+	if err := setHTTP2EnabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
+		t.Fatalf("failed to update ingress controller: %v", err)
 	}
 
 	ingressConfig, err := http2GetIngressConfig(t, kclient, 1*time.Minute)
@@ -84,12 +84,12 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 		t.Fatalf("failed to get ingress config: %v", err)
 	}
 
-	// By default the router should not have http/2 disabled
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, false); err != nil {
-		t.Fatalf("expected router deployment to have http/2 enabled: %v", err)
+	// By default the router should not have http/2 enabled
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, false); err != nil {
+		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
 	}
 
-	if err := setHTTP2DisabledForIngressConfig(t, kclient, 1*time.Minute, true, ingressConfig); err != nil {
+	if err := setHTTP2EnabledForIngressConfig(t, kclient, 1*time.Minute, true, ingressConfig); err != nil {
 		t.Fatalf("failed to update ingress config: %v", err)
 	}
 
@@ -97,19 +97,19 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, true); err != nil {
-		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, true); err != nil {
+		t.Fatalf("expected router deployment to have http/2 enabled: %v", err)
 	}
 
 	// Now set the ingress controller to also have the annotation
 	// but with an explicit value of "false" which will take
 	// precedence over the ingress config which is currently
 	// "true". The net result should be that the router deployment
-	// transitions from its current state of http/2 disabled
-	// (which we just asserted) back to http/2 enabled.
+	// transitions from its current state of http/2 enabled
+	// (which we just asserted) back to http/2 disabled.
 	//
 	// This update is different to
-	// setHTTP2DisabledForIngressController() as we preserve the
+	// setHTTP2EnabledForIngressController() as we preserve the
 	// annotation if the value is "false".
 	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), defaultName, ic); err != nil {
@@ -119,7 +119,7 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 		if ic.Annotations == nil {
 			ic.Annotations = map[string]string{}
 		}
-		ic.Annotations[ingress.RouterDisableHTTP2Annotation] = "false"
+		ic.Annotations[ingress.RouterDefaultEnableHTTP2Annotation] = "false"
 		if err := kclient.Update(context.TODO(), ic); err != nil {
 			t.Logf("failed to update ingress controller: %v", err)
 			return false, nil
@@ -133,17 +133,17 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := waitForRouterDeploymentHTTP2Disabled(kclient, routerDeployTimeout, ic, false); err != nil {
+	if err := waitForRouterDeploymentHTTP2Enabled(kclient, routerDeployTimeout, ic, false); err != nil {
 		t.Fatalf("expected router deployment to have http/2 disabled: %v", err)
 	}
 
 	// cleanup
 
-	if err := setHTTP2DisabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
-		t.Fatalf("failed to update ingress config: %v", err)
+	if err := setHTTP2EnabledForIngressController(t, kclient, 1*time.Minute, false, ic); err != nil {
+		t.Fatalf("failed to update ingress controller: %v", err)
 	}
 
-	if err := setHTTP2DisabledForIngressConfig(t, kclient, 1*time.Minute, false, ingressConfig); err != nil {
+	if err := setHTTP2EnabledForIngressConfig(t, kclient, 1*time.Minute, false, ingressConfig); err != nil {
 		t.Fatalf("failed to update ingress config: %v", err)
 	}
 }
@@ -189,7 +189,7 @@ func http2GetIngressConfig(t *testing.T, client client.Client, timeout time.Dura
 	return &ingressConfig, nil
 }
 
-func waitForRouterDeploymentHTTP2Disabled(client client.Client, timeout time.Duration, c *operatorv1.IngressController, expectedDisabledStatus bool) error {
+func waitForRouterDeploymentHTTP2Enabled(client client.Client, timeout time.Duration, c *operatorv1.IngressController, expectedDisabledStatus bool) error {
 	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		deployment := &appsv1.Deployment{}
 		if err := client.Get(context.TODO(), controller.RouterDeploymentName(c), deployment); err != nil {
@@ -199,7 +199,7 @@ func waitForRouterDeploymentHTTP2Disabled(client client.Client, timeout time.Dur
 	})
 }
 
-func setHTTP2DisabledForIngressConfig(t *testing.T, client client.Client, timeout time.Duration, disableHTTP2 bool, c *configv1.Ingress) error {
+func setHTTP2EnabledForIngressConfig(t *testing.T, client client.Client, timeout time.Duration, enableHTTP2 bool, c *configv1.Ingress) error {
 	name := types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
 
 	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
@@ -210,10 +210,10 @@ func setHTTP2DisabledForIngressConfig(t *testing.T, client client.Client, timeou
 		if c.Annotations == nil {
 			c.Annotations = map[string]string{}
 		}
-		if disableHTTP2 {
-			c.Annotations[ingress.RouterDisableHTTP2Annotation] = "true"
+		if enableHTTP2 {
+			c.Annotations[ingress.RouterDefaultEnableHTTP2Annotation] = "true"
 		} else {
-			delete(c.Annotations, ingress.RouterDisableHTTP2Annotation)
+			delete(c.Annotations, ingress.RouterDefaultEnableHTTP2Annotation)
 		}
 		if err := client.Update(context.TODO(), c); err != nil {
 			t.Logf("Update %q failed: %v, retrying...", name, err)
@@ -223,7 +223,7 @@ func setHTTP2DisabledForIngressConfig(t *testing.T, client client.Client, timeou
 	})
 }
 
-func setHTTP2DisabledForIngressController(t *testing.T, client client.Client, timeout time.Duration, disableHTTP2 bool, c *operatorv1.IngressController) error {
+func setHTTP2EnabledForIngressController(t *testing.T, client client.Client, timeout time.Duration, enableHTTP2 bool, c *operatorv1.IngressController) error {
 	name := types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
 
 	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
@@ -234,10 +234,10 @@ func setHTTP2DisabledForIngressController(t *testing.T, client client.Client, ti
 		if c.Annotations == nil {
 			c.Annotations = map[string]string{}
 		}
-		if disableHTTP2 {
-			c.Annotations[ingress.RouterDisableHTTP2Annotation] = "true"
+		if enableHTTP2 {
+			c.Annotations[ingress.RouterDefaultEnableHTTP2Annotation] = "true"
 		} else {
-			delete(c.Annotations, ingress.RouterDisableHTTP2Annotation)
+			delete(c.Annotations, ingress.RouterDefaultEnableHTTP2Annotation)
 		}
 		if err := client.Update(context.TODO(), c); err != nil {
 			t.Logf("Update %q failed: %v, retrying...", name, err)


### PR DESCRIPTION
Annotation has been renamed to:

    ingress.operator.openshift.io/default-enable-http2

and by default is "false".