### PR TITLE
Fixes Bug 1866299: Adds region verification for custom endpoints

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -471,7 +471,7 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, operatorutil.SchemeHTTPS)
 					}
 					cfg.ServiceEndpoints = append(cfg.ServiceEndpoints, awsdns.ServiceEndpoint{Name: ep.Name, URL: ep.URL})
-				case ep.Name == awsdns.ResourceGroupsService:
+				case ep.Name == awsdns.TaggingService:
 					tagFound = true
 					scheme, err := operatorutil.URI(ep.URL)
 					if err != nil {


### PR DESCRIPTION
- Uses status instead of spec of `infrastructure` now that https://bugzilla.redhat.com/show_bug.cgi?id=1850681 is fixed.
- Removes the unnecessary poll from `defer()` after custom endpoints are removed from `infrastructure`.
- Adds the elb custom endpoint that was removed by https://github.com/openshift/cluster-ingress-operator/commit/21d57e5ab2a44787f57d7e4fa7261ce8332f14c9, this time using the region from platform status.

/assign @knobunc @Miciah 
/cc @sgreene570 @frobware 