### PR TITLE
Follow-Up fixes for PR 427

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -178,6 +178,7 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 			if ci.Status.EndpointPublishingStrategy.LoadBalancer != nil &&
 				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters != nil &&
 				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.Type == operatorv1.AWSLoadBalancerProvider &&
+				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.AWS != nil &&
 				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.AWS.Type == operatorv1.AWSNetworkLoadBalancer {
 				service.Annotations[AWSLBTypeAnnotation] = AWSNLBAnnotation
 			}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -31,11 +31,8 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 		{
 			description:  "external classic load balancer without scope",
 			strategyType: operatorv1.LoadBalancerServiceStrategyType,
-			lbStrategy: operatorv1.LoadBalancerStrategy{
-				Scope: operatorv1.ExternalLoadBalancer,
-			},
-			proxyNeeded: true,
-			expect:      true,
+			proxyNeeded:  true,
+			expect:       true,
 		},
 		{
 			description:  "external classic load balancer without LoadBalancerStrategy",


### PR DESCRIPTION
- `pkg/operator/controller/ingress/load_balancer_service.go`: Checks for the absence of AWS provider parameters.
- `pkg/operator/controller/ingress/load_balancer_service_test.go`: removes load balancer scope from "external classic load balancer without scope" test case.
