### PR TITLE
Changing default router deployment number to 3

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -157,7 +157,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	volumes := deployment.Spec.Template.Spec.Volumes
 	routerVolumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
 
-	var desiredReplicas int32 = 2
+	var desiredReplicas int32 = 3
 	if ci.Spec.Replicas != nil {
 		desiredReplicas = *ci.Spec.Replicas
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -601,7 +601,7 @@ func TestDeploymentHash(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		two := int32(2)
+		defaultReplicas := int32(3)
 		original := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "router-original",
@@ -614,7 +614,7 @@ func TestDeploymentHash(t *testing.T) {
 						Tolerations: []corev1.Toleration{toleration, otherToleration},
 					},
 				},
-				Replicas: &two,
+				Replicas: &defaultReplicas,
 			},
 		}
 		mutated := original.DeepCopy()

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -163,14 +163,14 @@ func (o *Operator) ensureDefaultIngressController() error {
 	// https://github.com/kubernetes/kubernetes/pull/75210
 	//
 	// TODO: Set the replicas value to the number of workers.
-	two := int32(2)
+	defaultReplicas := int32(3)
 	ic := &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manifests.DefaultIngressControllerName,
 			Namespace: o.namespace,
 		},
 		Spec: operatorv1.IngressControllerSpec{
-			Replicas: &two,
+			Replicas: &defaultReplicas,
 		},
 	}
 	err := o.client.Get(context.TODO(), types.NamespacedName{Namespace: ic.Namespace, Name: ic.Name}, ic)


### PR DESCRIPTION
This PR is in response to OSD-3918, which outlines increasing the router deployment to match the default number of infra nodes. It also provides an an increase in capacity and stability, and a slightly more intuitive ELB Status from the AWS console.

e.g. By having only 2 router pods and 3 infra nodes, one infra node continuously fails health-checks behind the *.app.clustername.openshiftapps.com ELB.


Please let me know if there's a more appropriate place to manage this configuration.