### PR TITLE
Bug 1862892: Reconcile openshift-ingress-router clusterrole on upgrades

### DIFF
--- a/pkg/operator/controller/ingress/cluster-role.go
+++ b/pkg/operator/controller/ingress/cluster-role.go
@@ -1,0 +1,87 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+)
+
+func (r *reconciler) ensureClusterRole() (bool, *rbacv1.ClusterRole, error) {
+	wantCR, desired, err := desiredClusterRole()
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to build cluster role: %v", err)
+	}
+
+	haveCR, current, err := r.currentClusterRole()
+	if err != nil {
+		return false, nil, err
+	}
+
+	switch {
+	case !wantCR && !haveCR:
+		return false, nil, nil
+	case !wantCR && haveCR:
+		if err := r.client.Delete(context.TODO(), current); err != nil {
+			if !errors.IsNotFound(err) {
+				return true, current, fmt.Errorf("failed to delete cluster role: %v", err)
+			}
+		} else {
+			log.Info("deleted cluster role", "current", current)
+		}
+		return false, nil, nil
+	case wantCR && !haveCR:
+		if err := r.client.Create(context.TODO(), desired); err != nil {
+			return false, nil, fmt.Errorf("failed to create cluster role: %v", err)
+		}
+		log.Info("created cluster role", "desired", desired)
+		return r.currentClusterRole()
+	case wantCR && haveCR:
+		if updated, err := r.updateClusterRole(current, desired); err != nil {
+			return true, current, fmt.Errorf("failed to update cluster role: %v", err)
+		} else if updated {
+			log.Info("updated cluster role", "desired", desired)
+			return r.currentClusterRole()
+		}
+	}
+
+	return true, current, nil
+}
+
+func desiredClusterRole() (bool, *rbacv1.ClusterRole, error) {
+	return true, manifests.RouterClusterRole(), nil
+}
+
+func (r *reconciler) currentClusterRole() (bool, *rbacv1.ClusterRole, error) {
+	cr := &rbacv1.ClusterRole{}
+	name := types.NamespacedName{
+		Name: manifests.RouterClusterRole().Name,
+	}
+	if err := r.client.Get(context.TODO(), name, cr); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, cr, nil
+}
+
+func (r *reconciler) updateClusterRole(current, desired *rbacv1.ClusterRole) (bool, error) {
+	if reflect.DeepEqual(current.Rules, desired.Rules) {
+		return false, nil
+	}
+	updated := current.DeepCopy()
+	updated.Rules = desired.Rules
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -601,6 +601,10 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		ci = updated
 	}
 
+	if _, _, err := r.ensureClusterRole(); err != nil {
+		return fmt.Errorf("failed to ensure cluster role: %v", err)
+	}
+
 	if err := r.ensureRouterNamespace(); err != nil {
 		return fmt.Errorf("failed to ensure namespace: %v", err)
 	}

--- a/pkg/operator/controller/ingress/namespace.go
+++ b/pkg/operator/controller/ingress/namespace.go
@@ -13,17 +13,6 @@ import (
 // ensureRouterNamespace ensures all the necessary scaffolding exists for
 // routers generally, including a namespace and all RBAC setup.
 func (r *reconciler) ensureRouterNamespace() error {
-	cr := manifests.RouterClusterRole()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: cr.Name}, cr); err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get router cluster role %s: %v", cr.Name, err)
-		}
-		if err := r.client.Create(context.TODO(), cr); err != nil {
-			return fmt.Errorf("failed to create router cluster role %s: %v", cr.Name, err)
-		}
-		log.Info("created router cluster role", "name", cr.Name)
-	}
-
 	ns := manifests.RouterNamespace()
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ns.Name}, ns); err != nil {
 		if !errors.IsNotFound(err) {


### PR DESCRIPTION
On upgrades we have never needed to handle changes to the
openshift-ingress-router cluster role. This broke 4.5->4.6 upgrades
because the router switched to watching endpointslices in 4.6 and, as
this permission was not granted to the role, it failed to start.

This change now ensures that the cluster role gets updated/reconciled
with the (bindata) values from assets/router/cluster-role.yaml. In
this particular upgrade case it will now add the endpointslices RBAC
rules allowing the router to start.