### PR TITLE
Bug 1866575: Escape unique-id format

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -600,7 +600,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		}
 		env = append(env,
 			corev1.EnvVar{Name: RouterUniqueHeaderName, Value: headerName},
-			corev1.EnvVar{Name: RouterUniqueHeaderFormat, Value: headerFormat},
+			corev1.EnvVar{Name: RouterUniqueHeaderFormat, Value: fmt.Sprintf("%q", headerFormat)},
 		)
 	}
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -371,7 +371,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_HEADER_NAME", true, "unique-id")
-	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_FORMAT", true, "%{+X}o %ci:%cp_%fi:%fp_%Ts_%rt:%pid")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_FORMAT", true, `"%{+X}o %ci:%cp_%fi:%fp_%Ts_%rt:%pid"`)
 
 	secretName := fmt.Sprintf("secret-%v", time.Now().UnixNano())
 	ci.Spec.DefaultCertificate = &corev1.LocalObjectReference{
@@ -489,7 +489,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, true, "true")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_HEADER_NAME", true, "unique-id")
-	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_FORMAT", true, "foo")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_UNIQUE_ID_FORMAT", true, `"foo"`)
 }
 
 func TestInferTLSProfileSpecFromDeployment(t *testing.T) {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1,0 +1,110 @@
+// +build e2e
+
+package e2e
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// buildEchoPod returns a pod definition for an socat-based echo server.
+func buildEchoPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "echo",
+			},
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Args: []string{
+						"TCP4-LISTEN:8080,reuseaddr,fork",
+						`EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'`,
+					},
+					Command: []string{"/bin/socat"},
+					Image:   "openshift/origin-node",
+					Name:    "echo",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(8080),
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildEchoService returns a service definition for an HTTP service.
+func buildEchoService(name, namespace string, labels map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       int32(80),
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Selector: labels,
+		},
+	}
+}
+
+// buildCurlPod returns a pod definition for a pod with the given name and image
+// and in the given namespace that curls the specified host and address.
+func buildCurlPod(name, namespace, image, host, address string, extraArgs ...string) *corev1.Pod {
+	curlArgs := []string{
+		"-s",
+		"--retry", "300", "--retry-delay", "1", "--max-time", "2",
+		"--resolve", host + ":80:" + address,
+	}
+	curlArgs = append(curlArgs, extraArgs...)
+	curlArgs = append(curlArgs, "http://"+host)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "curl",
+					Image:   image,
+					Command: []string{"/bin/curl"},
+					Args:    curlArgs,
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}
+
+// buildRoute returns a route definition targeting the specified service.
+func buildRoute(name, namespace, serviceName string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: serviceName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
#### desiredRouterDeployment: Escape unique-id format

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Escape the unique-id header format string.


#### Add HTTP Unique-Id header E2E test

* `test/e2e/operator_test.go` (`TestUniqueIdHeader`): New test.