### PR TITLE
Bug 1873728: publishRecordToZones: Fix status merge

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -277,7 +277,7 @@ func (r *reconciler) publishRecordToZones(zones []configv1.DNSZone, record *iov1
 			Conditions: []iov1.DNSZoneCondition{condition},
 		})
 	}
-	return mergeStatuses(record.Status.Zones, statuses), result
+	return mergeStatuses(record.Status.DeepCopy().Zones, statuses), result
 }
 
 // recordIsAlreadyPublishedToZone returns a Boolean value indicating whether the

--- a/pkg/operator/controller/dns/controller_test.go
+++ b/pkg/operator/controller/dns/controller_test.go
@@ -150,6 +150,9 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 		zone := []configv1.DNSZone{{ID: "zone2"}}
 		oldStatuses := record.Status.DeepCopy().Zones
 		newStatuses, _ := r.publishRecordToZones(zone, record)
+		if !dnsZoneStatusSlicesEqual(oldStatuses, tc.oldZoneStatuses) {
+			t.Fatalf("%q: publishRecordToZones mutated the record's status conditions\nold: %#v\nnew: %#v", tc.description, oldStatuses, tc.oldZoneStatuses)
+		}
 		if equal := dnsZoneStatusSlicesEqual(oldStatuses, newStatuses); !equal != tc.expectChange {
 			t.Fatalf("%q: expected old and new status equal to be %v, got %v\nold: %#v\nnew: %#v", tc.description, tc.expectChange, equal, oldStatuses, newStatuses)
 		}


### PR DESCRIPTION
In `publishRecordToZones`, when merging the updated status with the input status in order to produce the output status, first make a copy of the input status, and use the copy to avoid mutating the input status.

Before this change, `publishRecordToZones` mutated the input status, and so when the caller compared the input status with the output status, it would always find them to be identical.  As a result, the caller never updated the DNSRecord's status in the API, which caused the DNS controller to endlessly retry the update and the ingress controller to report `DNSReady=False`.

* `pkg/operator/controller/dns/controller.go` (`publishRecordToZones`): Make a copy of the zone statuses, and pass the copy to `mergeStatuses` to avoid mutating the original zone statuses that the caller passed in.
* `pkg/operator/controller/dns/controller_test.go` (`TestPublishRecordToZonesMergesStatus`): Verify that `publishRecordToZones` does not mutate the status.


----

/cherry-pick release-4.5