### PR TITLE
Bug 1866299: Fixes AWS Tagging Client for GovCloud East Region

### DIFF
--- a/pkg/dns/aws/dns_test.go
+++ b/pkg/dns/aws/dns_test.go
@@ -80,8 +80,14 @@ func TestURLContainsValidRegion(t *testing.T) {
 		},
 		{
 			description: "tagging GovCloud uri for region us-gov-west-1",
-			uri:         "https://tagging.us-gov-west-1.amazonaws.com",
+			uri:         govCloudTaggingEndpoint,
 			region:      endpoints.UsGovWest1RegionID,
+			expected:    true,
+		},
+		{
+			description: "tagging GovCloud uri for region us-gov-east-1",
+			uri:         govCloudTaggingEndpoint,
+			region:      endpoints.UsGovEast1RegionID,
 			expected:    true,
 		},
 		{


### PR DESCRIPTION
As with other AWS partitions, the GovCloud Tagging client must be in the same region as the Route53 client to find the hosted zone of managed records. The AWS GovCloud [docs](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html) do not specify Group Tagging details, so this dependency was not included until tests confirmed the requirement.

/assign @Miciah @knobunc 
/cc @frobware @sgreene570 