### PR TITLE
[release-4.5] Bug 1878148: Backport: Delete Router Deployment Only Upon DNSRecord Deletion

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -46,23 +46,23 @@ const (
 
 // ensureRouterDeployment ensures the router deployment exists for a given
 // ingresscontroller.
-func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network) (*appsv1.Deployment, error) {
+func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network) (bool, *appsv1.Deployment, error) {
+	haveDepl, current, err := r.currentRouterDeployment(ci)
+	if err != nil {
+		return false, nil, err
+	}
 	desired, err := desiredRouterDeployment(ci, r.Config.IngressControllerImage, infraConfig, ingressConfig, apiConfig, networkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build router deployment: %v", err)
-	}
-	current, err := r.currentRouterDeployment(ci)
-	if err != nil {
-		return nil, err
+		return haveDepl, current, fmt.Errorf("failed to build router deployment: %v", err)
 	}
 	switch {
-	case desired != nil && current == nil:
+	case !haveDepl:
 		if err := r.createRouterDeployment(desired); err != nil {
-			return nil, err
+			return false, nil, err
 		}
-	case desired != nil && current != nil:
+	case haveDepl:
 		if err := r.updateRouterDeployment(current, desired); err != nil {
-			return nil, err
+			return true, current, err
 		}
 	}
 	return r.currentRouterDeployment(ci)
@@ -847,15 +847,15 @@ func hashableProbe(probe *corev1.Probe) *corev1.Probe {
 }
 
 // currentRouterDeployment returns the current router deployment.
-func (r *reconciler) currentRouterDeployment(ci *operatorv1.IngressController) (*appsv1.Deployment, error) {
+func (r *reconciler) currentRouterDeployment(ci *operatorv1.IngressController) (bool, *appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	if err := r.client.Get(context.TODO(), controller.RouterDeploymentName(ci), deployment); err != nil {
 		if errors.IsNotFound(err) {
-			return nil, nil
+			return false, nil, nil
 		}
-		return nil, err
+		return false, nil, err
 	}
-	return deployment, nil
+	return true, deployment, nil
 }
 
 // createRouterDeployment creates a router deployment.

--- a/pkg/operator/controller/ingress/dns_test.go
+++ b/pkg/operator/controller/ingress/dns_test.go
@@ -95,15 +95,15 @@ func TestDesiredWildcardDNSRecord(t *testing.T) {
 			service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, ingress)
 		}
 
-		actual := desiredWildcardRecord(controller, service)
+		haveWC, actual := desiredWildcardDNSRecord(controller, service)
 		switch {
-		case test.expect != nil && actual != nil:
+		case test.expect != nil && haveWC:
 			if !cmp.Equal(actual.Spec, *test.expect) {
 				t.Errorf("expected:\n%s\n\nactual:\n%s", toYaml(test.expect), toYaml(actual.Spec))
 			}
-		case test.expect == nil && actual != nil:
+		case test.expect == nil && haveWC:
 			t.Errorf("expected nil record, got:\n%s", toYaml(actual))
-		case test.expect != nil && actual == nil:
+		case test.expect != nil && !haveWC:
 			t.Errorf("expected record but got nil:\n%s", toYaml(test.expect))
 		}
 	}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -49,12 +49,12 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 			},
 		}
 
-		svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig)
+		haveSvc, svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig)
 		if err != nil {
 			t.Errorf("unexpected error from desiredLoadBalancerService for endpoint publishing strategy type %v: %v", tc.strategyType, err)
-		} else if tc.expect && svc == nil {
+		} else if tc.expect && !haveSvc {
 			t.Errorf("expected desiredLoadBalancerService to return a service for endpoint publishing strategy type %v, got nil", tc.strategyType)
-		} else if !tc.expect && svc != nil {
+		} else if !tc.expect && haveSvc {
 			t.Errorf("expected desiredLoadBalancerService to return nil service for endpoint publishing strategy type %v, got %#v", tc.strategyType, svc)
 		}
 	}

--- a/pkg/operator/controller/ingress/monitoring.go
+++ b/pkg/operator/controller/ingress/monitoring.go
@@ -37,7 +37,7 @@ func (r *reconciler) ensureServiceMonitor(ic *operatorv1.IngressController, svc 
 		}
 	case haveSM:
 		if updated, err := r.updateServiceMonitor(current, desired); err != nil {
-			return true, nil, fmt.Errorf("failed to update servicemonitor %s/%s: %v", desired.GetNamespace(), desired.GetName(), err)
+			return true, current, fmt.Errorf("failed to update servicemonitor %s/%s: %v", desired.GetNamespace(), desired.GetName(), err)
 		} else if updated {
 			log.Info("updated servicemonitor", "namespace", desired.GetNamespace(), "name", desired.GetName())
 		}

--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -49,7 +49,7 @@ func (r *reconciler) ensureNodePortService(ic *operatorv1.IngressController, dep
 		log.Info("created NodePort service", "service", desired)
 	case wantService && haveService:
 		if updated, err := r.updateNodePortService(current, desired); err != nil {
-			return true, nil, fmt.Errorf("failed to update NodePort service: %v", err)
+			return true, current, fmt.Errorf("failed to update NodePort service: %v", err)
 		} else if updated {
 			log.Info("updated NodePort service", "service", desired)
 		}

--- a/pkg/operator/controller/ingress/poddisruptionbudget.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget.go
@@ -49,7 +49,7 @@ func (r *reconciler) ensureRouterPodDisruptionBudget(ic *operatorv1.IngressContr
 		log.Info("created pod disruption budget", "poddisruptionbudget", desired)
 	case wantPDB && havePDB:
 		if updated, err := r.updateRouterPodDisruptionBudget(current, desired); err != nil {
-			return true, nil, fmt.Errorf("failed to update pod disruption budget: %v", err)
+			return true, current, fmt.Errorf("failed to update pod disruption budget: %v", err)
 		} else if updated {
 			log.Info("updated pod disruption budget", "poddisruptionbudget", desired)
 		}

--- a/pkg/operator/controller/ingress/rsyslog_configmap.go
+++ b/pkg/operator/controller/ingress/rsyslog_configmap.go
@@ -55,7 +55,7 @@ func (r *reconciler) ensureRsyslogConfigMap(ic *operatorv1.IngressController, de
 		}
 	case wantCM && haveCM:
 		if updated, err := r.updateRsyslogConfigMap(current, desired); err != nil {
-			return true, nil, fmt.Errorf("failed to update configmap: %v", err)
+			return true, current, fmt.Errorf("failed to update configmap: %v", err)
 		} else if updated {
 			log.Info("updated configmap", "configmap", desired)
 		}

--- a/pkg/operator/controller/ingress/serviceca_configmap.go
+++ b/pkg/operator/controller/ingress/serviceca_configmap.go
@@ -43,7 +43,7 @@ func (r *reconciler) ensureServiceCAConfigMap() (bool, *corev1.ConfigMap, error)
 		log.Info("created configmap", "configmap", desired)
 	case wantCM && haveCM:
 		if updated, err := r.updateServiceCAConfigMap(current, desired); err != nil {
-			return true, nil, fmt.Errorf("failed to update configmap: %v", err)
+			return true, current, fmt.Errorf("failed to update configmap: %v", err)
 		} else if updated {
 			log.Info("updated configmap", "configmap", desired)
 		}


### PR DESCRIPTION
This PR backports https://github.com/openshift/cluster-ingress-operator/pull/419 to `release-4.5`. The backport had to be done manually due to merge conflicts. PR https://github.com/openshift/cluster-ingress-operator/pull/408 was added to this backport to resolve the merge conflicts. https://github.com/openshift/cluster-ingress-operator/pull/408 introduced a regression, so https://github.com/openshift/cluster-ingress-operator/pull/412 has been added to this backport as well. All commits were applied as is without hitting any merge conflicts, so reviewing this should be straightforward.

This backport is needed to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1876919.

/assign @danehans @Miciah 
/cc @frobware 