### PR TITLE
Organize dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.15 AS builder
 WORKDIR /ingress-operator
 COPY . .
 RUN make build

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,13 +1,13 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 WORKDIR /ingress-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /ingress-operator/ingress-operator /usr/bin/
 COPY manifests /manifests
 ENTRYPOINT ["/usr/bin/ingress-operator"]
-LABEL io.openshift.release.operator true
+LABEL io.openshift.release.operator="true"
 LABEL io.k8s.display-name="OpenShift ingress-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of ingress controller components." \
       maintainer="Dan Mace <dmace@redhat.com>"


### PR DESCRIPTION
Appropriately moves `Dockerfile` (the dockerfile currently used by ART) to `Dockerfile.rhel`. Moves` Dockerfile.rhel7` (not used by ART, not a RHEL-8 base) to `Dockerfile`. Basically following along with other components Dockerfile naming conventions, such as the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator/blob/master/Dockerfile.rhel).

This will have repercussions in CI/ART and will most likely require follow up PRs in `openshift/release`, etc. We can safely merge this once 4.7 branching is open.

Slack context w/ Clayton: https://coreos.slack.com/archives/CCH60A77E/p1599076992180700?thread_ts=1598992667.131100&cid=CCH60A77E