### PR TITLE
Bug 1891625: Support changing ingresscontroller load balancer scope

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -359,6 +359,12 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 		ic.Status.EndpointPublishingStrategy = effectiveStrategy
 		return true
 	}
+	// Detect changes to LB scope, which is something we can safely roll out.
+	statusLB := ic.Status.EndpointPublishingStrategy.LoadBalancer
+	specLB := effectiveStrategy.LoadBalancer
+	if specLB != nil && statusLB != nil && specLB.Scope != statusLB.Scope {
+		ic.Status.EndpointPublishingStrategy.LoadBalancer.Scope = effectiveStrategy.LoadBalancer.Scope
+	}
 	return false
 }
 

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -9,6 +9,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestDesiredLoadBalancerService(t *testing.T) {
@@ -327,5 +328,206 @@ func checkServiceHasAnnotation(svc *corev1.Service, name string, expectValue boo
 		return fmt.Errorf("service has unexpected %s annotation setting: expected %q, got %q", name, expectedValue, actualValue)
 	default:
 		return nil
+	}
+}
+
+func TestLoadBalancerServiceChanged(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*corev1.Service)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *corev1.Service) {},
+			expect:      false,
+		},
+		{
+			description: "if .uid changes",
+			mutate: func(svc *corev1.Service) {
+				svc.UID = "2"
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.clusterIP changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.ClusterIP = "2.3.4.5"
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.externalIPs changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.ExternalIPs = []string{"3.4.5.6"}
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.externalTrafficPolicy changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.healthCheckNodePort changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.HealthCheckNodePort = int32(34566)
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.ports changes",
+			mutate: func(svc *corev1.Service) {
+				newPort := corev1.ServicePort{
+					Name:       "foo",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       int32(8080),
+					TargetPort: intstr.FromString("foo"),
+				}
+				svc.Spec.Ports = append(svc.Spec.Ports, newPort)
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.ports[*].nodePort changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.Ports[0].NodePort = int32(33337)
+				svc.Spec.Ports[1].NodePort = int32(33338)
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.selector changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.Selector = nil
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.sessionAffinity is defaulted",
+			mutate: func(service *corev1.Service) {
+				service.Spec.SessionAffinity = corev1.ServiceAffinityNone
+			},
+			expect: false,
+		},
+		{
+			description: "if .spec.sessionAffinity is set to a non-default value",
+			mutate: func(service *corev1.Service) {
+				service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.type changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.Type = corev1.ServiceTypeNodePort
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		platformStatus := &configv1.PlatformStatus{
+			Type: configv1.AWSPlatformType,
+		}
+		original := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-ingress",
+				Name:      "router-original",
+				UID:       "1",
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP:             "1.2.3.4",
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				HealthCheckNodePort:   int32(33333),
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "http",
+						NodePort:   int32(33334),
+						Port:       int32(80),
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromString("http"),
+					},
+					{
+						Name:       "https",
+						NodePort:   int32(33335),
+						Port:       int32(443),
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromString("https"),
+					},
+				},
+				Selector: map[string]string{
+					"foo": "bar",
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		mutated := original.DeepCopy()
+		tc.mutate(mutated)
+		if changed, updated, needsRecreate := loadBalancerServiceChanged(&original, mutated, platformStatus); changed != tc.expect {
+			t.Errorf("%s, expect loadBalancerServiceChanged to be %t, got %t", tc.description, tc.expect, changed)
+		} else if needsRecreate {
+			t.Errorf("%s, loadBalancerServiceChanged returned needsRecreate=true", tc.description)
+		} else if changed {
+			if changedAgain, _, _ := loadBalancerServiceChanged(mutated, updated, platformStatus); changedAgain {
+				t.Errorf("%s, loadBalancerServiceChanged does not behave as a fixed point function", tc.description)
+			}
+		}
+	}
+}
+
+func TestLoadBalancerServiceChangedScopeNeedsRecreate(t *testing.T) {
+	testCases := []struct {
+		platform configv1.PlatformType
+		expect   bool
+	}{
+		{platform: configv1.AWSPlatformType, expect: true},
+		{platform: configv1.AzurePlatformType, expect: false},
+		{platform: configv1.GCPPlatformType, expect: false},
+		{platform: configv1.IBMCloudPlatformType, expect: true},
+	}
+
+	for _, tc := range testCases {
+		platformStatus := &configv1.PlatformStatus{Type: tc.platform}
+		original := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+				Namespace:   "openshift-ingress",
+				Name:        "router-original",
+			},
+		}
+		internal := original.DeepCopy()
+		extAnnotations := externalLBAnnotations[platformStatus.Type]
+		for name, value := range extAnnotations {
+			original.Annotations[name] = value
+		}
+		intAnnotations := InternalLBAnnotations[platformStatus.Type]
+		for name, value := range intAnnotations {
+			internal.Annotations[name] = value
+		}
+		if changed, updated, needsRecreate := loadBalancerServiceChanged(&original, internal, platformStatus); needsRecreate != tc.expect {
+			t.Errorf("on platform %s, when setting internal scope, expected loadBalancerServiceChanged to return needsRecreate=%t, got %t", tc.platform, tc.expect, needsRecreate)
+		} else if !changed {
+			t.Errorf("on platform %s, when setting internal scope, expected loadBalancerServiceChanged to return changed=%t, got %t", tc.platform, true, changed)
+		} else {
+			for name, value := range intAnnotations {
+				if err := checkServiceHasAnnotation(updated, name, true, value); err != nil {
+					t.Errorf("on platform %s, when setting internal scope, %v", tc.platform, err)
+				}
+			}
+		}
+		if changed, updated, needsRecreate := loadBalancerServiceChanged(internal, &original, platformStatus); needsRecreate != tc.expect {
+			t.Errorf("on platform %s, when setting external scope, expected loadBalancerServiceChanged to return needsRecreate=%t, got %t", tc.platform, tc.expect, needsRecreate)
+		} else if !changed {
+			t.Errorf("on platform %s, when setting external scope, expected loadBalancerServiceChanged to return changed=%t, got %t", tc.platform, true, changed)
+		} else {
+			for name, value := range extAnnotations {
+				if err := checkServiceHasAnnotation(updated, name, true, value); err != nil {
+					t.Errorf("on platform %s, when setting external scope, %v", tc.platform, err)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Add support for changing ingresscontroller load balancer scope.  On AWS and IBM cloud, this requires deleting the existing load balancer service and recreating it with the desired scope.   On Azure and GCP, it suffices to update the existing service's annotations.

This change also adds logic to remove the service finalizer, which is no longer needed to clean up DNS records since the DNSRecord CRD was added.

* `pkg/operator/controller/ingress/controller.go` (`setDefaultPublishingStrategy`): Update scope if needed.
* `pkg/operator/controller/ingress/load_balancer_service.go` (`externalLBAnnotations`): New variable.  Map platform type to the annotation for that platform that makes the load balancer external, if the platform requires an explicit annotation.
(`ensureLoadBalancerService`): Add delete and update logic.  Use the new `deleteLoadBalancerServiceFinalizer` method to delete any finalizer on any existing service.  Use the new `createLoadBalancerService`, `deleteLoadBalancerService`, and `updateLoadBalancerService` methods to create, update, or delete the service as needed.
(`desiredLoadBalancerService`): Delete logic to add a finalizer to the service.  Use new externalLBAnnotations variable to simplify logic.
(`finalizeLoadBalancerService`): Refactor to use the new `deleteLoadBalancerServiceFinalizer` method.
(`createLoadBalancerService`, `deleteLoadBalancerService`): New methods.
(`updateLoadBalancerService`): New method.  Update the LoadBalancer service, using the new `loadBalancerServiceChanged` function.
(`loadBalancerServiceScopeChanged`): New function.  Check if the load balancer's scope changed.
(`loadBalancerServiceChanged`): New function.  Check if the current service needs to be updated, and if so, whether it needs to be modified or deleted and recreated.
(`deleteLoadBalancerServiceFinalizer`): New method.  Delete any finalizer from the service.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceChanged`): New test.
(`TestLoadBalancerServiceChangedScopeNeedsRecreate`): New test.
* `test/e2e/operator_test.go` (`isServiceInternal`): New function.  Return a Boolean value indicating whether the provided service is annotated to request an internal load-balancer.
(`TestScopeChange`): New test.  Verify that mutating scope from the default external scope to internal scope and from internal back to external succeeds on AWS, Azure, GCP, and IBM Cloud.


----

Based on #394.