### PR TITLE
TestForwardedHeaderPolicy*: Make case-insensitive

### DIFF
--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -32,7 +32,8 @@ var testPodCount int
 
 // testRouteHeaders connects to the specified route using the provided address
 // and verifies that the response has the expected number of matches of the
-// expected string.
+// expected string.  Case is ignored when comparing the expected response and
+// the actual response.
 func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address string, headers []string, expectedResponse string, expectedMatches int) {
 	t.Helper()
 
@@ -62,6 +63,7 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 			}
 		}
 	}()
+	expectedResponse = strings.ToLower(expectedResponse)
 	err = wait.PollImmediate(1*time.Second, 4*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
 			Container: "curl",
@@ -80,7 +82,7 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 		var numMatches int
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, expectedResponse) {
+			if strings.Contains(strings.ToLower(line), expectedResponse) {
 				numMatches++
 				t.Logf("found match %d of %d expected: %s", numMatches, expectedMatches, line)
 			}


### PR DESCRIPTION
#### `TestForwardedHeaderPolicy*`: Show pod logs if failed

* `test/e2e/forwarded_header_policy_test.go` (`testRouteHeaders`): If the polling loop fails, output the client pod's spec and logs as part of the failure message.

#### `TestForwardedHeaderPolicy*`: Make case-insensitive

Ignore case when comparing the expected response and the actual response in the Forwarded header policy E2E tests. https://github.com/openshift/router/pull/194 turns off HAProxy's HTX option when HTTP/2 is not enabled.  As a result, HAProxy does not down-case HTTP header names.

* `test/e2e/forwarded_header_policy_test.go` (`testRouteHeaders`): Ignore case when comparing the expected response and the actual response.