### PR TITLE
dns: Don't hotloop on updates to DNSRecord status

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -67,7 +67,7 @@ func New(mgr manager.Manager, config Config) (runtimecontroller.Controller, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := c.Watch(&source.Kind{Type: &iov1.DNSRecord{}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(&source.Kind{Type: &iov1.DNSRecord{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{}); err != nil {
 		return nil, err
 	}
 	if err := c.Watch(&source.Kind{Type: &configv1.DNS{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(reconciler.ToDNSRecords)}); err != nil {


### PR DESCRIPTION
Add a predicate to the DNS controller's watch on `DNSRecords` so that only updates a `DNSRecord's` spec triggers reconciliation (and updates to its status do not).

Before this change, one reconciliation could update the `DNSRecord's` status and trigger a second reconciliation.  In the case of a successful update, the second reconciliation would have no work to do, so it would complete without triggering a third reconciliation.  In the case of a failed update, the second reconciliation would retry the update.  If retrying the update then failed, the second reconciliation could update the `DNSRecord's` status to record the new failure, triggering a third reconciliation, which could similarly trigger a fourth reconciliation, and so on ad infinitum.

* `pkg/operator/controller/dns/controller.go` (`New`): Add a predicate to the watch on `DNSRecords` to ignore updates to status.


----

@ironcladlou