### PR TITLE
Bug 1896923: Configure operator metrics handler to use localhost

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -59,7 +59,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.OperatorNamespace, "namespace", "n", manifests.DefaultOperatorNamespace, "namespace the operator is deployed to (required)")
 	cmd.Flags().StringVarP(&options.IngressControllerImage, "image", "i", "", "image of the ingress controller the operator will manage (required)")
 	cmd.Flags().StringVarP(&options.ReleaseVersion, "release-version", "", statuscontroller.UnknownVersionValue, "the release version the operator should converge to (required)")
-	cmd.Flags().StringVarP(&options.MetricsListenAddr, "metrics-listen-addr", "", ":60000", "metrics endpoint listen address (required)")
+	cmd.Flags().StringVarP(&options.MetricsListenAddr, "metrics-listen-addr", "", "127.0.0.1:60000", "metrics endpoint listen address (required)")
 	cmd.Flags().StringVarP(&options.ShutdownFile, "shutdown-file", "s", defaultTrustedCABundle, "if provided, shut down the operator when this file changes")
 
 	if err := cmd.MarkFlagRequired("namespace"); err != nil {


### PR DESCRIPTION
Configure the operator's metrics handler to listen on 127.0.0.1 only.

Before this change, metrics were exposed on port 60000, without authentication.  Although the pod spec does not advertise port 60000, the port was still accessible outside the pod.  After this change, port 60000 is inaccessible outside the pod, so the only way to get metrics is by connecting to port 9393 and authenticating with kube-rbac-proxy.

* `cmd/ingress-operator/start.go` (`NewStartCommand`): Configure metrics to listen on 127.0.0.1:60000.