### PR TITLE
Bug 1880902: automatically set the dnsPolicy with ClusterFirstWithHostNet when endpoint publishing strategy type is set to hostnetwork

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -374,6 +374,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	}
 
 	deployment.Spec.Template.Spec.Containers[0].Image = ingressControllerImage
+	deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
 
 	if ci.Status.EndpointPublishingStrategy.Type == operatorv1.HostNetworkStrategyType {
 		// Expose ports 80 and 443 on the host to provide endpoints for
@@ -386,6 +387,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		// problems or firewall restrictions.
 		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host = "localhost"
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Handler.HTTPGet.Host = "localhost"
+		deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	// Fill in the default certificate secret name.
@@ -861,6 +863,7 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 		return containers[i].Name < containers[j].Name
 	})
 	hashableDeployment.Spec.Template.Spec.Containers = containers
+	hashableDeployment.Spec.Template.Spec.DNSPolicy = deployment.Spec.Template.Spec.DNSPolicy
 	hashableDeployment.Spec.Template.Spec.HostNetwork = deployment.Spec.Template.Spec.HostNetwork
 	volumes := make([]corev1.Volume, len(deployment.Spec.Template.Spec.Volumes))
 	for i, vol := range deployment.Spec.Template.Spec.Volumes {
@@ -1005,6 +1008,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 		containers[i+1] = *container.DeepCopy()
 	}
 	updated.Spec.Template.Spec.Containers = containers
+	updated.Spec.Template.Spec.DNSPolicy = expected.Spec.Template.Spec.DNSPolicy
 	updated.Spec.Template.Labels = expected.Spec.Template.Labels
 	updated.Spec.Strategy = expected.Spec.Strategy
 	volumes := make([]corev1.Volume, len(expected.Spec.Template.Spec.Volumes))

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -229,6 +229,10 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		t.Error("expected host network to be false")
 	}
 
+	if deployment.Spec.Template.Spec.DNSPolicy != corev1.DNSClusterFirst {
+		t.Errorf("expected dnsPolicy to be %s, got %s", corev1.DNSClusterFirst, deployment.Spec.Template.Spec.DNSPolicy)
+	}
+
 	if len(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host) != 0 {
 		t.Errorf("expected empty liveness probe host, got %q", deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host)
 	}
@@ -306,6 +310,9 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkRollingUpdateParams(t, deployment, intstr.FromString("25%"), intstr.FromString("25%"))
 	if deployment.Spec.Template.Spec.HostNetwork != false {
 		t.Error("expected host network to be false")
+	}
+	if deployment.Spec.Template.Spec.DNSPolicy != corev1.DNSClusterFirst {
+		t.Errorf("expected dnsPolicy to be %s, got %s", corev1.DNSClusterFirst, deployment.Spec.Template.Spec.DNSPolicy)
 	}
 	if len(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host) != 0 {
 		t.Errorf("expected empty liveness probe host, got %q", deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host)
@@ -459,6 +466,11 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	if deployment.Spec.Template.Spec.HostNetwork != true {
 		t.Error("expected host network to be true")
 	}
+
+	if deployment.Spec.Template.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
+		t.Errorf("expected dnsPolicy to be %s, got %s", corev1.DNSClusterFirstWithHostNet, deployment.Spec.Template.Spec.DNSPolicy)
+	}
+
 	if deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host != "localhost" {
 		t.Errorf("expected liveness probe host to be \"localhost\", got %q", deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Host)
 	}
@@ -875,6 +887,13 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if dnsPolicy is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -901,6 +920,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 						},
 					},
 					Spec: corev1.PodSpec{
+						DNSPolicy: corev1.DNSClusterFirst,
 						Volumes: []corev1.Volume{
 							{
 								Name: "default-certificate",


### PR DESCRIPTION
Bug 1880902 - If the endpoint publishing strategy type is set to hostnetwork then
we should automatically set the dnsPolicy with ClusterFirstWithHostNet.