### PR TITLE
Keep reporting old versions while progressing

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -46,6 +46,7 @@ const (
 	IngressControllerDeploymentAvailableConditionType            = "DeploymentAvailable"
 	IngressControllerDeploymentReplicasMinAvailableConditionType = "DeploymentReplicasMinAvailable"
 	IngressControllerDeploymentReplicasAllAvailableConditionType = "DeploymentReplicasAllAvailable"
+	IngressControllerProgressingConditionType                    = "Progressing"
 )
 
 var (


### PR DESCRIPTION
* `pkg/operator/controller/ingress/controller.go` (`IngressControllerProgressingConditionType`): New const.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Compute the "Progressing" status condition using the new `computeIngressProgressingCondition` function.
(`computeIngressProgressingCondition`): New function.
* `pkg/operator/controller/status/controller.go` (`Reconcile`): Check whether any ingresscontrollers are progressing using the new `checkAnyIngressProgressing` function.  Pass this information to `computeOperatorStatusVersions`.
(`computeOperatorStatusVersions`): Replace `allIngressesAvailable` parameter with `anyIngressProgressing` parameter.  Continue reporting the old versions as long as the ingresscontroller is progressing.
(`checkAnyIngressProgressing`): New function.
* `pkg/operator/controller/status/controller_test.go` (`TestComputeOperatorProgressingCondition`): Replace `allIngressesAvailable` test input with `anyIngressProgressing`, and adjust test cases accordingly.