### PR TITLE
hack: verify-generated-crd.sh should fail on diffs

### DIFF
--- a/hack/verify-generated-crd.sh
+++ b/hack/verify-generated-crd.sh
@@ -6,6 +6,7 @@ function verify_crd {
   local DST="$2"
   if ! diff -Naup "$SRC" "$DST"; then
     echo "invalid CRD: $SRC => $DST"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Add an exit code to the `hack/verify-generated-crd.sh`
script so discovered diffs return an exit code of 1,
rather than 0 (which fakes out the verify CI job).