### PR TITLE
Bug 1898417: GCP the dns targets in Google Cloud DNS is not updated after recreating loadbalancer service

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -361,6 +361,10 @@ func (m *Provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 	return m.change(record, zone, deleteAction)
 }
 
+func (m *Provider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error {
+	return m.change(record, zone, upsertAction)
+}
+
 // change will perform an action on a record. The target must correspond to the
 // hostname of an ELB which will be automatically discovered.
 func (m *Provider) change(record *iov1.DNSRecord, zone configv1.DNSZone, action action) error {

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -125,6 +125,10 @@ func (m *provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 	return err
 }
 
+func (m *provider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error {
+	return m.Ensure(record, zone)
+}
+
 // getARecordName extracts the ARecord subdomain name from the full domain string.
 // azure defines the ARecord Name as the subdomain name only.
 func getARecordName(recordDomain string, zoneName string) (string, error) {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -13,11 +13,15 @@ type Provider interface {
 
 	// Delete will delete record.
 	Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error
+
+	// Replace will replace the record
+	Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error
 }
 
 var _ Provider = &FakeProvider{}
 
 type FakeProvider struct{}
 
-func (_ *FakeProvider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error { return nil }
-func (_ *FakeProvider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error { return nil }
+func (_ *FakeProvider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
+func (_ *FakeProvider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
+func (_ *FakeProvider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error { return nil }

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -262,17 +262,34 @@ func (r *reconciler) publishRecordToZones(zones []configv1.DNSZone, record *iov1
 			LastTransitionTime: metav1.Now(),
 		}
 
-		if err := r.dnsProvider.Ensure(record, zone); err != nil {
-			log.Error(err, "failed to publish DNS record to zone", "record", record.Spec, "dnszone", zone)
-			condition.Status = string(operatorv1.ConditionTrue)
-			condition.Reason = "ProviderError"
-			condition.Message = fmt.Sprintf("The DNS provider failed to ensure the record: %v", err)
-			result.RequeueAfter = 30 * time.Second
+		if recordIsAlreadyPublishedToZone(record, &zone) {
+			log.Info("replacing DNS record", "record", record.Spec, "dnszone", zone)
+
+			if err := r.dnsProvider.Replace(record, zone); err != nil {
+				log.Error(err, "failed to replace DNS record in zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(operatorv1.ConditionTrue)
+				condition.Reason = "ProviderError"
+				condition.Message = fmt.Sprintf("The DNS provider failed to replace the record: %v", err)
+				result.RequeueAfter = 30 * time.Second
+			} else {
+				log.Info("replaced DNS record in zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(operatorv1.ConditionFalse)
+				condition.Reason = "ProviderSuccess"
+				condition.Message = "The DNS provider succeeded in replacing the record"
+			}
 		} else {
-			log.Info("published DNS record to zone", "record", record.Spec, "dnszone", zone)
-			condition.Status = string(operatorv1.ConditionFalse)
-			condition.Reason = "ProviderSuccess"
-			condition.Message = "The DNS provider succeeded in ensuring the record"
+			if err := r.dnsProvider.Ensure(record, zone); err != nil {
+				log.Error(err, "failed to publish DNS record to zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(operatorv1.ConditionTrue)
+				condition.Reason = "ProviderError"
+				condition.Message = fmt.Sprintf("The DNS provider failed to ensure the record: %v", err)
+				result.RequeueAfter = 30 * time.Second
+			} else {
+				log.Info("published DNS record to zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(operatorv1.ConditionFalse)
+				condition.Reason = "ProviderSuccess"
+				condition.Message = "The DNS provider succeeded in ensuring the record"
+			}
 		}
 		statuses = append(statuses, iov1.DNSZoneStatus{
 			DNSZone:    zone,


### PR DESCRIPTION
GCP: the dns targets in Google Cloud DNS is not updated after recreating loadbalancer service