### PR TITLE
Bug 1903165: NE-199 Follow Up Fixes.

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -9,9 +9,10 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/fsnotify.v1"
 
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator"
+
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	canarycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 
@@ -59,7 +60,7 @@ func NewStartCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.OperatorNamespace, "namespace", "n", manifests.DefaultOperatorNamespace, "namespace the operator is deployed to (required)")
+	cmd.Flags().StringVarP(&options.OperatorNamespace, "namespace", "n", operatorcontroller.DefaultOperatorNamespace, "namespace the operator is deployed to (required)")
 	cmd.Flags().StringVarP(&options.IngressControllerImage, "image", "i", "", "image of the ingress controller the operator will manage (required)")
 	cmd.Flags().StringVarP(&options.CanaryImage, "canary-image", "c", "", "image of the canary container that the operator will manage (optional)")
 	cmd.Flags().StringVarP(&options.ReleaseVersion, "release-version", "", statuscontroller.UnknownVersionValue, "the release version the operator should converge to (required)")

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,13 +65,6 @@ const (
 	// operator has ensured it's safe for deletion to proceeed.
 	DNSRecordFinalizer = "operator.openshift.io/ingress-dns"
 
-	DefaultOperatorNamespace = "openshift-ingress-operator"
-	DefaultOperandNamespace  = "openshift-ingress"
-
-	// DefaultCanaryNamespace is the default namespace for
-	// the ingress canary check resources.
-	DefaultCanaryNamespace = "openshift-ingress-canary"
-
 	// DefaultIngressControllerName is the name of the default IngressController
 	// instance.
 	DefaultIngressControllerName = "default"
@@ -118,7 +113,7 @@ func RouterStatsSecret(cr *operatorv1.IngressController) *corev1.Secret {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("router-stats-%s", cr.Name),
-			Namespace: "openshift-ingress",
+			Namespace: operatorcontroller.DefaultOperandNamespace,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{},

--- a/pkg/operator/controller/canary/controller.go
+++ b/pkg/operator/controller/canary/controller.go
@@ -57,7 +57,7 @@ var (
 // the canary service, daemonset, and route resources.
 func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	reconciler := &reconciler{
-		Config: config,
+		config: config,
 		client: mgr.GetClient(),
 	}
 	c, err := controller.New(canaryControllerName, mgr, controller.Options{Reconciler: reconciler})
@@ -170,7 +170,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// has been admitted.
 	if checkRouteAdmitted(route) {
 		routeProbeRunner.Do(func() {
-			r.startCanaryRoutePolling(r.Config.Stop)
+			r.startCanaryRoutePolling(r.config.Stop)
 		})
 	}
 
@@ -187,7 +187,7 @@ type Config struct {
 // reconciler handles the actual canary reconciliation logic in response to
 // events.
 type reconciler struct {
-	Config
+	config Config
 
 	client client.Client
 }
@@ -285,7 +285,7 @@ func (r *reconciler) setCanaryStatusCondition(cond operatorv1.OperatorCondition)
 	ic := &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      manifests.DefaultIngressControllerName,
-			Namespace: r.Config.Namespace,
+			Namespace: r.config.Namespace,
 		},
 	}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: ic.Namespace, Name: ic.Name}, ic); err != nil {

--- a/pkg/operator/controller/canary/daemonset.go
+++ b/pkg/operator/controller/canary/daemonset.go
@@ -13,7 +13,7 @@ import (
 
 // ensureCanaryDaemonSet ensures the canary daemonset exists
 func (r *reconciler) ensureCanaryDaemonSet() (bool, *appsv1.DaemonSet, error) {
-	desired := desiredCanaryDaemonSet(r.Config.CanaryImage)
+	desired := desiredCanaryDaemonSet(r.config.CanaryImage)
 	haveDs, current, err := r.currentCanaryDaemonSet()
 	if err != nil {
 		return false, nil, err

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -23,7 +23,7 @@ func TestDesiredCanaryRoute(t *testing.T) {
 
 	expectedRouteName := types.NamespacedName{
 		Namespace: "openshift-ingress-canary",
-		Name:      "ingress-canary-route",
+		Name:      "canary",
 	}
 
 	if !cmp.Equal(route.Name, expectedRouteName.Name) {

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -12,6 +12,7 @@ import (
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -111,12 +112,12 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// In an operator maintained cluster, this is always `oc get -n openshift-ingress-operator ingresscontroller/default`, skip the rest and return here.
 	// TODO if network-edge wishes to expand the scope of the CA bundle (and you could legitimately see a need/desire to have one CA that verifies all ingress traffic).
 	// TODO this could be accomplished using union logic similar to the kube-apiserver's join of multiple CAs.
-	if ingress == nil || ingress.Namespace != "openshift-ingress-operator" || ingress.Name != "default" {
+	if ingress == nil || ingress.Namespace != operatorcontroller.DefaultOperatorNamespace || ingress.Name != "default" {
 		return result, utilerrors.NewAggregate(errs)
 	}
 
 	wildcardServingCertKeySecret := &corev1.Secret{}
-	if err := r.client.Get(context.TODO(), controller.RouterEffectiveDefaultCertificateSecretName(ingress, "openshift-ingress"), wildcardServingCertKeySecret); err != nil {
+	if err := r.client.Get(context.TODO(), controller.RouterEffectiveDefaultCertificateSecretName(ingress, operatorcontroller.DefaultOperandNamespace), wildcardServingCertKeySecret); err != nil {
 		errs = append(errs, fmt.Errorf("failed to lookup wildcard cert: %v", err))
 		return result, utilerrors.NewAggregate(errs)
 	}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -9,6 +9,7 @@ import (
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	retryable "github.com/openshift/cluster-ingress-operator/pkg/util/retryableerror"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/slice"
 
@@ -676,13 +677,13 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 	}
 
 	operandEvents := &corev1.EventList{}
-	if err := r.cache.List(context.TODO(), operandEvents, client.InNamespace("openshift-ingress")); err != nil {
-		errs = append(errs, fmt.Errorf("failed to list events in namespace %q: %v", "openshift-ingress", err))
+	if err := r.cache.List(context.TODO(), operandEvents, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list events in namespace %q: %v", operatorcontroller.DefaultOperandNamespace, err))
 	}
 
 	pods := &corev1.PodList{}
-	if err := r.cache.List(context.TODO(), pods, client.InNamespace("openshift-ingress")); err != nil {
-		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", "openshift-ingress", err))
+	if err := r.cache.List(context.TODO(), pods, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
 	}
 
 	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig))

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -67,7 +67,7 @@ var (
 // in the manager namespace.
 func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	reconciler := &reconciler{
-		Config:   config,
+		config:   config,
 		client:   mgr.GetClient(),
 		cache:    mgr.GetCache(),
 		recorder: mgr.GetEventRecorderFor(controllerName),
@@ -97,7 +97,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 func (r *reconciler) ingressConfigToIngressController(o handler.MapObject) []reconcile.Request {
 	var requests []reconcile.Request
 	controllers := &operatorv1.IngressControllerList{}
-	if err := r.cache.List(context.Background(), controllers, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.cache.List(context.Background(), controllers, client.InNamespace(r.config.Namespace)); err != nil {
 		log.Error(err, "failed to list ingresscontrollers for ingress", "related", o.Meta.GetSelfLink())
 		return requests
 	}
@@ -144,7 +144,7 @@ type Config struct {
 // reconciler handles the actual ingress reconciliation logic in response to
 // events.
 type reconciler struct {
-	Config
+	config Config
 
 	client   client.Client
 	cache    cache.Cache
@@ -426,7 +426,7 @@ func (r *reconciler) validate(ic *operatorv1.IngressController) error {
 	var errors []error
 
 	ingresses := &operatorv1.IngressControllerList{}
-	if err := r.cache.List(context.TODO(), ingresses, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.cache.List(context.TODO(), ingresses, client.InNamespace(r.config.Namespace)); err != nil {
 		return fmt.Errorf("failed to list ingresscontrollers: %v", err)
 	}
 

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -71,7 +71,7 @@ func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, in
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to determine if proxy protocol is needed for ingresscontroller %s/%s: %v", ci.Namespace, ci.Name, err)
 	}
-	desired, err := desiredRouterDeployment(ci, r.Config.IngressControllerImage, ingressConfig, apiConfig, networkConfig, proxyNeeded)
+	desired, err := desiredRouterDeployment(ci, r.config.IngressControllerImage, ingressConfig, apiConfig, networkConfig, proxyNeeded)
 	if err != nil {
 		return haveDepl, current, fmt.Errorf("failed to build router deployment: %v", err)
 	}

--- a/pkg/operator/controller/ingress/monitoring.go
+++ b/pkg/operator/controller/ingress/monitoring.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -60,7 +62,7 @@ func desiredServiceMonitor(ic *operatorv1.IngressController, svc *corev1.Service
 			"spec": map[string]interface{}{
 				"namespaceSelector": map[string]interface{}{
 					"matchNames": []interface{}{
-						"openshift-ingress",
+						operatorcontroller.DefaultOperandNamespace,
 					},
 				},
 				"selector": map[string]interface{}{

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -29,6 +29,13 @@ const (
 	// CanaryDaemonsetLabel identifies a daemonset as an ingress canary daemonset, and
 	// the value is the name of the owning canary controller.
 	CanaryDaemonSetLabel = "ingresscanary.operator.openshift.io/daemonset-ingresscanary"
+
+	DefaultOperatorNamespace = "openshift-ingress-operator"
+	DefaultOperandNamespace  = "openshift-ingress"
+
+	// DefaultCanaryNamespace is the default namespace for
+	// the ingress canary check resources.
+	DefaultCanaryNamespace = "openshift-ingress-canary"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator
@@ -42,7 +49,7 @@ func IngressClusterOperatorName() types.NamespacedName {
 // RouterDeploymentName returns the namespaced name for the router deployment.
 func RouterDeploymentName(ci *operatorv1.IngressController) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress",
+		Namespace: DefaultOperandNamespace,
 		Name:      "router-" + ci.Name,
 	}
 }
@@ -90,7 +97,7 @@ func RouterOperatorGeneratedDefaultCertificateSecretName(ci *operatorv1.IngressC
 // RsyslogConfigMapName returns the namespaced name for the rsyslog configmap.
 func RsyslogConfigMapName(ic *operatorv1.IngressController) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress",
+		Namespace: DefaultOperandNamespace,
 		Name:      "rsyslog-conf-" + ic.Name,
 	}
 }
@@ -99,7 +106,7 @@ func RsyslogConfigMapName(ic *operatorv1.IngressController) types.NamespacedName
 // deployment's pod disruption budget.
 func RouterPodDisruptionBudgetName(ic *operatorv1.IngressController) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress",
+		Namespace: DefaultOperandNamespace,
 		Name:      "router-" + ic.Name,
 	}
 }
@@ -117,7 +124,7 @@ func RouterEffectiveDefaultCertificateSecretName(ci *operatorv1.IngressControlle
 // configmap with the service CA bundle.
 func ServiceCAConfigMapName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress",
+		Namespace: DefaultOperandNamespace,
 		Name:      "service-ca-bundle",
 	}
 }
@@ -136,22 +143,22 @@ func IngressControllerDeploymentPodSelector(ic *operatorv1.IngressController) *m
 
 func InternalIngressControllerServiceName(ic *operatorv1.IngressController) types.NamespacedName {
 	// TODO: remove hard-coded namespace
-	return types.NamespacedName{Namespace: "openshift-ingress", Name: "router-internal-" + ic.Name}
+	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-internal-" + ic.Name}
 }
 
 func IngressControllerServiceMonitorName(ic *operatorv1.IngressController) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress",
+		Namespace: DefaultOperandNamespace,
 		Name:      "router-" + ic.Name,
 	}
 }
 
 func LoadBalancerServiceName(ic *operatorv1.IngressController) types.NamespacedName {
-	return types.NamespacedName{Namespace: "openshift-ingress", Name: "router-" + ic.Name}
+	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-" + ic.Name}
 }
 
 func NodePortServiceName(ic *operatorv1.IngressController) types.NamespacedName {
-	return types.NamespacedName{Namespace: "openshift-ingress", Name: "router-nodeport-" + ic.Name}
+	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-nodeport-" + ic.Name}
 }
 
 func WildcardDNSRecordName(ic *operatorv1.IngressController) types.NamespacedName {
@@ -163,7 +170,7 @@ func WildcardDNSRecordName(ic *operatorv1.IngressController) types.NamespacedNam
 
 func CanaryDaemonSetName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress-canary",
+		Namespace: DefaultCanaryNamespace,
 		Name:      "ingress-canary",
 	}
 }
@@ -178,14 +185,14 @@ func CanaryDaemonSetPodSelector(canaryControllerName string) *metav1.LabelSelect
 
 func CanaryServiceName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress-canary",
+		Namespace: DefaultCanaryNamespace,
 		Name:      "ingress-canary",
 	}
 }
 
 func CanaryRouteName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-ingress-canary",
+		Namespace: DefaultCanaryNamespace,
 		Name:      "ingress-canary-route",
 	}
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -193,6 +193,6 @@ func CanaryServiceName() types.NamespacedName {
 func CanaryRouteName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: DefaultCanaryNamespace,
-		Name:      "ingress-canary-route",
+		Name:      "canary",
 	}
 }

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -116,7 +116,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	related := []configv1.ObjectReference{
 		{
 			Resource: "namespaces",
-			Name:     "openshift-ingress-operator",
+			Name:     r.Namespace,
 		},
 		{
 			Group:     operatorv1.GroupName,

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -56,7 +56,7 @@ var clock utilclock.Clock = utilclock.RealClock{}
 // and uses them to compute the operator status.
 func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	reconciler := &reconciler{
-		Config: config,
+		config: config,
 		client: mgr.GetClient(),
 		cache:  mgr.GetCache(),
 	}
@@ -80,7 +80,7 @@ type Config struct {
 // reconciler handles the actual status reconciliation logic in response to
 // events.
 type reconciler struct {
-	Config
+	config Config
 
 	client client.Client
 	cache  cache.Cache
@@ -116,17 +116,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	related := []configv1.ObjectReference{
 		{
 			Resource: "namespaces",
-			Name:     r.Namespace,
+			Name:     r.config.Namespace,
 		},
 		{
 			Group:     operatorv1.GroupName,
 			Resource:  "IngressController",
-			Namespace: r.Namespace,
+			Namespace: r.config.Namespace,
 		},
 		{
 			Group:     iov1.GroupVersion.Group,
 			Resource:  "DNSRecord",
-			Namespace: r.Namespace,
+			Namespace: r.config.Namespace,
 		},
 	}
 	if state.IngressNamespace != nil {
@@ -149,7 +149,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	co.Status.Versions = r.computeOperatorStatusVersions(oldStatus.Versions, allIngressesAvailable)
 
 	co.Status.Conditions = mergeConditions(co.Status.Conditions, computeOperatorAvailableCondition(allIngressesAvailable))
-	co.Status.Conditions = mergeConditions(co.Status.Conditions, computeOperatorProgressingCondition(allIngressesAvailable, oldStatus.Versions, co.Status.Versions, r.OperatorReleaseVersion, r.IngressControllerImage))
+	co.Status.Conditions = mergeConditions(co.Status.Conditions, computeOperatorProgressingCondition(allIngressesAvailable, oldStatus.Versions, co.Status.Versions, r.config.OperatorReleaseVersion, r.config.IngressControllerImage))
 	co.Status.Conditions = mergeConditions(co.Status.Conditions, computeOperatorDegradedCondition(state.IngressControllers))
 
 	if !operatorStatusesEqual(*oldStatus, co.Status) {
@@ -220,8 +220,8 @@ func (r *reconciler) getOperatorState(ingressNamespace, canaryNamespace string) 
 	}
 
 	ingressList := &operatorv1.IngressControllerList{}
-	if err := r.cache.List(context.TODO(), ingressList, client.InNamespace(r.Namespace)); err != nil {
-		return state, fmt.Errorf("failed to list ingresscontrollers in %q: %v", r.Namespace, err)
+	if err := r.cache.List(context.TODO(), ingressList, client.InNamespace(r.config.Namespace)); err != nil {
+		return state, fmt.Errorf("failed to list ingresscontrollers in %q: %v", r.config.Namespace, err)
 	} else {
 		state.IngressControllers = ingressList.Items
 	}
@@ -240,11 +240,11 @@ func (r *reconciler) computeOperatorStatusVersions(oldVersions []configv1.Operan
 	return []configv1.OperandVersion{
 		{
 			Name:    OperatorVersionName,
-			Version: r.OperatorReleaseVersion,
+			Version: r.config.OperatorReleaseVersion,
 		},
 		{
 			Name:    IngressControllerVersionName,
-			Version: r.IngressControllerImage,
+			Version: r.config.IngressControllerImage,
 		},
 	}
 }

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -471,7 +471,7 @@ func TestComputeOperatorStatusVersions(t *testing.T) {
 		}
 
 		r := &reconciler{
-			Config: Config{
+			config: Config{
 				OperatorReleaseVersion: tc.curVersions.operator,
 				IngressControllerImage: tc.curVersions.operand,
 			},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -61,8 +61,8 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		Scheme:    scheme,
 		NewCache: cache.MultiNamespacedCacheBuilder([]string{
 			config.Namespace,
-			manifests.DefaultOperandNamespace,
-			manifests.DefaultCanaryNamespace,
+			operatorcontroller.DefaultOperandNamespace,
+			operatorcontroller.DefaultCanaryNamespace,
 			operatorcontroller.GlobalMachineSpecifiedConfigNamespace,
 		}),
 		// Use a non-caching client everywhere. The default split client does not
@@ -103,7 +103,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	}
 
 	// Set up the certificate-publisher controller
-	if _, err := certpublishercontroller.New(mgr, config.Namespace, "openshift-ingress"); err != nil {
+	if _, err := certpublishercontroller.New(mgr, config.Namespace, operatorcontroller.DefaultOperandNamespace); err != nil {
 		return nil, fmt.Errorf("failed to create certificate-publisher controller: %v", err)
 	}
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -69,7 +70,7 @@ var (
 var kclient client.Client
 var dnsConfig configv1.DNS
 var infraConfig configv1.Infrastructure
-var operatorNamespace = manifests.DefaultOperatorNamespace
+var operatorNamespace = operatorcontroller.DefaultOperatorNamespace
 var defaultName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.DefaultIngressControllerName}
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This PR addresses several fixups from [NE-199 Phase 1](https://github.com/openshift/cluster-ingress-operator/pull/476) and [Phase 2](https://github.com/openshift/cluster-ingress-operator/pull/493). The most notable being the redundant e2e test code in `test/e2e/canary_test.go` (see the [BZ 1903165](https://bugzilla.redhat.com/show_bug.cgi?id=1903165)).

---

Previous PR comments that this PR addresses (in addition to the canary status e2e test cleanup):

https://github.com/openshift/cluster-ingress-operator/pull/493#issuecomment-737430978
https://github.com/openshift/cluster-ingress-operator/pull/476/files#r513779823
https://github.com/openshift/cluster-ingress-operator/pull/476/files#r513784808.

See individual commit messages for more details.