### PR TITLE
add loadBalancerSourceRanges as a preserved field

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -381,6 +381,7 @@ func loadBalancerServiceChanged(current, expected *corev1.Service, platform *con
 	// modified.
 	updated.Spec.ClusterIP = current.Spec.ClusterIP
 	updated.Spec.ExternalIPs = current.Spec.ExternalIPs
+	updated.Spec.LoadBalancerSourceRanges = current.Spec.LoadBalancerSourceRanges
 	updated.Spec.HealthCheckNodePort = current.Spec.HealthCheckNodePort
 	for i, updatedPort := range updated.Spec.Ports {
 		for _, currentPort := range current.Spec.Ports {

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -350,6 +350,13 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			expect: false,
 		},
 		{
+			description: "if .spec.loadBalancerSourceRanges changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.LoadBalancerSourceRanges = []string{"3.4.5.6/32"}
+			},
+			expect: false,
+		},
+		{
 			description: "if .spec.clusterIP changes",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.ClusterIP = "2.3.4.5"


### PR DESCRIPTION
Case 02819675

As an OCP customer
I want to be able to set loadBalancerSourceRanges in the ingress service
so that I can restrict internet ingress to trusted sources

After upgrading from 4.5.x to 4.6.x we found that `loadBalancerSourceRanges` is no longer preserved when we patch our `router-default` Service. This regression is blocking our ability to upgrade to 4.6 in production as we can not restrict internet access to our cluster ingress to trusted sources.

This was a previously recommended solution https://access.redhat.com/solutions/5158751 

It seems during the refactor https://github.com/openshift/cluster-ingress-operator/compare/release-4.5...openshift:release-4.6 only `ClusterIP`, `ExternalIPs` and `HealthCheckNodePort` were considered as fields that other controllers or users could modify. This PR would add `LoadBalancerSourceRanges` to that list for the existing use case above.

Would it be possible to accept this PR and backport it to 4.6?