### PR TITLE
Bug 1906508: test/e2e: Don't clobber err in TestHeaderNameCaseAdjust

### DIFF
--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -112,7 +112,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 		}
 	}()
 
-	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+	pollErr := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
 			Container: "curl",
 			Follow:    false,
@@ -148,7 +148,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 		}
 		return true, nil
 	})
-	if err != nil {
+	if pollErr != nil {
 		pod := &corev1.Pod{}
 		podName := types.NamespacedName{
 			Namespace: clientPod.Namespace,
@@ -166,6 +166,6 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 			t.Errorf("failed to get logs from pod %s: %v", clientPod.Name, err)
 		}
 
-		t.Fatalf("failed to observe the expected output: %v\nclient pod spec: %#v\nclient pod logs:\n%s", err, pod, logs)
+		t.Fatalf("failed to observe the expected output: %v\nclient pod spec: %#v\nclient pod logs:\n%s", pollErr, pod, logs)
 	}
 }


### PR DESCRIPTION
test/e2e/http_header_name_case_adjustment_test.go:
Fix TestHeaderNameCaseAdjust to properly output the error
from the polling loop (when applicable) by not overwriting
the commonly used `err` variable.

---

This is a trivial fix for the TestHeaderNameCaseAdjust test function added in https://github.com/openshift/cluster-ingress-operator/pull/496.