### PR TITLE
Bug 1908758: AWS: Set health check interval to 10s for NLBs

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -49,6 +49,9 @@ const (
 	// 5 and 300.
 	awsLBHealthCheckIntervalAnnotation = "service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"
 	awsLBHealthCheckIntervalDefault    = "5"
+	// Network Load Balancers require a health check interval of 10 or 30.
+	// See https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html
+	awsLBHealthCheckIntervalNLB = "10"
 
 	// awsLBHealthCheckTimeoutAnnotation is the amount of time, in seconds, during which no response
 	// means a failed AWS load balancer health check. The value must be less than the value of
@@ -252,9 +255,12 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.AWS != nil &&
 				ci.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.AWS.Type == operatorv1.AWSNetworkLoadBalancer {
 				service.Annotations[AWSLBTypeAnnotation] = AWSNLBAnnotation
+				// NLBs require a different health check interval than CLBs
+				service.Annotations[awsLBHealthCheckIntervalAnnotation] = awsLBHealthCheckIntervalNLB
+			} else {
+				service.Annotations[awsLBHealthCheckIntervalAnnotation] = awsLBHealthCheckIntervalDefault
 			}
 			// Set the load balancer for AWS to be as aggressive as Azure (2 fail @ 5s interval, 2 healthy)
-			service.Annotations[awsLBHealthCheckIntervalAnnotation] = awsLBHealthCheckIntervalDefault
 			service.Annotations[awsLBHealthCheckTimeoutAnnotation] = awsLBHealthCheckTimeoutDefault
 			service.Annotations[awsLBHealthCheckUnhealthyThresholdAnnotation] = awsLBHealthCheckUnhealthyThresholdDefault
 			service.Annotations[awsLBHealthCheckHealthyThresholdAnnotation] = awsLBHealthCheckHealthyThresholdDefault

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -223,9 +223,6 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 				}
 			}
 			if tc.strategyType == operatorv1.LoadBalancerServiceStrategyType {
-				if err := checkServiceHasAnnotation(svc, awsLBHealthCheckIntervalAnnotation, true, awsLBHealthCheckIntervalDefault); err != nil {
-					t.Errorf("annotation check for test %q failed: %v", tc.description, err)
-				}
 				if err := checkServiceHasAnnotation(svc, awsLBHealthCheckTimeoutAnnotation, true, awsLBHealthCheckTimeoutDefault); err != nil {
 					t.Errorf("annotation check for test %q failed: %v", tc.description, err)
 				}
@@ -238,10 +235,16 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 				classicLB := tc.lbStrategy.ProviderParameters == nil || tc.lbStrategy.ProviderParameters.AWS.Type == operatorv1.AWSClassicLoadBalancer
 				switch {
 				case classicLB:
+					if err := checkServiceHasAnnotation(svc, awsLBHealthCheckIntervalAnnotation, true, awsLBHealthCheckIntervalDefault); err != nil {
+						t.Errorf("annotation check for test %q failed: %v", tc.description, err)
+					}
 					if err := checkServiceHasAnnotation(svc, awsLBProxyProtocolAnnotation, true, "*"); err != nil {
 						t.Errorf("annotation check for test %q failed: %v", tc.description, err)
 					}
 				case tc.lbStrategy.ProviderParameters.AWS.Type == operatorv1.AWSNetworkLoadBalancer:
+					if err := checkServiceHasAnnotation(svc, awsLBHealthCheckIntervalAnnotation, true, awsLBHealthCheckIntervalNLB); err != nil {
+						t.Errorf("annotation check for test %q failed: %v", tc.description, err)
+					}
 					if err := checkServiceHasAnnotation(svc, AWSLBTypeAnnotation, true, AWSNLBAnnotation); err != nil {
 						t.Errorf("annotation check for test %q failed: %v", tc.description, err)
 					}


### PR DESCRIPTION
Set the health check interval to 10s for NLBs to resolve the following error made visible in our operator e2e tests after the 1.20 rebase.

```
Error syncing load balancer: failed to ensure load balancer: error creating load balancer target group: \"ValidationError: Health check interval '5' not supported for target groups with the TCP protocol. Must be one of the following values '[10, 30]'"
```