### PR TITLE
Cleanup: Canary histogram adjustments + move DefaultIngressControllerName const

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -65,10 +65,6 @@ const (
 	// operator has ensured it's safe for deletion to proceeed.
 	DNSRecordFinalizer = "operator.openshift.io/ingress-dns"
 
-	// DefaultIngressControllerName is the name of the default IngressController
-	// instance.
-	DefaultIngressControllerName = "default"
-
 	NamespaceManifest                = "manifests/00-namespace.yaml"
 	CustomResourceDefinitionManifest = "manifests/00-custom-resource-definition.yaml"
 )

--- a/pkg/operator/controller/canary/controller.go
+++ b/pkg/operator/controller/canary/controller.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -76,7 +75,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 
 	// trigger reconcile requests for the canary controller via events for the default ingress controller.
 	defaultIcPredicate := predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
-		return meta.GetName() == manifests.DefaultIngressControllerName
+		return meta.GetName() == operatorcontroller.DefaultIngressControllerName
 	})
 
 	if err := c.Watch(&source.Kind{Type: &operatorv1.IngressController{}}, &handler.EnqueueRequestForObject{}, defaultIcPredicate); err != nil {
@@ -119,7 +118,7 @@ func enqueueRequestForDefaultIngressController(namespace string) handler.EventHa
 				{
 					NamespacedName: types.NamespacedName{
 						Namespace: namespace,
-						Name:      manifests.DefaultIngressControllerName,
+						Name:      operatorcontroller.DefaultIngressControllerName,
 					},
 				},
 			}
@@ -322,7 +321,7 @@ func (r *reconciler) setCanaryPassingStatusCondition() error {
 func (r *reconciler) setCanaryStatusCondition(cond operatorv1.OperatorCondition) error {
 	ic := &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      manifests.DefaultIngressControllerName,
+			Name:      operatorcontroller.DefaultIngressControllerName,
 			Namespace: r.config.Namespace,
 		},
 	}

--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -99,16 +99,13 @@ func probeRouteEndpoint(route *routev1.Route) error {
 
 	// Check status code
 	switch status := response.StatusCode; status {
-	case 200:
+	case http.StatusOK:
 		// Register total time in metrics (use milliseconds)
 		CanaryRequestTime.WithLabelValues(route.Spec.Host).Observe(float64(totalTime.Milliseconds()))
-	case 408:
+	case http.StatusRequestTimeout:
 		return fmt.Errorf("status code %d: request timed out", status)
-	case 503:
+	case http.StatusServiceUnavailable:
 		return fmt.Errorf("status code %d: Canary route not available via router", status)
-	// TODO (sgreene):
-	// Add more specific status code checks, if any are missing.
-	// Also, use HTTP status code constants, if available.
 	default:
 		return fmt.Errorf("unexpected status code: %d", status)
 	}

--- a/pkg/operator/controller/canary/metrics.go
+++ b/pkg/operator/controller/canary/metrics.go
@@ -14,7 +14,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "ingress_canary_check_duration",
 			Help:    "Canary endpoint request time in ms",
-			Buckets: []float64{25, 50, 100, 200, 400, 800, 1600},
+			Buckets: []float64{5, 10, 25, 50, 100, 250, 500, 1000},
 		}, []string{"host"})
 
 	CanaryEndpointWrongPortEcho = prometheus.NewCounter(

--- a/pkg/operator/controller/canary/route.go
+++ b/pkg/operator/controller/canary/route.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -155,7 +156,7 @@ func desiredCanaryRoute(service *corev1.Service) (*routev1.Route, error) {
 // by the default Ingress Controller.
 func checkRouteAdmitted(route *routev1.Route) bool {
 	for _, routeIngress := range route.Status.Ingress {
-		if routeIngress.RouterName != manifests.DefaultIngressControllerName {
+		if routeIngress.RouterName != operatorcontroller.DefaultIngressControllerName {
 			continue
 		}
 		conditions := routeIngress.Conditions

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -77,6 +77,25 @@ func TestDesiredCanaryRoute(t *testing.T) {
 	}
 }
 
+func TestDesiredCanaryRouteWithInvalidService(t *testing.T) {
+	daemonsetRef := metav1.OwnerReference{
+		Name: "test",
+	}
+
+	_, err := desiredCanaryRoute(nil)
+	if err == nil {
+		t.Errorf("expected desiredCanaryService to return an error when the parameter service is nil")
+	}
+
+	service := desiredCanaryService(daemonsetRef)
+	service.Spec.Ports = nil
+
+	_, err = desiredCanaryRoute(service)
+	if err == nil {
+		t.Errorf("expected desiredCanaryService to return an error when the parameter service has empty spec.ports")
+	}
+}
+
 func TestCanaryRouteChanged(t *testing.T) {
 	testCases := []struct {
 		description string

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -112,7 +112,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// In an operator maintained cluster, this is always `oc get -n openshift-ingress-operator ingresscontroller/default`, skip the rest and return here.
 	// TODO if network-edge wishes to expand the scope of the CA bundle (and you could legitimately see a need/desire to have one CA that verifies all ingress traffic).
 	// TODO this could be accomplished using union logic similar to the kube-apiserver's join of multiple CAs.
-	if ingress == nil || ingress.Namespace != operatorcontroller.DefaultOperatorNamespace || ingress.Name != "default" {
+	if ingress == nil || ingress.Namespace != operatorcontroller.DefaultOperatorNamespace || ingress.Name != operatorcontroller.DefaultIngressControllerName {
 		return result, utilerrors.NewAggregate(errs)
 	}
 

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -689,7 +689,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 
 	pods := &corev1.PodList{}
 	if err := r.cache.List(context.TODO(), pods, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
-		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
+		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperandNamespace, err))
 	}
 
 	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig))

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	iov1 "github.com/openshift/api/operatoringress/v1"
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/retryableerror"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -475,7 +475,7 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition, 
 
 	// Only check the default ingress controller for the canary
 	// success status condition.
-	if icName == manifests.DefaultIngressControllerName {
+	if icName == operatorcontroller.DefaultIngressControllerName {
 		canaryCond := struct {
 			condition        string
 			status           operatorv1.ConditionStatus

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -36,6 +36,10 @@ const (
 	// DefaultCanaryNamespace is the default namespace for
 	// the ingress canary check resources.
 	DefaultCanaryNamespace = "openshift-ingress-canary"
+
+	// DefaultIngressControllerName is the name of the default IngressController
+	// instance.
+	DefaultIngressControllerName = "default"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorconfig "github.com/openshift/cluster-ingress-operator/pkg/operator/config"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -169,7 +168,7 @@ func (o *Operator) Start(stop <-chan struct{}) error {
 // ensureDefaultIngressController creates the default ingresscontroller if it
 // doesn't already exist.
 func (o *Operator) ensureDefaultIngressController() error {
-	name := types.NamespacedName{Namespace: o.namespace, Name: manifests.DefaultIngressControllerName}
+	name := types.NamespacedName{Namespace: o.namespace, Name: operatorcontroller.DefaultIngressControllerName}
 	ic := &operatorv1.IngressController{}
 	if err := o.client.Get(context.TODO(), name, ic); err == nil {
 		return nil
@@ -192,8 +191,8 @@ func (o *Operator) ensureDefaultIngressController() error {
 	}
 	ic = &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
+			Name:      operatorcontroller.DefaultIngressControllerName,
+			Namespace: o.namespace,
 		},
 		Spec: operatorv1.IngressControllerSpec{
 			Replicas: &replicas,

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -25,7 +25,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	iov1 "github.com/openshift/api/operatoringress/v1"
-	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -73,7 +72,7 @@ var kclient client.Client
 var dnsConfig configv1.DNS
 var infraConfig configv1.Infrastructure
 var operatorNamespace = operatorcontroller.DefaultOperatorNamespace
-var defaultName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.DefaultIngressControllerName}
+var defaultName = types.NamespacedName{Namespace: operatorNamespace, Name: operatorcontroller.DefaultIngressControllerName}
 
 func TestMain(m *testing.M) {
 	kubeConfig, err := config.GetConfig()


### PR DESCRIPTION
**canary: Adjust canary request latency histogram** 

pkg/operator/controller/canary/http.go:
Previously, the `ingress_canary_check_duration`
histogram metric had the following buckets:

{25, 50, 100, 200, 400, 800, 1600}

AWS CI clusters typically experience a canary request latency somewhere
in the neighborhood of 15-20 ms.

This commit changes the canary check latency metric to use more precise
and appropriate bucket values:

{5, 10, 25, 50, 100, 250, 500, 1000}

This will enable cluster administrators to take advantage of the
canary histogram values, since the latency values will actually fall
into specific buckets, rather than every bucket.

---

**cleanup: Move DefaultIngressControllerName const**

Move the DefaultIngressControllerName const from
pkg/manifests/manifests.go to pkg/operator/controller/names.go.


Replace all references to `manifests.DefaultIngressControllerName` with
`operatorcontroller.DefaultIngressControllerName`.


