### PR TITLE
Bug 1912922: default_cert.go: Handle redundantly specified default certificate

### DIFF
--- a/pkg/operator/controller/certificate/default_cert.go
+++ b/pkg/operator/controller/certificate/default_cert.go
@@ -73,9 +73,12 @@ func desiredRouterDefaultCertificateSecret(ca *crypto.CA, namespace string, depl
 		return false, nil, nil
 	}
 
+	name := controller.RouterOperatorGeneratedDefaultCertificateSecretName(ci, namespace)
+
 	// If the ingresscontroller specifies a default certificate secret, the
-	// operator does not need to generate a certificate.
-	if ci.Spec.DefaultCertificate != nil {
+	// operator does not need to generate a certificate, unless the specified
+	// secret name redundantly corresponds to the operator generated secret.
+	if ci.Spec.DefaultCertificate != nil && ci.Spec.DefaultCertificate.Name != name.Name {
 		return false, nil, nil
 	}
 
@@ -90,7 +93,6 @@ func desiredRouterDefaultCertificateSecret(ca *crypto.CA, namespace string, depl
 		return false, nil, fmt.Errorf("failed to encode certificate: %v", err)
 	}
 
-	name := controller.RouterOperatorGeneratedDefaultCertificateSecretName(ci, namespace)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.Name,

--- a/pkg/operator/controller/certificate/default_cert_test.go
+++ b/pkg/operator/controller/certificate/default_cert_test.go
@@ -1,0 +1,136 @@
+package certificate
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/crypto"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// cert is a PEM-encoded certificate.
+	cert = `-----BEGIN CERTIFICATE-----
+MIIDIjCCAgqgAwIBAgIBBjANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
+ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
+dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
+Y29tMB4XDTE2MDExMzE5NDA1N1oXDTI2MDExMDE5NDA1N1owfDEYMBYGA1UEAxMP
+d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIEwJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
+hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoTB0V4YW1wbGUx
+EDAOBgNVBAsTB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM0B
+u++oHV1wcphWRbMLUft8fD7nPG95xs7UeLPphFZuShIhhdAQMpvcsFeg+Bg9PWCu
+v3jZljmk06MLvuWLfwjYfo9q/V+qOZVfTVHHbaIO5RTXJMC2Nn+ACF0kHBmNcbth
+OOgF8L854a/P8tjm1iPR++vHnkex0NH7lyosVc/vAgMBAAGjDTALMAkGA1UdEwQC
+MAAwDQYJKoZIhvcNAQEFBQADggEBADjFm5AlNH3DNT1Uzx3m66fFjqqrHEs25geT
+yA3rvBuynflEHQO95M/8wCxYVyuAx4Z1i4YDC7tx0vmOn/2GXZHY9MAj1I8KCnwt
+Jik7E2r1/yY0MrkawljOAxisXs821kJ+Z/51Ud2t5uhGxS6hJypbGspMS7OtBbw7
+8oThK7cWtCXOldNF6ruqY1agWnhRdAq5qSMnuBXuicOP0Kbtx51a1ugE3SnvQenJ
+nZxdtYUXvEsHZC/6bAtTfNh+/SwgxQJuL2ZM+VG3X2JIKY8xTDui+il7uTh422lq
+wED8uwKl+bOj6xFDyw4gWoBxRobsbFaME8pkykP1+GnKDberyAM=
+-----END CERTIFICATE-----
+`
+	// key is a PEM-encoded private key.
+	key = `-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDNAbvvqB1dcHKYVkWzC1H7fHw+5zxvecbO1Hiz6YRWbkoSIYXQ
+EDKb3LBXoPgYPT1grr942ZY5pNOjC77li38I2H6Pav1fqjmVX01Rx22iDuUU1yTA
+tjZ/gAhdJBwZjXG7YTjoBfC/OeGvz/LY5tYj0fvrx55HsdDR+5cqLFXP7wIDAQAB
+AoGAfE7P4Zsj6zOzGPI/Izj7Bi5OvGnEeKfzyBiH9Dflue74VRQkqqwXs/DWsNv3
+c+M2Y3iyu5ncgKmUduo5X8D9To2ymPRLGuCdfZTxnBMpIDKSJ0FTwVPkr6cYyyBk
+5VCbc470pQPxTAAtl2eaO1sIrzR4PcgwqrSOjwBQQocsGAECQQD8QOra/mZmxPbt
+bRh8U5lhgZmirImk5RY3QMPI/1/f4k+fyjkU5FRq/yqSyin75aSAXg8IupAFRgyZ
+W7BT6zwBAkEA0A0ugAGorpCbuTa25SsIOMxkEzCiKYvh0O+GfGkzWG4lkSeJqGME
+keuJGlXrZNKNoCYLluAKLPmnd72X2yTL7wJARM0kAXUP0wn324w8+HQIyqqBj/gF
+Vt9Q7uMQQ3s72CGu3ANZDFS2nbRZFU5koxrggk6lRRk1fOq9NvrmHg10AQJABOea
+pgfj+yGLmkUw8JwgGH6xCUbHO+WBUFSlPf+Y50fJeO+OrjqPXAVKeSV3ZCwWjKT4
+9viXJNJJ4WfF0bO/XwJAOMB1wQnEOSZ4v+laMwNtMq6hre5K8woqteXICoGcIWe8
+u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
+-----END RSA PRIVATE KEY-----
+`
+)
+
+func TestDesiredRouterDefaultCertificateSecret(t *testing.T) {
+	ca, err := crypto.GetCAFromBytes([]byte(cert), []byte(key))
+	if err != nil {
+		t.Fatalf("failed to create CA")
+	}
+
+	testCases := []struct {
+		description string
+		ic          *operatorv1.IngressController
+		wantCert    bool
+	}{
+		{
+			description: "want operator generated default certificate",
+			ic: &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "test.com",
+				},
+			},
+			wantCert: true,
+		},
+		{
+			description: "domain not set",
+			ic: &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+			wantCert: false,
+		},
+		{
+			description: "do not want operator generated default certificate",
+			ic: &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: operatorv1.IngressControllerSpec{
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: "my-cert",
+					},
+				},
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "test.com",
+				},
+			},
+			wantCert: false,
+		},
+		{
+			description: "specify operated generated default certificate in ingress controller",
+			ic: &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: operatorv1.IngressControllerSpec{
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: "router-certs-default",
+					},
+				},
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "test.com",
+				},
+			},
+			wantCert: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		wantCert, _, err := desiredRouterDefaultCertificateSecret(ca, "test-namespace", metav1.OwnerReference{Name: "test-ref"}, tc.ic)
+		if err != nil {
+			t.Fatalf("%s, unexpected error: %v", tc.description, err)
+		}
+		if tc.wantCert {
+			if !wantCert {
+				t.Fatalf("%s, expected a default certificate", tc.description)
+			}
+		} else if wantCert {
+			t.Fatalf("%s, expected no default certificate", tc.description)
+		}
+	}
+}


### PR DESCRIPTION
**pkg/operator/controller/certificate/default_certificate.go:**
If an ingress controller has the Spec.DefaultCertificate field set to the name of the operator generated default certificate, use/create the operator generated default certificate rather than delete it.

This commit resolves BZ#1912922 by enhancing `desiredRouterDefaultCertificateSecret` to explicitly check if `Spec.DefaultCertificate` is set to the same name as the operator generated default certificate before returning a false value
 ndicating that an operator generated default certificate is not desired.
 
 **pkg/operator/controller/certificate/default_cert_test.go:**
Add unit test for `desiredRouterDefaultCertificateSecret`.