### PR TITLE
Bug 1915079: Disable canary route churn by default

### DIFF
--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -5,14 +5,19 @@ package e2e
 import (
 	"bufio"
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	canarycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -141,4 +146,85 @@ func buildCanaryCurlPod(name, namespace, image, host string) *corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
+}
+
+// TestCanaryRouteRotationAnnotation verifies that the
+// canary controller respects the canary route rotation
+// annotation for the default ingress controller.
+//
+// Note that this test will mutate the default ingress controller
+func TestCanaryRouteRotationAnnotation(t *testing.T) {
+	// Set the CanaryRouteRotation annotation to true
+	// on the default ingress controller.
+	if err := setDefaultIngressControllerRotationAnnotation(t, true); err != nil {
+		t.Fatalf("failed to set canary route rotation annotation: %v", err)
+	}
+
+	// Cleanup default ingress controller by setting the canary rotation
+	// annotation to false (and verifying that we were successful in doing so).
+	defer func() {
+		if err := setDefaultIngressControllerRotationAnnotation(t, false); err != nil {
+			t.Fatalf("failed to set canary route rotation annotation: %v", err)
+		}
+	}()
+
+	// Get canary route.
+	canaryRoute := &routev1.Route{}
+	name := controller.CanaryRouteName()
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), name, canaryRoute); err != nil {
+			t.Logf("failed to get canary route %s: %v", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		t.Fatalf("failed to observe canary route: %v", err)
+	}
+
+	// The canary controller should update the canary route after 5 successful
+	// canary checks. Canary checks happen once a minute.
+	updatedCanaryRoute := &routev1.Route{}
+	err = wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), name, updatedCanaryRoute); err != nil {
+			t.Logf("failed to get canary route %s: %v", name, err)
+			return false, nil
+		}
+		// If the canaryRoute and updatedCanaryRoute do not have the same targetPort,
+		// then the canary route rotation annotation is working.
+		if cmp.Equal(canaryRoute.Spec.Port.TargetPort, updatedCanaryRoute.Spec.Port.TargetPort) {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		t.Fatalf("failed to observe canary route rotation: %v", err)
+	}
+}
+
+func setDefaultIngressControllerRotationAnnotation(t *testing.T, val bool) error {
+	t.Helper()
+	ic := &operatorv1.IngressController{}
+	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), defaultName, ic); err != nil {
+			t.Logf("Get failed: %v, retrying...", err)
+			return false, nil
+		}
+		if ic.Annotations == nil {
+			ic.Annotations = map[string]string{}
+		}
+		ic.Annotations[canarycontroller.CanaryRouteRotationAnnotation] = strconv.FormatBool(val)
+		if err := kclient.Update(context.TODO(), ic); err != nil {
+			t.Logf("failed to update ingress controller: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("failed to update ingress controller: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**canary: Disable canary route rotation by default**

Forcing the router to reload every 5 minutes for canary testing has a
heavy performance impact for larger clusters. By default, disable the
canary route rotation logic. Canary route rotation can be enabled for
internal use or debugging by setting the new
"ingress.operator.openshift.io/rotate-canary-route" annotation to
"true" on the default ingress controller.

pkg/operator/controller/canary/controller.go:
Add a mutex to the canary controller's reconciler type
to make the new reconciler `enableCanaryRouteRotation` field
go-routine safe. Set this field to true when the default ingress
controller has the new  canary route rotation annotation
set to true. Use this field in the canary check polling loop
to determine if the canary route endpoint should be rotated.

---

**test/e2e: Add canary route rotation annotation test**

test/e2e/canary_test.go: Add an e2e test to verify
that annotating the default ingress controller with the
canary route rotation annotation works as intended.