### PR TITLE
Bug 1905778: Fix inconsistent ingress operator status after upgrade

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -230,9 +230,9 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// TODO: remove this fix-up logic in 4.8
 	if ingress.Status.EndpointPublishingStrategy != nil && ingress.Status.EndpointPublishingStrategy.Type == operatorv1.LoadBalancerServiceStrategyType && ingress.Status.EndpointPublishingStrategy.LoadBalancer == nil {
-		log.Info("EndpointPublishingStrategy missing LoadBalancer")
-		// set loadbalancer to external
+		log.Info("Setting default value for empty status.endpointPublishingStrategy.loadBalancer field", "ingresscontroller", ingress)
 		ingress.Status.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
 			Scope: operatorv1.ExternalLoadBalancer,
 		}

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -66,6 +66,7 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, degradedCondition)
+	updated.Status.Conditions = PruneConditions(updated.Status.Conditions)
 
 	if !IngressStatusesEqual(updated.Status, ic.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
@@ -102,6 +103,18 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 		}
 	}
 	conditions = append(conditions, additions...)
+	return conditions
+}
+
+// PruneConditions removes any conditions that are not currently supported.
+// Returns the updated condition array.
+func PruneConditions(conditions []operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
+	for i, condition := range conditions {
+		if condition.Type == "DeploymentDegraded" {
+			// DeploymentDegraded was removed in 4.6.0
+			conditions = append(conditions[:i], conditions[i+1:]...)
+		}
+	}
 	return conditions
 }
 

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -110,6 +110,7 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 // Returns the updated condition array.
 func PruneConditions(conditions []operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
 	for i, condition := range conditions {
+		// TODO: Remove this fix-up logic in 4.8
 		if condition.Type == "DeploymentDegraded" {
 			// DeploymentDegraded was removed in 4.6.0
 			conditions = append(conditions[:i], conditions[i+1:]...)


### PR DESCRIPTION
`status.DeploymentDegraded` was removed in favor of several more specific status fields in 4.6, but if the cluster was upgraded from 4.5 or earlier, the existing `DeploymentDegraded` status will continue to be reported

If the cluster was upgraded from 4.1 or earlier, `status.EndpointPublishingStrategy.LoadBalancer` (introduced in 4.2?) may not be present when `status.EndpointPublishingStrategy.Type` is set to `LoadBalancerService`. Internally, the assumption is made that this is equivalent to `status.EndpointPublishingStrategy.LoadBalancer` being set to `.LoadBalancer.scope: External`, but this PR makes that implicit assumption explicit.
