### PR TITLE
Bug 1916401: DNS: Skip deleting records that were not published.

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -322,6 +322,11 @@ func (r *reconciler) delete(record *iov1.DNSRecord) error {
 	var errs []error
 	for i := range record.Status.Zones {
 		zone := record.Status.Zones[i].DNSZone
+		// If the record is currently not published in a zone,
+		// skip deleting it for that zone.
+		if !recordIsAlreadyPublishedToZone(record, &zone) {
+			continue
+		}
 		err := r.dnsProvider.Delete(record, zone)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
**pkg/operator/controller/dns/controller.go:**

When deleting DNS records from the provider, only delete records that
have been successfully published by the provider. This resolves
BZ#1916401, in which an ingress controller created with a domain
that refers to a non-existent zone cannot be deleted. If the provider
failed to publish the DNS record, it will also fail to delete it.
It is safe to delete a DNSRecord resource in the cluster when the record
does not exist in the provider, since no upstream record needs to be
deleted first.

---