### PR TITLE
Bug 1917942: canary: Check canary service for nil elements

### DIFF
--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -19,7 +19,11 @@ func TestDesiredCanaryRoute(t *testing.T) {
 		Name: "test",
 	}
 	service := desiredCanaryService(daemonsetRef)
-	route := desiredCanaryRoute(service)
+	route, err := desiredCanaryRoute(service)
+
+	if err != nil {
+		t.Fatalf("desiredCanaryService returned an error: %v", err)
+	}
 
 	expectedRouteName := types.NamespacedName{
 		Namespace: "openshift-ingress-canary",
@@ -106,7 +110,10 @@ func TestCanaryRouteChanged(t *testing.T) {
 	service := desiredCanaryService(daemonsetRef)
 
 	for _, tc := range testCases {
-		original := desiredCanaryRoute(service)
+		original, err := desiredCanaryRoute(service)
+		if err != nil {
+			t.Fatalf("desiredCanaryService returned an error: %v", err)
+		}
 		mutated := original.DeepCopy()
 		tc.mutate(mutated)
 		if changed, updated := canaryRouteChanged(original, mutated); changed != tc.expect {


### PR DESCRIPTION
**pkg/operator/controller/canary/route.go:** 
Check that the canary service is not nil and that the canary service has a non-empty spec.ports field when building the canary route via `desiredCanaryRoute` to avoid nil dereferences.

**pkg/operator/controller/canary/route_test.go:** 
Ensure `desiredCanaryRoute` does not return any errors.

---

These changes resolve [BZ 1917942](https://bugzilla.redhat.com/show_bug.cgi?id=1917942), in which canary controller panic's were observed in OpenShift CI.