### PR TITLE
[release-4.6] Bug 1921193: Fix inconsistent ingress operator status after upgrade

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -228,9 +228,9 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// TODO: remove this fix-up logic in 4.8
 	if ingress.Status.EndpointPublishingStrategy != nil && ingress.Status.EndpointPublishingStrategy.Type == operatorv1.LoadBalancerServiceStrategyType && ingress.Status.EndpointPublishingStrategy.LoadBalancer == nil {
-		log.Info("EndpointPublishingStrategy missing LoadBalancer")
-		// set loadbalancer to external
+		log.Info("Setting default value for empty status.endpointPublishingStrategy.loadBalancer field", "ingresscontroller", ingress)
 		ingress.Status.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
 			Scope: operatorv1.ExternalLoadBalancer,
 		}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -228,6 +228,18 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	if ingress.Status.EndpointPublishingStrategy != nil && ingress.Status.EndpointPublishingStrategy.Type == operatorv1.LoadBalancerServiceStrategyType && ingress.Status.EndpointPublishingStrategy.LoadBalancer == nil {
+		log.Info("EndpointPublishingStrategy missing LoadBalancer")
+		// set loadbalancer to external
+		ingress.Status.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+			Scope: operatorv1.ExternalLoadBalancer,
+		}
+		if err := r.client.Status().Update(context.TODO(), ingress); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to update status: %v", err)
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// The ingresscontroller is safe to process, so ensure it.
 	if err := r.ensureIngressController(ingress, dnsConfig, infraConfig, ingressConfig, apiConfig, networkConfig); err != nil {
 		switch e := err.(type) {

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -98,6 +98,7 @@ func mergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 // Returns the updated condition array.
 func PruneConditions(conditions []operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
 	for i, condition := range conditions {
+		// TODO: Remove this fix-up logic in 4.8
 		if condition.Type == "DeploymentDegraded" {
 			// DeploymentDegraded was removed in 4.6.0
 			conditions = append(conditions[:i], conditions[i+1:]...)


### PR DESCRIPTION
4.6 backport of #526 

`status.DeploymentDegraded` was removed in favor of several more specific status fields in 4.6, but if the cluster was upgraded from 4.5 or earlier, the existing `DeploymentDegraded` status will continue to be reported

If the cluster was upgraded from 4.1 or earlier, `status.EndpointPublishingStrategy.LoadBalancer` (introduced in 4.2?) may not be present when `status.EndpointPublishingStrategy.Type` is set to `LoadBalancerService`. Internally, the assumption is made that this is equivalent to `status.EndpointPublishingStrategy.LoadBalancer` being set to `.LoadBalancer.scope: External`, but this PR makes that implicit assumption explicit.
