### PR TITLE
Bug 1925245: Verify that Serivce resources have idle annotations from corresponding Endpoint resources, should they exist.

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,8 +17,14 @@ import (
 	canarycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
 )
 
 const (
@@ -88,6 +95,20 @@ func start(opts *StartOptions) error {
 
 	if opts.ReleaseVersion == statuscontroller.UnknownVersionValue {
 		log.Info("Warning: no release version is specified", "release version", statuscontroller.UnknownVersionValue)
+	}
+
+	// verify that all idled services have the correct idle annotations
+	// mirrored over from the corresponding endpoints resources.
+	// This is to ensure that applications idled with an older version of oc
+	// (and thus do not have the idle annotations on the service) are still
+	// safely un-idleable afer an upgrade that affects `oc idle` functionality.
+	// use a single-use client here separate from the client used by the operator.
+	cl, err := client.New(kubeConfig, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create client from kube config: %v", kubeConfig)
+	}
+	if err := ensureServicesHaveIdleAnnotation(cl); err != nil {
+		log.Error(err, "failed to verify idling endpoints between endpoints and services")
 	}
 
 	// Set up the channels for the watcher, operator, and metrics.
@@ -167,4 +188,55 @@ func start(opts *StartOptions) error {
 		return fmt.Errorf("failed to create operator: %v", err)
 	}
 	return op.Start(stop)
+}
+
+func ensureServicesHaveIdleAnnotation(cl client.Client) error {
+	endpointsList := &corev1.EndpointsList{}
+	err := cl.List(context.TODO(), endpointsList, &client.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list endpoints in all namespaces: %v", err)
+	}
+
+	for _, endpoints := range endpointsList.Items {
+		idledAt, haveIdledAt := endpoints.Annotations[unidlingapi.IdledAtAnnotation]
+		unidleTarget, haveUnidleTarget := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
+		// If the endpoints don't have the idle annotations, continue since we aren't idled.
+		if !haveIdledAt || !haveUnidleTarget {
+			continue
+		}
+		service := &corev1.Service{}
+		serviceName := types.NamespacedName{
+			Name:      endpoints.Name,
+			Namespace: endpoints.Namespace,
+		}
+		if err := cl.Get(context.TODO(), serviceName, service); err != nil {
+			log.Error(err, "failed to get service for endpoints", "namespace", service.Namespace, "name", service.Name)
+			continue
+		}
+
+		_, haveIdledAt = service.Annotations[unidlingapi.IdledAtAnnotation]
+		_, haveUnidleTarget = service.Annotations[unidlingapi.UnidleTargetAnnotation]
+		// If the service already has the correct annotations, continue.
+		if haveIdledAt && haveUnidleTarget {
+			continue
+		}
+
+		annotations := service.Annotations
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[unidlingapi.IdledAtAnnotation] = idledAt
+		annotations[unidlingapi.UnidleTargetAnnotation] = unidleTarget
+		updated := service.DeepCopy()
+		updated.Annotations = annotations
+
+		if err := cl.Update(context.TODO(), updated); err != nil {
+			log.Error(err, "failed to update service to have endpoint idling annotations", "namespace", updated.Namespace, "name", updated.Name)
+			continue
+		}
+
+		log.Info("added idle annotations from endpoint to service", "namespace", updated.Namespace, "name", updated.Name)
+	}
+
+	return nil
 }

--- a/vendor/github.com/openshift/api/unidling/v1alpha1/types.go
+++ b/vendor/github.com/openshift/api/unidling/v1alpha1/types.go
@@ -1,0 +1,43 @@
+package v1alpha1
+
+const (
+	// IdledAtAnnotation indicates that a given object (endpoints or scalable object))
+	// is currently idled (and the time at which it was idled)
+	IdledAtAnnotation = "idling.alpha.openshift.io/idled-at"
+
+	// UnidleTargetAnnotation contains the references and former scales for the scalable
+	// objects associated with the idled endpoints
+	UnidleTargetAnnotation = "idling.alpha.openshift.io/unidle-targets"
+
+	// PreviousScaleAnnotation contains the previous scale of a scalable object
+	// (currently only applied by the idler)
+	PreviousScaleAnnotation = "idling.alpha.openshift.io/previous-scale"
+
+	// NeedPodsReason is the reason for the event emitted to indicate that endpoints should be unidled
+	NeedPodsReason = "NeedPods"
+)
+
+// NB: if these get changed, you'll need to actually add in the full API machinery for them
+
+// RecordedScaleReference is a CrossGroupObjectReference to a scale subresource that also
+// has the previous replica count recorded
+type RecordedScaleReference struct {
+	// Reference to the idled resource
+	CrossGroupObjectReference `json:",inline" protobuf:"bytes,1,opt,name=crossVersionObjectReference"`
+	// The last seen scale of the idled resource (before idling)
+	Replicas int32 `json:"replicas" protobuf:"varint,2,opt,name=replicas"`
+}
+
+// CrossGroupObjectReference is a reference to an object in the same
+// namespace in the specified group.  It is similar to
+// autoscaling.CrossVersionObjectReference.
+type CrossGroupObjectReference struct {
+	// Kind of the referent; More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds"
+	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
+	// Name of the referent; More info: http://releases.k8s.io/release-1.3/docs/user-guide/identifiers.md#names
+	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
+	// API version of the referent (deprecated, prefer usng Group instead)
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
+	// Group of the referent
+	Group string `json:"group,omitempty" protobuf:"bytes,3,opt,name=group"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,6 +161,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operatoringress/v1
 github.com/openshift/api/route/v1
+github.com/openshift/api/unidling/v1alpha1
 # github.com/openshift/library-go v0.0.0-20200423123937-d1360419413d
 ## explicit
 github.com/openshift/library-go/pkg/crypto


### PR DESCRIPTION
**operator.go: Add endpoint/service idle annotations check**

pkg/operator/operator.go:

Add a new function, `ensureServicesHaveIdledAnnotation(...)` that
mirrors over any idling annotations from endpoint resources when the
idling annotations are not present on the corresponding service. Call
this function during the operator start up logic so that it only runs
once (rather than calling this function within the ingress controller's
reconcile function).


**vendor: Import openshift unidling API**