### PR TITLE
Bug 1907315: Change AWS interal LB annotation to match documentation

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -97,6 +97,10 @@ var (
 	//
 	// https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
 	InternalLBAnnotations = map[configv1.PlatformType]map[string]string{
+		// Prior to 4.8, the aws internal LB annotation was set to "0.0.0.0/0".
+		// While "0.0.0.0/0" is valid, the preferred value, according to the
+		// documentation[1], is "true".
+		// [1] https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
 		configv1.AWSPlatformType: {
 			awsInternalLBAnnotation: "true",
 		},

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -98,7 +98,7 @@ var (
 	// https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
 	InternalLBAnnotations = map[configv1.PlatformType]map[string]string{
 		configv1.AWSPlatformType: {
-			awsInternalLBAnnotation: "0.0.0.0/0",
+			awsInternalLBAnnotation: "true",
 		},
 		configv1.AzurePlatformType: {
 			// Azure load balancers are not customizable and are set to (2 fail @ 5s interval, 2 healthy)

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -218,7 +218,7 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 		switch platform.Type {
 		case configv1.AWSPlatformType:
 			if isInternal {
-				if err := checkServiceHasAnnotation(svc, awsInternalLBAnnotation, true, "0.0.0.0/0"); err != nil {
+				if err := checkServiceHasAnnotation(svc, awsInternalLBAnnotation, true, "true"); err != nil {
 					t.Errorf("annotation check for test %q failed: %v", tc.description, err)
 				}
 			}


### PR DESCRIPTION
Annotation `service.beta.kubernetes.io/aws-load-balancer-internal` is
currently set as `"0.0.0.0/0"` in the operator-created load balancer
service when using an internal load balancer on AWS. The prefered value
for this annotation is now `"true"`[1][2], although both values seem to be
valid.

[1] https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
[2] https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html