### PR TITLE
Bug 1927364: Verify that Serivce resources have idle annotations from corresponding Endpoint resources, should they exist.

### DIFF
--- a/vendor/github.com/openshift/api/unidling/v1alpha1/types.go
+++ b/vendor/github.com/openshift/api/unidling/v1alpha1/types.go
@@ -1,0 +1,43 @@
+package v1alpha1
+
+const (
+	// IdledAtAnnotation indicates that a given object (endpoints or scalable object))
+	// is currently idled (and the time at which it was idled)
+	IdledAtAnnotation = "idling.alpha.openshift.io/idled-at"
+
+	// UnidleTargetAnnotation contains the references and former scales for the scalable
+	// objects associated with the idled endpoints
+	UnidleTargetAnnotation = "idling.alpha.openshift.io/unidle-targets"
+
+	// PreviousScaleAnnotation contains the previous scale of a scalable object
+	// (currently only applied by the idler)
+	PreviousScaleAnnotation = "idling.alpha.openshift.io/previous-scale"
+
+	// NeedPodsReason is the reason for the event emitted to indicate that endpoints should be unidled
+	NeedPodsReason = "NeedPods"
+)
+
+// NB: if these get changed, you'll need to actually add in the full API machinery for them
+
+// RecordedScaleReference is a CrossGroupObjectReference to a scale subresource that also
+// has the previous replica count recorded
+type RecordedScaleReference struct {
+	// Reference to the idled resource
+	CrossGroupObjectReference `json:",inline" protobuf:"bytes,1,opt,name=crossVersionObjectReference"`
+	// The last seen scale of the idled resource (before idling)
+	Replicas int32 `json:"replicas" protobuf:"varint,2,opt,name=replicas"`
+}
+
+// CrossGroupObjectReference is a reference to an object in the same
+// namespace in the specified group.  It is similar to
+// autoscaling.CrossVersionObjectReference.
+type CrossGroupObjectReference struct {
+	// Kind of the referent; More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds"
+	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
+	// Name of the referent; More info: http://releases.k8s.io/release-1.3/docs/user-guide/identifiers.md#names
+	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
+	// API version of the referent (deprecated, prefer usng Group instead)
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
+	// Group of the referent
+	Group string `json:"group,omitempty" protobuf:"bytes,3,opt,name=group"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,6 +142,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operatoringress/v1
 github.com/openshift/api/route/v1
+github.com/openshift/api/unidling/v1alpha1
 # github.com/openshift/library-go v0.0.0-20200423123937-d1360419413d
 github.com/openshift/library-go/pkg/crypto
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
**operator.go: Add endpoint/service idle annotations check**

pkg/operator/operator.go:

Add a new function, `ensureServicesHaveIdledAnnotation(...)` that
mirrors over any idling annotations from endpoint resources when the
idling annotations are not present on the corresponding service. Call
this function during the operator start up logic so that it only runs
once (rather than calling this function within the ingress controller's
reconcile function).


**vendor: Import openshift unidling API**

---

This a manual backport of https://github.com/openshift/cluster-ingress-operator/pull/542 for 4.6.