### PR TITLE
Override the default node selector for the openshift-ingress-canary namespace

### DIFF
--- a/assets/canary/namespace.yaml
+++ b/assets/canary/namespace.yaml
@@ -2,3 +2,5 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: openshift-ingress-canary
+  annotations:
+    openshift.io/node-selector: "" #override default node selector


### PR DESCRIPTION
When the `openshift-ingress-canary` namespace is deployed, it automatically inherits the default node selector, which can result in pods failing to be scheduled due to node(s) not matching the pod's node affinity. Overriding the default node selector, as we do in `openshift-network-diagnostics`, resolves this problem. 

In my specific case, I have infrastructure nodes in the cluster that are labeled with `node-role.kubernetes.io/infra=''`, but my default node selector is `node-role.kubernetes.io/worker=''`. This results in the ingress-canary daemonset failing to completely rollout, and leaves pods in a pending state (which triggers additional cluster alerting). 

I believe this should be combined with #554 to properly tolerate node taints as well. 