### PR TITLE
Bug 1934773: Canary: Perform canary test probes over https 

### DIFF
--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -28,7 +28,12 @@ func probeRouteEndpoint(route *routev1.Route) error {
 	}
 
 	// Create HTTP request
-	request, err := http.NewRequest("GET", "http://"+route.Spec.Host, nil)
+	// Use https now that the canary route uses edge termination.
+	// Some clusters that expose the default ingress controller
+	// via an external load balancer drop all traffic on port 80,
+	// in which case redirecting insecure traffic is not possible.
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=1934773.
+	request, err := http.NewRequest("GET", "https://"+route.Spec.Host, nil)
 	if err != nil {
 		return fmt.Errorf("error creating canary HTTP request %v: %v", request, err)
 	}

--- a/pkg/operator/controller/canary/route.go
+++ b/pkg/operator/controller/canary/route.go
@@ -93,8 +93,8 @@ func (r *reconciler) deleteCanaryRoute(route *routev1.Route) (bool, error) {
 	return true, nil
 }
 
-// canaryRouteChanged returns true if current and expected differ by Spec.Port
-// or Spec.To
+// canaryRouteChanged returns true if current and expected differ by Spec.Port,
+// Spec.To, or Spec.TLS.
 func canaryRouteChanged(current, expected *routev1.Route) (bool, *routev1.Route) {
 	changed := false
 	updated := current.DeepCopy()
@@ -106,6 +106,11 @@ func canaryRouteChanged(current, expected *routev1.Route) (bool, *routev1.Route)
 
 	if !cmp.Equal(current.Spec.To, expected.Spec.To, cmpopts.EquateEmpty()) {
 		updated.Spec.To = expected.Spec.To
+		changed = true
+	}
+
+	if !cmp.Equal(current.Spec.TLS, expected.Spec.TLS, cmpopts.EquateEmpty()) {
+		updated.Spec.TLS = expected.Spec.TLS
 		changed = true
 	}
 

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -75,6 +75,14 @@ func TestDesiredCanaryRoute(t *testing.T) {
 	if !cmp.Equal(route.OwnerReferences, expectedOwnerRefs) {
 		t.Errorf("expected service owner references %#v, but got %#v", expectedOwnerRefs, route.OwnerReferences)
 	}
+
+	expectedTLS := &routev1.TLSConfig{
+		Termination:                   routev1.TLSTerminationEdge,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+	}
+	if !cmp.Equal(route.Spec.TLS, expectedTLS) {
+		t.Errorf("expected route TLS config to be %v, but got %v", route.Spec.TLS, expectedTLS)
+	}
 }
 
 func TestCanaryRouteChanged(t *testing.T) {
@@ -99,6 +107,15 @@ func TestCanaryRouteChanged(t *testing.T) {
 			description: "if route spec.Port changes",
 			mutate: func(route *routev1.Route) {
 				route.Spec.Port.TargetPort = intstr.IntOrString{}
+			},
+			expect: true,
+		},
+		{
+			description: "if route spec.TLS changes",
+			mutate: func(route *routev1.Route) {
+				route.Spec.TLS = &routev1.TLSConfig{
+					Termination: routev1.TLSTerminationPassthrough,
+				}
 			},
 			expect: true,
 		},


### PR DESCRIPTION
**Canary: Perform canary test probes over https**

pkg/operator/controller/canary/http.go:

Commit `c98416` switched the canary route from a cleartext route to an edge terminated route. Prior to this change, the canary client made periodic test probes to the canary backend pods using http, since the insecure traffic would be redirected to https by the ingress controller. Some clusters expose the default ingress controller using an external load balancer that blocks all traffic on port 80, so this is not feasible.

**Canary: Reconcile updates for the canary route**

pkg/operator/controller/canary/route.go:

Trigger updates for the canary route when the canary route's Spec.TLS field in the cluster differs from what the operator expects.

pkg/operator/controller/canary/route_test.go:

Enhance existing unit test coverage.

---

This is a follow up to https://bugzilla.redhat.com/show_bug.cgi?id=1932401 / https://github.com/openshift/cluster-ingress-operator/pull/556