### PR TITLE
Bug 1935528: Canary: Use cluster-wide proxy for canary client

### DIFF
--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -52,6 +52,9 @@ func probeRouteEndpoint(route *routev1.Route) error {
 		// TODO: Add the router's certificate to the HTTP client
 		// so we can enable TLS verification.
 		Transport: &http.Transport{
+			// Use the cluster-wide proxy if it is available in the
+			// pod's environment.
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}


### PR DESCRIPTION
pkg/operator/controller/canary/http.go:

Commit b796725 overrides the default go HTTP transport
by setting a TLS configuration. The default HTTP transport
takes environment proxy settings into account, while our current
transport declaration does not. This commit explicitly adds
the `Proxy` field to the Canary `Client.Transport` field.

Note that if a cluster-wide proxy is not configured, then no proxy will
be used.

See https://golang.org/pkg/net/http/ (search for DefaultTransport)
for more information.