### PR TITLE
Bug 1936030: Fix spurious reconciliation of NodePort services

### DIFF
--- a/pkg/operator/controller/canary/route.go
+++ b/pkg/operator/controller/canary/route.go
@@ -75,10 +75,12 @@ func (r *reconciler) updateCanaryRoute(current, desired *routev1.Route) (bool, e
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, fmt.Errorf("failed to update canary route %s/%s: %v", updated.Namespace, updated.Name, err)
 	}
-	log.Info("updated canary route", "namespace", updated.Namespace, "name", updated.Name)
+	log.Info("updated canary route", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/ingress/dns.go
+++ b/pkg/operator/controller/ingress/dns.go
@@ -51,7 +51,6 @@ func (r *reconciler) ensureWildcardDNSRecord(ic *operatorv1.IngressController, s
 		if updated, err := r.updateDNSRecord(current, desired); err != nil {
 			return true, current, fmt.Errorf("failed to update dnsrecord %s/%s: %v", desired.Namespace, desired.Name, err)
 		} else if updated {
-			log.Info("updated dnsrecord", "dnsrecord", desired)
 			return r.currentWildcardDNSRecord(ic)
 		}
 	}
@@ -170,9 +169,12 @@ func (r *reconciler) updateDNSRecord(current, desired *iov1.DNSRecord) (bool, er
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, err
 	}
+	log.Info("updated dnsrecord", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -160,7 +163,6 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 		if updated, err := r.updateLoadBalancerService(currentLBService, desiredLBService, platform); err != nil {
 			return true, currentLBService, fmt.Errorf("failed to update load balancer service: %v", err)
 		} else if updated {
-			log.Info("updated load balancer service", "namespace", desiredLBService.Namespace, "name", desiredLBService.Name)
 			return r.currentLoadBalancerService(ci)
 		}
 	}
@@ -299,9 +301,12 @@ func (r *reconciler) updateLoadBalancerService(current, desired *corev1.Service,
 	if !changed {
 		return false, nil
 	}
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, err
 	}
+	log.Info("updated load balancer service", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -53,7 +53,6 @@ func (r *reconciler) ensureNodePortService(ic *operatorv1.IngressController, dep
 		if updated, err := r.updateNodePortService(current, desired); err != nil {
 			return true, current, fmt.Errorf("failed to update NodePort service: %v", err)
 		} else if updated {
-			log.Info("updated NodePort service", "service", desired)
 			return r.currentNodePortService(ic)
 		}
 	}
@@ -126,9 +125,12 @@ func (r *reconciler) updateNodePortService(current, desired *corev1.Service) (bo
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, err
 	}
+	log.Info("updated NodePort service", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
 }
 

--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -141,7 +141,7 @@ func nodePortServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 		// Ignore fields that the API, other controllers, or user may
 		// have modified.
 		cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort"),
-		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ExternalIPs", "HealthCheckNodePort"),
+		cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ClusterIPs", "ExternalIPs", "HealthCheckNodePort"),
 		cmp.Comparer(cmpServiceAffinity),
 		cmpopts.EquateEmpty(),
 	}

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -75,6 +75,7 @@ func TestNodePortServiceChanged(t *testing.T) {
 			description: "if .spec.clusterIP changes",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.ClusterIP = "2.3.4.5"
+				svc.Spec.ClusterIPs = []string{"2.3.4.5"}
 			},
 			expect: false,
 		},

--- a/pkg/operator/controller/ingress/poddisruptionbudget.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget.go
@@ -53,7 +53,6 @@ func (r *reconciler) ensureRouterPodDisruptionBudget(ic *operatorv1.IngressContr
 		if updated, err := r.updateRouterPodDisruptionBudget(current, desired); err != nil {
 			return true, current, fmt.Errorf("failed to update pod disruption budget: %v", err)
 		} else if updated {
-			log.Info("updated pod disruption budget", "poddisruptionbudget", desired)
 			return r.currentRouterPodDisruptionBudget(ic)
 		}
 	}
@@ -115,9 +114,12 @@ func (r *reconciler) updateRouterPodDisruptionBudget(current, desired *policyv1b
 		return false, nil
 	}
 
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
 	if err := r.client.Update(context.TODO(), updated); err != nil {
 		return false, err
 	}
+	log.Info("updated pod disruption budget", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
 }
 


### PR DESCRIPTION
#### Log diffs when reconciling resources

This change improves log output when reconciling managed resources to include the diff between the current and updated resources when updating resources.

* `pkg/operator/controller/canary/route.go` (`updateCanaryRoute`): Log the diff between the current and updated resources when updating the route.
* `pkg/operator/controller/ingress/cluster-role.go` (`ensureClusterRole`): Move logging of updates from here...
(`updateClusterRole`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/dns.go` (`ensureWildcardDNSRecord`): Move logging of updates from here...
(`updateDNSRecord`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/load_balancer_service.go` (`ensureLoadBalancerService`): Move logging of updates from here...
(`updateLoadBalancerService`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/monitoring.go` (`ensureServiceMonitor`): Move logging of updates from here...
(`updateServiceMonitor`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/nodeport_service.go` (`ensureNodePortService`): Move logging of updates from here...
(`updateNodePortService`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/poddisruptionbudget.go` (`ensureRouterPodDisruptionBudget`): Move logging of updates from here...
(`updateRouterPodDisruptionBudget`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/rsyslog_configmap.go` (`ensureRsyslogConfigMap`): Move logging of updates from here...
(`updateRouterPodDisruptionBudget`): ...to here.  Log diff.
* `pkg/operator/controller/ingress/serviceca_configmap.go` (`ensureServiceCAConfigMap`): Move logging of updates from here...
(`updateServiceCAConfigMap`): ...to here.  Log diff.


#### `nodePortServiceChanged`: Fix for `clusterIPs`

Ignore the `clusterIPs` field when comparing NodePort services to determine whether an update is required.

Before this change, the update logic would keep trying to revert the default value that the API set for the service's `clusterIPs` field.

The `clusterIPs` field is new in Kubernetes 1.20 (OpenShift 4.7).

* `pkg/operator/controller/ingress/nodeport_service.go` (`nodePortServiceChanged`): Ignore the service's `clusterIPs` field.
* `pkg/operator/controller/ingress/nodeport_service_test.go` (`TestNodePortServiceChanged`): Verify that `nodePortServiceChanged` returns false if the only mutation is that the `clusterIPs` field's value has changed.