### PR TITLE
Bug 1959194: Ingress rollouts should specify minReadySeconds

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1015,6 +1015,20 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if .spec.minReadySeconds changes to non-zero",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.MinReadySeconds = 10
+			},
+			expect: true,
+		},
+		{
+			description: "if .spec.minReadySeconds changes to none",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.MinReadySeconds = 0
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1027,6 +1041,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 				UID:       "1",
 			},
 			Spec: appsv1.DeploymentSpec{
+				MinReadySeconds: 30,
 				Strategy: appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDeployment{


### PR DESCRIPTION
Ingress components may run directly behind load balancers and thus
need to delay deployment rollout long enough for the load balancers
to see the new process. Without minReadySeconds, the upgrade process
will immediately delete the old pod as soon as the new pod is ready,
which means that the LB may briefly see no pods, which then triggers
on some LB the behavior of including all hosts (generally if all
hosts are unhealthy the LB will allow requests to go to any host
as opposed to failing closed).

while we test with this