### PR TITLE
Use HAProxy log level "info" to enable access logs

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -491,7 +491,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 
 			env = append(env,
 				corev1.EnvVar{Name: RouterSyslogAddressEnvName, Value: socketPath},
-				corev1.EnvVar{Name: RouterLogLevelEnvName, Value: "debug"},
+				corev1.EnvVar{Name: RouterLogLevelEnvName, Value: "info"},
 			)
 			volumes = append(volumes, rsyslogConfigVolume, rsyslogSocketVolume)
 			routerVolumeMounts = append(routerVolumeMounts, rsyslogSocketVolumeMount)
@@ -504,7 +504,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 			port := accessLogging.Destination.Syslog.Port
 			endpoint := net.JoinHostPort(address, fmt.Sprintf("%d", port))
 			env = append(env,
-				corev1.EnvVar{Name: RouterLogLevelEnvName, Value: "debug"},
+				corev1.EnvVar{Name: RouterLogLevelEnvName, Value: "info"},
 				corev1.EnvVar{Name: RouterSyslogAddressEnvName, Value: endpoint},
 			)
 		}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -351,7 +351,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_FACILITY", false, "")
-	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "debug")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "info")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", true, "/var/lib/rsyslog/rsyslog.sock")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", true, `"%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV"`)
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", true, "foo:256")
@@ -516,7 +516,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, false)
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_FACILITY", true, "local2")
-	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "debug")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_LEVEL", true, "info")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", true, "1.2.3.4:12345")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS", true, "Host:15,Referer:15")


### PR DESCRIPTION
Before this PR, the operator configured HAProxy with log level "debug" to enable access logs.  However, access logs are emitted at the "info" or "error" levels, so setting the log level to "info" is sufficient and avoids logging superfluous information.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Set the `ROUTER_LOG_LEVEL` environment variable's value to "info" instead of to "debug" when enabling access logs.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Expect "info" instead of "debug" for `ROUTER_LOG_LEVEL`.