### PR TITLE
NE-354: Implement Tunable router header buffers

### DIFF
--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -317,3 +317,60 @@ func TestTLSProfileSpecForIngressController(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateHTTPHeaderBufferValues(t *testing.T) {
+	testCases := []struct {
+		description      string
+		httpHeaderBuffer operatorv1.IngressControllerHTTPHeaderBuffer
+		valid            bool
+	}{
+		{
+			description:      "no httpHeaderBuffer values",
+			httpHeaderBuffer: operatorv1.IngressControllerHTTPHeaderBuffer{},
+			valid:            true,
+		},
+		{
+			description: "valid httpHeaderBuffer values",
+			httpHeaderBuffer: operatorv1.IngressControllerHTTPHeaderBuffer{
+				HeaderBufferBytes:           32768,
+				HeaderBufferMaxRewriteBytes: 8192,
+			},
+			valid: true,
+		},
+		{
+			description: "invalid httpHeaderBuffer values",
+			httpHeaderBuffer: operatorv1.IngressControllerHTTPHeaderBuffer{
+				HeaderBufferBytes:           8192,
+				HeaderBufferMaxRewriteBytes: 32768,
+			},
+			valid: false,
+		},
+		{
+			description: "invalid httpHeaderBuffer values, HeaderBufferMaxRewriteBytes not set",
+			httpHeaderBuffer: operatorv1.IngressControllerHTTPHeaderBuffer{
+				HeaderBufferBytes: 1,
+			},
+			valid: false,
+		},
+		{
+			description: "invalid httpHeaderBuffer values, HeaderBufferBytes not set",
+			httpHeaderBuffer: operatorv1.IngressControllerHTTPHeaderBuffer{
+				HeaderBufferMaxRewriteBytes: 65536,
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		ic := &operatorv1.IngressController{}
+		ic.Spec.HTTPHeaderBuffer = tc.httpHeaderBuffer
+		err := validateHTTPHeaderBufferValues(ic)
+		if tc.valid && err != nil {
+			t.Errorf("%q: Expected valid HTTPHeaderBuffer to not return a validation error: %v", tc.description, err)
+		}
+
+		if !tc.valid && err == nil {
+			t.Errorf("%q: Expected invalid HTTPHeaderBuffer to return a validation error", tc.description)
+		}
+	}
+}

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -53,6 +53,9 @@ const (
 	RouterCaptureHTTPResponseHeaders = "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS"
 	RouterCaptureHTTPCookies         = "ROUTER_CAPTURE_HTTP_COOKIE"
 
+	RouterHeaderBufferSize           = "ROUTER_BUF_SIZE"
+	RouterHeaderBufferMaxRewriteSize = "ROUTER_MAX_REWRITE_SIZE"
+
 	RouterDisableHTTP2EnvName          = "ROUTER_DISABLE_HTTP2"
 	RouterDefaultEnableHTTP2Annotation = "ingress.operator.openshift.io/default-enable-http2"
 
@@ -658,6 +661,18 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 
 	if enabled, value := HardStopAfterIsEnabled(ci, ingressConfig); enabled {
 		env = append(env, corev1.EnvVar{Name: RouterHardStopAfterEnvName, Value: value})
+	}
+
+	// Apply HTTP Header Buffer size values to env
+	// when they are specified.
+	if ci.Spec.HTTPHeaderBuffer.HeaderBufferBytes != 0 {
+		env = append(env, corev1.EnvVar{Name: RouterHeaderBufferSize, Value: strconv.Itoa(
+			int(ci.Spec.HTTPHeaderBuffer.HeaderBufferBytes))})
+	}
+
+	if ci.Spec.HTTPHeaderBuffer.HeaderBufferMaxRewriteBytes != 0 {
+		env = append(env, corev1.EnvVar{Name: RouterHeaderBufferMaxRewriteSize, Value: strconv.Itoa(
+			int(ci.Spec.HTTPHeaderBuffer.HeaderBufferMaxRewriteBytes))})
 	}
 
 	deployment.Spec.Template.Spec.Volumes = volumes

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -259,6 +259,9 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS", false, "")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", false, "")
 
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_BUF_SIZE", false, "")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_REWRITE_SIZE", false, "")
+
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "foo:bar:baz")
 
 	checkDeploymentHasEnvVar(t, deployment, "SSL_MIN_VERSION", true, "TLSv1.1")
@@ -293,6 +296,10 @@ func TestDesiredRouterDeployment(t *testing.T) {
 			"Host",
 			"Cache-Control",
 		},
+	}
+	ci.Spec.HTTPHeaderBuffer = operatorv1.IngressControllerHTTPHeaderBuffer{
+		HeaderBufferBytes:           16384,
+		HeaderBufferMaxRewriteBytes: 4096,
 	}
 	ci.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
 		Type: configv1.TLSProfileCustomType,
@@ -355,6 +362,9 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_ADDRESS", true, "/var/lib/rsyslog/rsyslog.sock")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SYSLOG_FORMAT", true, `"%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV"`)
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CAPTURE_HTTP_COOKIE", true, "foo:256")
+
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_BUF_SIZE", true, "16384")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_REWRITE_SIZE", true, "4096")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SET_FORWARDED_HEADERS", true, "append")
 

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -1,0 +1,311 @@
+// +build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestHTTPHeaderBufferSize(t *testing.T) {
+	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "header-buffer-size"}
+	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
+	ic := newPrivateController(icName, domain)
+	// Create an ingress controller with header buffer values that are 2x
+	// the defaults.
+	ic.Spec.HTTPHeaderBuffer = operatorv1.IngressControllerHTTPHeaderBuffer{
+		HeaderBufferBytes:           65536,
+		HeaderBufferMaxRewriteBytes: 16384,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
+	}
+
+	defer assertIngressControllerDeleted(t, kclient, ic)
+	conditions := []operatorv1.OperatorCondition{
+		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+	}
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
+		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
+	}
+
+	service := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.InternalIngressControllerServiceName(ic), service); err != nil {
+		t.Fatalf("failed to get ingresscontroller service: %v", err)
+	}
+
+	echoPod := buildEchoPod("header-buffer-size-echo", deployment.Namespace)
+	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
+			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+		}
+	}()
+
+	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
+	if err := kclient.Create(context.TODO(), echoService); err != nil {
+		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), echoService); err != nil {
+			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+		}
+	}()
+
+	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
+	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
+			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+		}
+	}()
+
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		t.Fatalf("failed to get kube config: %v", err)
+	}
+	cl, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to create kube client: %v", err)
+	}
+
+	// Generate an arbitrary request header with random phony data.
+	// Use a random string with length reasonably close to the
+	// buffer limits to save space for other headers.
+	length := int(ic.Spec.HTTPHeaderBuffer.HeaderBufferBytes-ic.Spec.HTTPHeaderBuffer.HeaderBufferMaxRewriteBytes) - 1024
+	random := randomString(length)
+
+	testHeaderName := "test-random-data-header"
+	headerString := fmt.Sprintf("%s: %s", testHeaderName, random)
+	extraCurlArgs := []string{
+		"-v",
+		"-H",
+		headerString,
+	}
+
+	name := "header-buffer-size-test-large-buffers"
+	image := deployment.Spec.Template.Spec.Containers[0].Image
+	clientPodValidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
+	if err := kclient.Create(context.TODO(), clientPodValidRequest); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), clientPodValidRequest); err != nil {
+			t.Fatalf("failed to delete pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
+		}
+	}()
+
+	pollErr := wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
+		readCloser, err := cl.CoreV1().Pods(clientPodValidRequest.Namespace).GetLogs(clientPodValidRequest.Name, &corev1.PodLogOptions{
+			Container: "curl",
+			Follow:    false,
+		}).Stream(context.TODO())
+		if err != nil {
+			t.Logf("failed to read output from pod %s: %v", clientPodValidRequest.Name, err)
+			return false, nil
+		}
+		scanner := bufio.NewScanner(readCloser)
+		defer func() {
+			if err := readCloser.Close(); err != nil {
+				t.Errorf("failed to close reader for pod %s: %v", clientPodValidRequest.Name, err)
+			}
+		}()
+		for scanner.Scan() {
+			line := scanner.Text()
+			if idx := strings.Index(line, ":"); idx != -1 {
+				// Ensure that we see the test header name in
+				// the echo response. We don't need to verify the
+				// contents of the header since HAProxy would return
+				// 400 if the header was too large.
+				headerName := line[:idx]
+				if headerName == testHeaderName {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	if pollErr != nil {
+		pod := &corev1.Pod{}
+		podName := types.NamespacedName{
+			Namespace: clientPodValidRequest.Namespace,
+			Name:      clientPodValidRequest.Name,
+		}
+		if err := kclient.Get(context.TODO(), podName, pod); err != nil {
+			t.Errorf("failed to get pod %s: %v", clientPodValidRequest.Name, err)
+		}
+
+		logs, err := cl.CoreV1().Pods(clientPodValidRequest.Namespace).GetLogs(clientPodValidRequest.Name, &corev1.PodLogOptions{
+			Container: "curl",
+			Follow:    false,
+		}).DoRaw(context.TODO())
+		if err != nil {
+			t.Errorf("failed to get logs from pod %s: %v", clientPodValidRequest.Name, err)
+		}
+
+		output := fmt.Sprintf("failed to observe the expected output: %v\nclient pod spec: %#v\nclient pod logs:\n%s", pollErr, pod, logs)
+		output = strings.Replace(output, random, fmt.Sprintf("<%d bytes of random data snipped>", length), 0)
+		t.Fatal(output)
+	}
+
+	if err := kclient.Get(context.TODO(), types.NamespacedName{Name: ic.Name, Namespace: ic.Namespace}, ic); err != nil {
+		t.Errorf("failed to get ingresscontroller %s: %v", ic.Name, err)
+	}
+
+	// Get the name of the current router pod for the test ingress controller
+	podList := &corev1.PodList{}
+	labels := map[string]string{
+		controller.ControllerDeploymentLabel: "header-buffer-size",
+	}
+	if err := kclient.List(context.TODO(), podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(labels)); err != nil {
+		t.Errorf("failed to list pods for ingress controllers %s: %v", ic.Name, err)
+	}
+
+	if len(podList.Items) != 1 {
+		t.Errorf("expected ingress controller %s to have exactly 1 router pod, but it has %d", ic.Name, len(podList.Items))
+	}
+
+	oldRouterPodName := podList.Items[0].Name
+
+	// Mutate the ic to use header buffer values that are 1/2 the default.
+	ic.Spec.HTTPHeaderBuffer = operatorv1.IngressControllerHTTPHeaderBuffer{
+		HeaderBufferBytes:           16384,
+		HeaderBufferMaxRewriteBytes: 4096,
+	}
+
+	if err := kclient.Update(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to update ingresscontroller %s: %v", icName, err)
+	}
+
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	// Wait for the new router pod for the updated ingresscontroller to become ready.
+	pollErr = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
+		podList := &corev1.PodList{}
+		if err := kclient.List(context.TODO(), podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(labels)); err != nil {
+			t.Errorf("failed to list pods for ingress controllers %s: %v", ic.Name, err)
+		}
+
+		for _, pod := range podList.Items {
+			if pod.Name == oldRouterPodName {
+				continue
+			}
+
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					return true, nil
+				}
+			}
+
+		}
+		t.Logf("waiting for new router pod for %s to become ready", ic.Name)
+		return false, nil
+	})
+
+	if pollErr != nil {
+		t.Errorf("timed out waiting for new router pod for %s to become ready: %v", ic.Name, pollErr)
+	}
+
+	name = name + "-fail-case"
+	clientPodInvalidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
+
+	if err := kclient.Create(context.TODO(), clientPodInvalidRequest); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
+	}
+
+	defer func() {
+		if err := kclient.Delete(context.TODO(), clientPodInvalidRequest); err != nil {
+			t.Fatalf("failed to delete pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
+		}
+	}()
+
+	// Check curl pod logs for a 400 response since the sent headers
+	// are too large for HAProxy.
+	pollErr = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
+		readCloser, err := cl.CoreV1().Pods(clientPodInvalidRequest.Namespace).GetLogs(clientPodInvalidRequest.Name, &corev1.PodLogOptions{
+			Container: "curl",
+			Follow:    false,
+		}).Stream(context.TODO())
+		if err != nil {
+			t.Logf("failed to read output from pod %s: %v", clientPodInvalidRequest.Name, err)
+			return false, nil
+		}
+		scanner := bufio.NewScanner(readCloser)
+		defer func() {
+			if err := readCloser.Close(); err != nil {
+				t.Errorf("failed to close reader for pod %s: %v", clientPodInvalidRequest.Name, err)
+			}
+		}()
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "400 Bad request") {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if pollErr != nil {
+		pod := &corev1.Pod{}
+		podName := types.NamespacedName{
+			Namespace: clientPodInvalidRequest.Namespace,
+			Name:      clientPodInvalidRequest.Name,
+		}
+		if err := kclient.Get(context.TODO(), podName, pod); err != nil {
+			t.Errorf("failed to get pod %s: %v", clientPodInvalidRequest.Name, err)
+		}
+
+		logs, err := cl.CoreV1().Pods(clientPodInvalidRequest.Namespace).GetLogs(clientPodInvalidRequest.Name, &corev1.PodLogOptions{
+			Container: "curl",
+			Follow:    false,
+		}).DoRaw(context.TODO())
+		if err != nil {
+			t.Errorf("failed to get logs from pod %s: %v", clientPodInvalidRequest.Name, err)
+		}
+
+		output := fmt.Sprintf("failed to observe the expected output: %v\nclient pod spec: %#v\nclient pod logs:\n%s", pollErr, pod, logs)
+		output = strings.Replace(output, random, fmt.Sprintf("<%d bytes of random data snipped>", length), 0)
+		t.Fatal(output)
+	}
+}
+
+// randomString quickly returns a string of
+// pseudo-random characters.
+func randomString(length int) (str string) {
+	b := make([]byte, (length+1)/2)
+	rand.Read(b)
+	// %x will output 2 chars per byte.
+	str = fmt.Sprintf("%x", b)
+	return
+}


### PR DESCRIPTION
**Implement Router Tunable Buffer Sizes**

pkg/operator/controller/ingress/controller.go:

New func, `validateHTTPHeaderBufferValues`, to validate `HTTPHeaderBuffer` values when an ingress controller specifies them. Reject ingress controllers that specify improper `HTTPHeaderBuffer` values (ie `HeaderBufferBytes < HeaderBufferMaxRewrite`).

pkg/operator/controller/ingress/controller_test.go:

Add unit test coverage for `validateHTTPHederBufferValues`.

pkg/operator/controller/ingress/deployment.go:

Append `ROUTER_BUF_SIZE` and `ROUTER_MAX_REWRITE_SIZE` env variables to an IngressController's deployment when an IngressController specifies either `HeaderBufferBytes` or `HeaderBufferMaxRewriteBytes` via `Spec.HTTPHeaderBuffer`.

pkg/operator/controller/ingress/deployment_test.go:

Add valid `HTTPHeaderBuffer` values to test deployment in `TestDesiredRouterDeployment`.

**test/e2e: Add e2e test to test configurable header buffers**

test/e2e/http_header_buffer_test.go: New file.

Add new e2e test, `TestHTTPHeaderBufferSize`, that performs the following:

1) Create an Ingress Controller with header buffer values that are 2x larger than the defaults.

2) Send an HTTP request with a test header packed with random data to a header echo server and verify that the header is successfully received. Note that the test request has headers large enough such that the default ingress controller would return "400 Bad request" if it were handling the request.

3) Mutate the created Ingress Controller so that it is using header buffer values that are 1/2 the size of the defaults.

4) Send the same HTTP request with large headers as before.

5) Ensure that HAProxy responds with "400 Bad Request" since the request headers exceed the buffer limits.

---
Prequisites:

- [x] https://github.com/openshift/cluster-ingress-operator/pull/575
- [x] https://github.com/openshift/api/pull/854
- [x] https://github.com/openshift/router/pull/193