### PR TITLE
NE-302: Add field for configuring number of HAProxy threads in router

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -390,7 +390,11 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		env = append(env, corev1.EnvVar{Name: "ROUTER_USE_PROXY_PROTOCOL", Value: "true"})
 	}
 
-	env = append(env, corev1.EnvVar{Name: "ROUTER_THREADS", Value: "4"})
+	threads := 4
+	if ci.Spec.TuningOptions.ThreadCount > 0 {
+		threads = int(ci.Spec.TuningOptions.ThreadCount)
+	}
+	env = append(env, corev1.EnvVar{Name: "ROUTER_THREADS", Value: strconv.Itoa(threads)})
 
 	nodeSelector := map[string]string{
 		"kubernetes.io/os":               "linux",

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -66,6 +66,9 @@ const (
 	RouterHardStopAfterAnnotation = "ingress.operator.openshift.io/hard-stop-after"
 
 	LivenessGracePeriodSecondsAnnotation = "unsupported.do-not-use.openshift.io/override-liveness-grace-period-seconds"
+
+	RouterHAProxyThreadsEnvName      = "ROUTER_THREADS"
+	RouterHAProxyThreadsDefaultValue = 4
 )
 
 // ensureRouterDeployment ensures the router deployment exists for a given
@@ -390,11 +393,11 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		env = append(env, corev1.EnvVar{Name: "ROUTER_USE_PROXY_PROTOCOL", Value: "true"})
 	}
 
-	threads := 4
+	threads := RouterHAProxyThreadsDefaultValue
 	if ci.Spec.TuningOptions.ThreadCount > 0 {
 		threads = int(ci.Spec.TuningOptions.ThreadCount)
 	}
-	env = append(env, corev1.EnvVar{Name: "ROUTER_THREADS", Value: strconv.Itoa(threads)})
+	env = append(env, corev1.EnvVar{Name: RouterHAProxyThreadsEnvName, Value: strconv.Itoa(threads)})
 
 	nodeSelector := map[string]string{
 		"kubernetes.io/os":               "linux",

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -279,6 +280,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_H1_CASE_ADJUST", false, "")
 
+	checkDeploymentHasEnvVar(t, deployment, RouterHAProxyThreadsEnvName, true, strconv.Itoa(RouterHAProxyThreadsDefaultValue))
+
 	ci.Spec.Logging = &operatorv1.IngressControllerLogging{
 		Access: &operatorv1.AccessLogging{
 			Destination: operatorv1.LoggingDestination{
@@ -306,6 +309,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	ci.Spec.TuningOptions = operatorv1.IngressControllerTuningOptions{
 		HeaderBufferBytes:           16384,
 		HeaderBufferMaxRewriteBytes: 4096,
+		ThreadCount:                 RouterHAProxyThreadsDefaultValue * 2,
 	}
 	ci.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
 		Type: configv1.TLSProfileCustomType,
@@ -379,6 +383,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_BUF_SIZE", true, "16384")
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_REWRITE_SIZE", true, "4096")
+
+	checkDeploymentHasEnvVar(t, deployment, RouterHAProxyThreadsEnvName, true, strconv.Itoa(RouterHAProxyThreadsDefaultValue*2))
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SET_FORWARDED_HEADERS", true, "append")
 

--- a/test/e2e/nbthread_test.go
+++ b/test/e2e/nbthread_test.go
@@ -1,0 +1,83 @@
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const nbthreadRouterDeployTimeout time.Duration = 1 * time.Minute
+
+// NOTE: This test will mutate the default ingresscontroller
+func TestRouteNbthreadIngressController(t *testing.T) {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, defaultName, defaultAvailableConditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	ic, err := getIngressController(t, kclient, defaultName, 1*time.Minute)
+	if err != nil {
+		t.Fatalf("failed to get ingress controller: %v", err)
+	}
+
+	routerDeployment, err := getDeployment(t, kclient, controller.RouterDeploymentName(ic), 1*time.Minute)
+	if err != nil {
+		t.Fatalf("failed to get router deployment: %v", err)
+	}
+
+	// by default, the router deployment should have ROUTER_THREADS set to 4
+	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", "4"); err != nil {
+		t.Fatalf("expected router deployment to have spec.threading.count unset: %v", err)
+	}
+
+	// set spec.threading.count to a nonstandard value, 7
+	if err := nbthreadSetThreadCount(t, kclient, 1*time.Minute, 7, ic); err != nil {
+		t.Fatalf("failed to update ingresscontroller: %v", err)
+	}
+
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, defaultName, defaultAvailableConditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", "7"); err != nil {
+		t.Fatalf("expected router deployment to set spec.threading.count: %v", err)
+	}
+
+	// set threading.count to 0, as if it was unset
+	if err := nbthreadSetThreadCount(t, kclient, 1*time.Minute, 0, ic); err != nil {
+		t.Fatalf("failed to update ingresscontroller: %v", err)
+	}
+
+	// when set back to default, the router deployment should have ROUTER_THREADS set to 4
+	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", "4"); err != nil {
+		t.Fatalf("expected router deployment to have spec.threading.count unset: %v", err)
+	}
+}
+
+func nbthreadSetThreadCount(t *testing.T, client client.Client, timeout time.Duration, nbthreads int, c *operatorv1.IngressController) error {
+	t.Helper()
+	name := types.NamespacedName{Namespace: c.Namespace, Name: c.Name}
+
+	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		if err := client.Get(context.TODO(), name, c); err != nil {
+			t.Logf("Get %q failed: %v, retrying...", name, err)
+			return false, nil
+		}
+		c.Spec.TuningOptions.ThreadCount = int32(nbthreads)
+		if err := client.Update(context.TODO(), c); err != nil {
+			t.Logf("Update %q failed: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}


### PR DESCRIPTION
ingress operator reads the IngressController's `spec.tuningOptions.threadCount` field, and sets the `"ROUTER_THREADS"` environment variable in the desired router deployment according to its value.

this is dependent on [openshift/api #875](https://github.com/openshift/api/pull/875), and part of the implementation of [openshift/enhancements #708](https://github.com/openshift/enhancements/pull/708)