### PR TITLE
NE-621: Support changing ingresscontroller load balancer scope

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -430,6 +430,10 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 		return true
 	}
 
+	// Detect changes to LB scope.
+	if specLB != nil && statusLB != nil && specLB.Scope != statusLB.Scope {
+		ic.Status.EndpointPublishingStrategy.LoadBalancer.Scope = effectiveStrategy.LoadBalancer.Scope
+	}
 	return false
 }
 
@@ -803,7 +807,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
 	}
 
-	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig))
+	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig))
 
 	return retryable.NewMaybeRetryableAggregate(errs)
 }

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -127,7 +127,7 @@ const (
 )
 
 var (
-	// internalLBAnnotations maps platform to the annotation name and value
+	// InternalLBAnnotations maps platform to the annotation name and value
 	// that tell the cloud provider that is associated with the platform
 	// that the load balancer is internal.
 	//

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -44,10 +44,15 @@ type expectedCondition struct {
 
 // syncIngressControllerStatus computes the current status of ic and
 // updates status upon any changes since last sync.
-func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS) error {
+func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure) error {
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
 		return fmt.Errorf("deployment has invalid spec.selector: %v", err)
+	}
+
+	platform, err := oputil.GetPlatformStatus(r.client, infraConfig)
+	if err != nil {
+		return fmt.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %w", ic.Namespace, ic.Name, err)
 	}
 
 	var errs []error
@@ -65,6 +70,7 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(updated.Status.Conditions))
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressProgressingCondition(updated.Status.Conditions, ic, service, platform))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, degradedCondition)
 	updated.Status.Conditions = PruneConditions(updated.Status.Conditions)
 
@@ -538,6 +544,45 @@ func formatConditions(conditions []*operatorv1.OperatorCondition) string {
 	}
 	formatted = formatted[2:]
 	return formatted
+}
+
+// computeIngressProgressingCondition computes the ingresscontroller's
+// "Progressing" status condition, which indicates if the ingresscontroller's
+// current state matches its desired state.
+func computeIngressProgressingCondition(conditions []operatorv1.OperatorCondition, ic *operatorv1.IngressController, service *corev1.Service, platform *configv1.PlatformStatus) operatorv1.OperatorCondition {
+	condition := operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeProgressing,
+		Status: operatorv1.ConditionFalse,
+	}
+	if ic.Status.EndpointPublishingStrategy.Type == operatorv1.LoadBalancerServiceStrategyType {
+		switch {
+		case ic.Status.EndpointPublishingStrategy.LoadBalancer == nil:
+			condition.Message = "status.endpointPublishingStrategy.loadBalancer is not set."
+			condition.Reason = "IncompleteStatus"
+			condition.Status = operatorv1.ConditionUnknown
+		case service == nil:
+			condition.Message = "LoadBalancer Service not created."
+			condition.Reason = "NoService"
+			condition.Status = operatorv1.ConditionTrue
+		default:
+			wantScope := ic.Status.EndpointPublishingStrategy.LoadBalancer.Scope
+			haveScope := operatorv1.ExternalLoadBalancer
+			if IsServiceInternal(service) {
+				haveScope = operatorv1.InternalLoadBalancer
+			}
+			if wantScope != haveScope {
+				message := fmt.Sprintf("The IngressController scope was changed from %q to %q.", haveScope, wantScope)
+				switch platform.Type {
+				case configv1.AWSPlatformType, configv1.IBMCloudPlatformType:
+					message = fmt.Sprintf("%[1]s  To effectuate this change, you must delete the service: `oc -n %[2]s delete svc/%[3]s`; the service load-balancer will then be deprovisioned and a new one created.  This will most likely cause the new load-balancer to have a different host name and IP address from the old one's.  Alternatively, you can revert the change to the IngressController: `oc -n openshift-ingress-operator patch ingresscontrollers/%[4]s --type=merge --patch='{\"spec\":{\"endpointPublishingStrategy\":{\"loadBalancer\":{\"scope\":\"%[5]s\"}}}}'", message, service.Namespace, service.Name, ic.Name, haveScope)
+				}
+				condition.Reason = "ScopeChanged"
+				condition.Message = message
+				condition.Status = operatorv1.ConditionTrue
+			}
+		}
+	}
+	return condition
 }
 
 // IngressStatusesEqual compares two IngressControllerStatus values.  Returns true

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -884,6 +884,138 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 	}
 }
 
+// TestScopeChange creates an ingresscontroller with the "LoadBalancerService"
+// endpoint publishing strategy type and verifies that the operator behaves
+// correctly when the ingresscontroller's scope is mutated.  The correct
+// behavior depends on the platform on which the test is running.  On AWS and
+// IBM Cloud, the operator should set the Progressing=True status condition to
+// prompt the administrator to delete the old LoadBalancer service.  On Azure
+// and GCP, the operator should update the LoadBalancer service's annotations.
+func TestScopeChange(t *testing.T) {
+	platform := infraConfig.Status.Platform
+	supportedPlatforms := map[configv1.PlatformType]struct{}{
+		configv1.AlibabaCloudPlatformType: {},
+		configv1.AWSPlatformType:          {},
+		configv1.AzurePlatformType:        {},
+		configv1.GCPPlatformType:          {},
+		configv1.IBMCloudPlatformType:     {},
+		configv1.PowerVSPlatformType:      {},
+	}
+	if _, supported := supportedPlatforms[platform]; !supported {
+		t.Skipf("test skipped on platform %q", platform)
+	}
+
+	name := types.NamespacedName{Namespace: operatorNamespace, Name: "scope"}
+	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		Scope: operatorv1.ExternalLoadBalancer,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for the load balancer and DNS to be ready.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	lbService := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		t.Fatalf("failed to get LoadBalancer service: %v", err)
+	}
+
+	if ingresscontroller.IsServiceInternal(lbService) {
+		t.Fatalf("load balancer is internal but should be external")
+	}
+
+	// Change the scope to internal and wait for everything to come back to
+	// normal.
+	if err := kclient.Get(context.TODO(), name, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller %s: %v", name, err)
+	}
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope = operatorv1.InternalLoadBalancer
+
+	if err := kclient.Update(context.TODO(), ic); err != nil {
+		t.Fatal(err)
+	}
+
+	switch platform {
+	case configv1.AlibabaCloudPlatformType, configv1.AWSPlatformType, configv1.IBMCloudPlatformType, configv1.PowerVSPlatformType:
+		progressingTrue := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeProgressing,
+			Status: operatorv1.ConditionTrue,
+		}
+		if err := waitForIngressControllerCondition(t, kclient, 1*time.Minute, name, progressingTrue); err != nil {
+			t.Fatalf("failed to observe the ingresscontroller report Progressing=True: %v", err)
+		}
+	case configv1.AzurePlatformType, configv1.GCPPlatformType:
+		err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+			service := &corev1.Service{}
+			if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), service); err != nil {
+				if errors.IsNotFound(err) {
+					return false, nil
+				}
+				t.Logf("failed to get service %s: %v", controller.LoadBalancerServiceName(ic), err)
+				return false, nil
+			}
+			if ingresscontroller.IsServiceInternal(service) {
+				return true, nil
+			}
+			t.Logf("service is still external: %#v\n", service)
+			return false, nil
+		})
+		if err != nil {
+			t.Fatalf("expected load balancer to become internal: %v", err)
+		}
+	}
+
+	// Change the scope back to external and wait for everything to come
+	// back to normal.
+	if err := kclient.Get(context.TODO(), name, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller %s: %v", name, err)
+	}
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope = operatorv1.ExternalLoadBalancer
+
+	if err := kclient.Update(context.TODO(), ic); err != nil {
+		t.Fatal(err)
+	}
+
+	switch platform {
+	case configv1.AWSPlatformType, configv1.IBMCloudPlatformType:
+		progressingFalse := operatorv1.OperatorCondition{
+			Type:   operatorv1.OperatorStatusTypeProgressing,
+			Status: operatorv1.ConditionFalse,
+		}
+		if err := waitForIngressControllerCondition(t, kclient, 1*time.Minute, name, progressingFalse); err != nil {
+			t.Fatalf("failed to observe the ingresscontroller report Progressing=True: %v", err)
+		}
+	case configv1.AzurePlatformType, configv1.GCPPlatformType:
+		err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+			service := &corev1.Service{}
+			if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), service); err != nil {
+				if errors.IsNotFound(err) {
+					return false, nil
+				}
+				t.Logf("failed to get ingresscontroller %s: %v", name.Name, err)
+				return false, nil
+			}
+			if ingresscontroller.IsServiceInternal(service) {
+				t.Logf("service is still internal: %#v\n", service)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Fatalf("expected load balancer to become external: %v", err)
+		}
+	}
+
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+}
+
 // TestNodePortServiceEndpointPublishingStrategy creates an ingresscontroller
 // with the "NodePortService" endpoint publishing strategy type and verifies
 // that the operator creates a router, that the router becomes available, and


### PR DESCRIPTION
Add support for changing ingresscontroller load balancer scope. On AWS and IBM cloud, this requires deleting the existing load balancer service and recreating it with the desired scope; if the administrator changes the scope on the ingresscontroller, the operator will report `Progressing=True` until the administrator either reverts the change or deletes the service. If the administrator deletes the service, then the operator will recreate the service with the desired scope.  On Azure and GCP, it suffices to update the existing service's annotations.

This commit is based on #472, which was reverted by commit #514.  Unlike the original implementation of this feature, the operator does not delete the service but instead leaves it up to the administrator to do so as needed.

* `pkg/operator/controller/ingress/controller.go` (`setDefaultPublishingStrategy`): Update scope if needed.
(`ensureIngressController`): Pass `infraConfig` to `syncIngressControllerStatus`.
* `pkg/operator/controller/ingress/load_balancer_service.go` (`externalLBAnnotations`): New variable.  Map platform type to the annotation for that platform that makes the load balancer external, if the platform requires an explicit annotation.
(`desiredLoadBalancerService`): Use new `externalLBAnnotations` variable to simplify logic.
(`updateLoadBalancerService`): Pass `platform` to `loadBalancerServiceScopeChanged`.
(`loadBalancerServiceChanged`): Add `platform` parameter.  Check if the scope changed and if the platform supports changing scope without recreating the service, and update the appropriate annotations if so.
(`loadBalancerServiceScopeChanged`): New function.  Check if the load balancer's scope changed.
(`IsServiceInternal`): New function.  Return a Boolean value indicating whether the provided service is annotated to request an internal load-balancer
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceChanged`): Update to pass platform status to `loadBalancerServiceChanged`.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Add `infraConfig` parameter.  Use `infraConfig` to get the platform type. Call the new `computeIngressProgressingCondition` function with the ingresscontroller, service, and platform to compute a "Progressing" status condition for the ingresscontroller.
(`computeIngressProgressingCondition`): New function.  Compute a "Progressing" status condition.  In particular, this status condition will indicate if it is necessary to delete the service so that it can be recreated with the updated scope.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputeIngressProgressCondition`): New test.  Verify that `computeIngressProgressingCondition` returns the expected status condition.
* `pkg/operator/controller/status/controller.go` (`Reconcile`): Pass ingresscontrollers to `computeOperatorProgressingCondition`.
(`computeOperatorProgressingCondition`): Report `Progressing=True` on the clusteroperator if any ingresscontroller reports `Progressing=True`.
* `pkg/operator/controller/status/controller_test.go` (`TestComputeOperatorProgressingCondition`): Add test case where an ingresscontroller is progressing.
* `test/e2e/operator_test.go` (`TestScopeChange`): New test.  Verify that the operator performs the appropriate behavior for the platform on which the test is running when an ingresscontroller's scope is changed from the default external scope to internal and then back to external.