### PR TITLE
Add h2spec client subcommand

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -7,6 +7,7 @@ import (
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	grpctestserver "github.com/openshift/cluster-ingress-operator/test/grpc"
+	h2specclient "github.com/openshift/cluster-ingress-operator/test/h2spec"
 	httphealthcheck "github.com/openshift/cluster-ingress-operator/test/http"
 	http2testserver "github.com/openshift/cluster-ingress-operator/test/http2"
 )
@@ -34,6 +35,7 @@ func main() {
 			http2testserver.Serve()
 		},
 	})
+	rootCmd.AddCommand(h2specclient.NewClientCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Error(err, "error")

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
+	github.com/summerwind/h2spec v0.0.0-20200804131034-70ac22940108
 	github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419
 	go.uber.org/zap v1.16.0
 	google.golang.org/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,7 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v0.0.0-20161025120501-bf82308e8c85/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
@@ -409,6 +410,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -478,7 +480,6 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/openshift/api v0.0.0-20210331162552-3e31249e6a55/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
-github.com/openshift/api v0.0.0-20210331193751-3acddb19d360 h1:EGWKZ4foeELg9R+0OaLXKUoqHmtUwAMq0fCBUirbKwY=
 github.com/openshift/api v0.0.0-20210331193751-3acddb19d360/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
 github.com/openshift/api v0.0.0-20210405135614-54ceb5f6699b h1:14IHIU4EH0JNVfR015L5H1pqtwTAqVCPCTbZAu8+914=
 github.com/openshift/api v0.0.0-20210405135614-54ceb5f6699b/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
@@ -519,7 +520,6 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
@@ -536,7 +536,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
-github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
@@ -574,6 +573,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.0-20170118185516-dc208f4211e7/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
@@ -603,6 +603,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/summerwind/h2spec v0.0.0-20200804131034-70ac22940108 h1:ecwW3RnjsJlnVZkvXHaxa+Hg0EW+6KF8mFovyFk+WZA=
+github.com/summerwind/h2spec v0.0.0-20200804131034-70ac22940108/go.mod h1:jn/HqC28P+sr5C23xwQQyRzsvJPpWnPGX20sJKIJIwE=
 github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419 h1:elOIj31UL4RZWgLfLV4pWZA0j5QqGO95/Dll2WIwOZU=
 github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419/go.mod h1:s3JVJFtQxtBEBC9dwcdTTXS9xFnM3SXAZwPG41aurT8=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -703,6 +705,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 h1:xUIPaMhvROX9dhPvRCenIJtU78+lbEenGbgqB5hfHCQ=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20161104230106-55a3084c9119/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/test/h2spec/client.go
+++ b/test/h2spec/client.go
@@ -1,0 +1,155 @@
+package h2spec
+
+// This is a slightly modified version of https://github.com/summerwind/h2spec/blob/70ac2294010887f48b18e2d64f5cccd48421fad1/cmd/h2spec/h2spec.go
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/summerwind/h2spec"
+	h2specconfig "github.com/summerwind/h2spec/config"
+)
+
+var (
+	version string = "2.6.0"
+	commit  string = "70ac2294010887f48b18e2d64f5cccd48421fad1"
+)
+
+func NewClientCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "h2spec [args...]",
+		Short: "Conformance testing tool for HTTP/2 implementation",
+		Long:  "Conformance testing tool for HTTP/2 implementation.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args)
+		},
+	}
+
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	flags := cmd.Flags()
+	flags.StringP("host", "h", "127.0.0.1", "Target host")
+	flags.IntP("port", "p", 0, "Target port")
+	flags.StringP("path", "P", "/", "Target path")
+	flags.IntP("timeout", "o", 2, "Time seconds to test timeout")
+	flags.Int("max-header-length", 4000, "Maximum length of HTTP header")
+	flags.StringP("junit-report", "j", "", "Path for JUnit test report")
+	flags.BoolP("strict", "S", false, "Run all test cases including strict test cases")
+	flags.Bool("dryrun", false, "Display only the title of test cases")
+	flags.BoolP("tls", "t", false, "Connect over TLS")
+	flags.StringP("ciphers", "c", "", "List of colon-separated TLS cipher names")
+	flags.BoolP("insecure", "k", false, "Don't verify server's certificate")
+	flags.BoolP("verbose", "v", false, "Output verbose log")
+	flags.Bool("version", false, "Display version information and exit")
+	flags.Bool("help", false, "Display this help and exit")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	flags := cmd.Flags()
+
+	v, err := flags.GetBool("version")
+	if err != nil {
+		return err
+	}
+
+	if v {
+		fmt.Printf("Version: %s (%s)\n", version, commit)
+		return nil
+	}
+
+	host, err := flags.GetString("host")
+	if err != nil {
+		return err
+	}
+
+	port, err := flags.GetInt("port")
+	if err != nil {
+		return err
+	}
+
+	path, err := flags.GetString("path")
+	if err != nil {
+		return err
+	}
+
+	timeout, err := flags.GetInt("timeout")
+	if err != nil {
+		return err
+	}
+
+	maxHeaderLen, err := flags.GetInt("max-header-length")
+	if err != nil {
+		return err
+	}
+
+	junitReport, err := flags.GetString("junit-report")
+	if err != nil {
+		return err
+	}
+
+	strict, err := flags.GetBool("strict")
+	if err != nil {
+		return err
+	}
+
+	dryRun, err := flags.GetBool("dryrun")
+	if err != nil {
+		return err
+	}
+
+	tls, err := flags.GetBool("tls")
+	if err != nil {
+		return err
+	}
+
+	ciphers, err := flags.GetString("ciphers")
+	if err != nil {
+		return err
+	}
+
+	insecure, err := flags.GetBool("insecure")
+	if err != nil {
+		return err
+	}
+
+	verbose, err := flags.GetBool("verbose")
+	if err != nil {
+		return err
+	}
+
+	if port == 0 {
+		if tls {
+			port = 443
+		} else {
+			port = 80
+		}
+	}
+
+	c := &h2specconfig.Config{
+		Host:         host,
+		Port:         port,
+		Path:         path,
+		Timeout:      time.Duration(timeout) * time.Second,
+		MaxHeaderLen: maxHeaderLen,
+		JUnitReport:  junitReport,
+		Strict:       strict,
+		DryRun:       dryRun,
+		TLS:          tls,
+		Ciphers:      ciphers,
+		Insecure:     insecure,
+		Verbose:      verbose,
+		Sections:     args,
+	}
+
+	success, err := h2spec.Run(c)
+	if !success {
+		os.Exit(1)
+	}
+
+	return err
+}

--- a/vendor/github.com/summerwind/h2spec/.gitignore
+++ b/vendor/github.com/summerwind/h2spec/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+h2spec
+h2specd
+glide.lock
+vendor/
+release/

--- a/vendor/github.com/summerwind/h2spec/Dockerfile
+++ b/vendor/github.com/summerwind/h2spec/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.14 as builder
+
+ARG VERSION
+ARG COMMIT
+
+ENV GO111MODULE=on \
+    GOPROXY=https://proxy.golang.org
+
+WORKDIR /go/src/github.com/summerwind/h2spec
+COPY go.mod go.sum .
+RUN go mod download
+
+COPY . /workspace
+WORKDIR /workspace
+
+RUN go vet ./...
+RUN go test -v ./...
+RUN CGO_ENABLED=0 go build -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT}" ./cmd/h2spec
+
+###################
+
+FROM ubuntu:18.04
+
+COPY --from=builder /workspace/h2spec /usr/local/bin/h2spec
+
+ENTRYPOINT ["/usr/local/bin/h2spec"]

--- a/vendor/github.com/summerwind/h2spec/LICENSE
+++ b/vendor/github.com/summerwind/h2spec/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Moto Ishizawa
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/summerwind/h2spec/Makefile
+++ b/vendor/github.com/summerwind/h2spec/Makefile
@@ -1,0 +1,42 @@
+VERSION=2.6.0
+COMMIT=$(shell git rev-parse --verify HEAD)
+BUILD_FLAGS=-ldflags "-X main.VERSION=$(VERSION) -X main.COMMIT=$(COMMIT)"
+
+all: build
+
+build:
+	go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+
+test:
+	go vet ./...
+	go test -v ./...
+
+clean:
+	rm -rf h2spec release
+
+build-container:
+	docker build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) -t summerwind/h2spec:latest -t summerwind/h2spec:$(VERSION) .
+
+push-container:
+	docker push summerwind/h2spec:latest
+
+push-release-container:
+	docker push summerwind/h2spec:$(VERSION)
+
+release:
+	mkdir -p release
+	
+	GOARCH=amd64 GOOS=darwin go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+	tar -czf release/h2spec_darwin_amd64.tar.gz h2spec
+	rm -rf h2spec
+	
+	GOARCH=amd64 GOOS=windows go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+	zip release/h2spec_windows_amd64.zip -r h2spec.exe
+	rm -rf h2spec.exe
+	
+	GOARCH=amd64 GOOS=linux go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+	tar -czf release/h2spec_linux_amd64.tar.gz h2spec
+	rm -rf h2spec
+
+github-release: release
+	ghr v$(VERSION) release/

--- a/vendor/github.com/summerwind/h2spec/README.md
+++ b/vendor/github.com/summerwind/h2spec/README.md
@@ -1,0 +1,109 @@
+# h2spec
+
+h2spec is a conformance testing tool for HTTP/2 implementation.  
+This tool is compliant with [RFC 7540 (HTTP/2)](http://www.rfc-editor.org/rfc/rfc7540.txt) and [RFC 7541 (HPACK)](http://www.rfc-editor.org/rfc/rfc7541.txt).
+
+## Install
+
+Go to the [releases page](https://github.com/summerwind/h2spec/releases), find the version you want, and download the zip file or tarball file. The docker image is also available in [Docker Hub](https://hub.docker.com/r/summerwind/h2spec/).
+
+## Your server
+
+Your server should respond on `GET /` or `POST /` requests with status 200 response with non-empty data.
+
+## Usage
+
+```
+Conformance testing tool for HTTP/2 implementation.
+
+Usage:
+  h2spec [spec...] [flags]
+
+Flags:
+  -c, --ciphers string          List of colon-separated TLS cipher names
+      --dryrun                  Display only the title of test cases
+      --help                    Display this help and exit
+  -h, --host string             Target host (default "127.0.0.1")
+  -k, --insecure                Don't verify server's certificate
+  -j, --junit-report string     Path for JUnit test report
+      --max-header-length int   Maximum length of HTTP header (default 4000)
+  -P, --path string             Target path (default "/")
+  -p, --port int                Target port
+  -S, --strict                  Run all test cases including strict test cases
+  -o, --timeout int             Time seconds to test timeout (default 2)
+  -t, --tls                     Connect over TLS
+  -v, --verbose                 Output verbose log
+      --version                 Display version information and exit
+```
+
+### Running a specific test case
+
+You can choose a test case to run by specifying the *Spec ID* as the command argument. For example, if you want to run test cases for HTTP/2, run h2spec as following:
+
+```
+$ h2spec http2
+```
+
+If you add a section number after the *Spec ID*, test cases related to a specific section will be run. For example, if you want to run test cases related to 6.3 of HTTP/2, run h2spec as following:
+
+```
+$ h2spec http2/6.3
+```
+
+If you add a test number after the section number, you can run the specific test case individually. For example, to run only the first test case related to 6.3 of HTTP/2 6.3, run h2spec as following:
+
+```
+$ h2spec http2/6.3/1
+```
+
+The *Spec ID* can be specified multiple times.
+
+```
+$ h2spec http2/6.3 generic
+```
+
+Currently supported *Spec IDs* are as follows. `generic` is the original spec of h2spec, includes generic test cases for HTTP/2 servers.
+
+Spec ID | Description
+--- | ---
+http2 | Test cases for RFC 7540 (HTTP/2)
+hpack | Test cases for RFC 7541 (HPACK)
+generic | Generic test cases for HTTP/2 servers
+
+### Dryrun Mode
+
+To display the list of test cases to be run, use *Dryrun Mode* as follows:
+
+```
+$ h2spec --dryrun
+```
+
+### Strict Mode
+
+When *Strict Mode* is enabled, h2spec will run the test cases related to the contents requested with the `SHOULD` notation in each specification. It is useful for more rigorous verification of HTTP/2 implementation.
+
+```
+$ h2spec --strict
+```
+
+## Screenshot
+
+![Sceenshot](https://cloud.githubusercontent.com/assets/230145/22183160/9e9fbb4c-e0fa-11e6-9383-e2cc1ed6750a.png)
+
+## Build
+
+To build from source, you need to install [Go](https://golang.org) and export `GO111MODULE=on` first.
+
+To build:
+```
+$ make build
+```
+
+To test:
+```
+$ make test
+```
+
+## License
+
+h2spec is made available under MIT license.

--- a/vendor/github.com/summerwind/h2spec/client/1_starting_http2.go
+++ b/vendor/github.com/summerwind/h2spec/client/1_starting_http2.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func StartingHTTP2() *spec.ClientTestGroup {
+	tg := NewTestGroup("1", "Starting HTTP/2")
+
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a server connection preface",
+		Requirement: "The endpoint MUST accept server connection preface.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			return err
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/4_1_frame_format.go
+++ b/vendor/github.com/summerwind/h2spec/client/4_1_frame_format.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func FrameFormat() *spec.ClientTestGroup {
+	tg := NewTestGroup("4.1", "Frame Format")
+
+	// Type: The 8-bit type of the frame. The frame type determines
+	// the format and semantics of the frame. Implementations MUST
+	// ignore and discard any frame that has a type that is unknown.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a frame with unknown type",
+		Requirement: "The endpoint MUST ignore and discard any frame that has a type that is unknown.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// UNKONWN Frame:
+			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// Flags are assigned semantics specific to the indicated frame
+	// type. Flags that have no defined semantics for a particular
+	// frame type MUST be ignored and MUST be left unset (0x0) when
+	// sending.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a frame with undefined flag",
+		Requirement: "The endpoint MUST ignore any flags that is undefined.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING Frame:
+			// Length: 8, Type: 6, Flags: 255, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x06\x16\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyEventType(conn, spec.EventPingFrame)
+		},
+	})
+
+	// R: A reserved 1-bit field. The semantics of this bit are
+	// undefined, and the bit MUST remain unset (0x0) when sending
+	// and MUST be ignored when receiving.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a frame with reserved field bit",
+		Requirement: "The endpoint MUST ignore the value of reserved field.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING Frame:
+			// Length: 8, Type: 6, Flags: 255, R: 1, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x06\x16\x80\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyEventType(conn, spec.EventPingFrame)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/4_2_frame_size.go
+++ b/vendor/github.com/summerwind/h2spec/client/4_2_frame_size.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func FrameSize() *spec.ClientTestGroup {
+	tg := NewTestGroup("4.2", "Frame Size")
+
+	// All implementations MUST be capable of receiving and minimally
+	// processing frames up to 2^14 octets in length, plus the 9-octet
+	// frame header (Section 4.1).
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a DATA frame with 2^14 octets in length",
+		Requirement: "The endpoint MUST be capable of receiving and minimally processing frames up to 2^14 octets in length.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			data := spec.DummyString(conn.MaxFrameSize())
+			conn.WriteData(req.StreamID, true, []byte(data))
+
+			pingData := [8]byte{}
+			conn.WritePing(false, pingData)
+
+			return spec.VerifyPingFrameWithAck(conn, pingData)
+		},
+	})
+
+	// An endpoint MUST send an error code of FRAME_SIZE_ERROR
+	// if a frame exceeds the size defined in SETTINGS_MAX_FRAME_SIZE,
+	// exceeds any limit defined for the frame type, or is too small
+	// to contain mandatory frame data.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a large size DATA frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
+		Requirement: "The endpoint MUST send an error code of FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			data := spec.DummyString(conn.MaxFrameSize() + 1)
+			conn.WriteData(req.StreamID, true, []byte(data))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	// A frame size error in a frame that could alter the state of
+	// the entire connection MUST be treated as a connection error
+	// (Section 5.4.1); this includes any frame carrying a header block
+	// (Section 4.3) (that is, HEADERS, PUSH_PROMISE, and CONTINUATION),
+	// SETTINGS, and any frame with a stream identifier of 0.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a large size HEADERS frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			headers = append(headers, spec.DummyRespHeaders(c, 5)...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/4_3_header_compression_and_decompression.go
+++ b/vendor/github.com/summerwind/h2spec/client/4_3_header_compression_and_decompression.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func HeaderCompressionAndDecompression() *spec.ClientTestGroup {
+	tg := NewTestGroup("4.3", "Header Compression and Decompression")
+
+	// A decoding error in a header block MUST be treated as
+	// a connection error (Section 5.4.1) of type COMPRESSION_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends invalid header block fragment",
+		Requirement: "The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field with Incremental Indexing without
+			// Length and String segment.
+			data := new(bytes.Buffer)
+			data.Write([]byte("\x00\x00\x01\x01\x05"))
+			binary.Write(data, binary.LittleEndian, req.StreamID)
+			data.Write([]byte{0x40})
+
+			err = conn.Send(data.Bytes())
+			if err != nil {
+				return err
+			}
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/4_http_frames.go
+++ b/vendor/github.com/summerwind/h2spec/client/4_http_frames.go
@@ -1,0 +1,13 @@
+package client
+
+import "github.com/summerwind/h2spec/spec"
+
+func HTTPFrames() *spec.ClientTestGroup {
+	tg := NewTestGroup("4", "HTTP Frames")
+
+	tg.AddTestGroup(FrameFormat())
+	tg.AddTestGroup(FrameSize())
+	tg.AddTestGroup(HeaderCompressionAndDecompression())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_1_1_stream_identifiers.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_1_1_stream_identifiers.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamIdentifiers() *spec.ClientTestGroup {
+	tg := NewTestGroup("5.1.1", "Stream Identifiers")
+
+	// An endpoint that receives an unexpected stream identifier
+	// MUST respond with a connection error (Section 5.4.1) of
+	// type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends an unexpected stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      101,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_1_stream_states.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_1_stream_states.go
@@ -1,0 +1,313 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamStates() *spec.ClientTestGroup {
+	tg := NewTestGroup("5.1", "Stream States")
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "idle: Sends a DATA frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteData(2, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "idle: Sends a RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(2, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "idle: Sends a WINDOW_UPDATE frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(2, 100)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "idle: Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			conn.WriteContinuation(2, true, blockFragment)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a DATA frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(req.StreamID, http2.ErrCodeCancel)
+
+			conn.WriteData(req.StreamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a HEADERS frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			conn.WriteRSTStream(req.StreamID, http2.ErrCodeCancel)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a CONTINUATION frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(req.StreamID, http2.ErrCodeCancel)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeStreamClosed,
+				http2.ErrCodeProtocol,
+			}
+			return spec.VerifyStreamError(conn, codes...)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a DATA frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteData(req.StreamID, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a HEADERS frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "closed: Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeStreamClosed,
+				http2.ErrCodeProtocol,
+			}
+			return spec.VerifyConnectionError(conn, codes...)
+		},
+	})
+
+	tg.AddTestGroup(StreamIdentifiers())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_4_1_connection_error_handling.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_4_1_connection_error_handling.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func ConnectionErrorHandling() *spec.ClientTestGroup {
+	tg := NewTestGroup("5.4.1", "Connection Error Handling")
+
+	// After sending the GOAWAY frame for an error condition,
+	// the endpoint MUST close the TCP connection.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends an invalid PING frame for connection close",
+		Requirement: "The endpoint MUST close the TCP connection",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame with invalid stream ID
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionClose(conn)
+		},
+	})
+
+	// An endpoint that encounters a connection error SHOULD first send
+	// a GOAWAY frame (Section 6.8) with the stream identifier of the last
+	// stream that it successfully received from its peer.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends an invalid PING frame to receive GOAWAY frame",
+		Requirement: "An endpoint that encounters a connection error SHOULD first send a GOAWAY frame",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame with invalid stream ID
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			actual, passed := conn.WaitEventByType(spec.EventGoAwayFrame)
+			if !passed {
+				return &spec.TestError{
+					Expected: []string{
+						fmt.Sprintf(spec.ExpectedGoAwayFrame, http2.ErrCodeProtocol),
+					},
+					Actual: actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_4_error_handling.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_4_error_handling.go
@@ -1,0 +1,11 @@
+package client
+
+import "github.com/summerwind/h2spec/spec"
+
+func ErrorHandling() *spec.ClientTestGroup {
+	tg := NewTestGroup("5.4", "Error Handling")
+
+	tg.AddTestGroup(ConnectionErrorHandling())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_5_extending_http2.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_5_extending_http2.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func ExtendingHTTP2() *spec.ClientTestGroup {
+	tg := NewTestGroup("5.5", "Extending HTTP/2")
+
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends an unknown extension frame",
+		Requirement: "The endpoint MUST ignore unknown or unsupported values in all extensible protocol elements.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// UNKONWN Frame:
+			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/5_streams_and_multiplexing.go
+++ b/vendor/github.com/summerwind/h2spec/client/5_streams_and_multiplexing.go
@@ -1,0 +1,13 @@
+package client
+
+import "github.com/summerwind/h2spec/spec"
+
+func StreamsAndMultiplexing() *spec.ClientTestGroup {
+	tg := NewTestGroup("5", "Streams and Multiplexing")
+
+	tg.AddTestGroup(StreamStates())
+	tg.AddTestGroup(ErrorHandling())
+	tg.AddTestGroup(ExtendingHTTP2())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_10_continuation.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_10_continuation.go
@@ -1,0 +1,230 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Continuation() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.10", "CONTINUATION")
+
+	// The CONTINUATION frame (type=0x9) is used to continue a sequence
+	// of header block fragments (Section 4.3). Any number of
+	// CONTINUATION frames can be sent, as long as the preceding frame
+	// is on the same stream and is a HEADERS, PUSH_PROMISE,
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends multiple CONTINUATION frames preceded by a HEADERS frame",
+		Requirement: "The endpoint must accept the frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// END_HEADERS (0x4):
+	// If the END_HEADERS bit is not set, this frame MUST be followed
+	// by another CONTINUATION frame. A receiver MUST treat the receipt
+	// of any other type of frame or a frame on a different stream as
+	// a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a CONTINUATION frame followed by any frame other than CONTINUATION",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteData(req.StreamID, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// CONTINUATION frames MUST be associated with a stream. If a
+	// CONTINUATION frame is received whose stream identifier field is
+	// 0x0, the recipient MUST respond with a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a CONTINUATION frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(0, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a HEADERS frame with END_HEADERS flag",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a CONTINUATION frame with END_HEADERS flag",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a DATA frame",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+			conn.WriteData(req.StreamID, true, []byte("test"))
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(0, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_1_data.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_1_data.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Data() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.1", "DATA")
+
+	// DATA frames MUST be associated with a stream. If a DATA frame is
+	// received whose stream identifier field is 0x0, the recipient
+	// MUST respond with a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a DATA frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteData(0, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// If a DATA frame is received whose stream is not in "open" or
+	// "half-closed (local)" state, the recipient MUST respond with
+	// a stream error (Section 5.4.2) of type STREAM_CLOSED.
+	//
+	// Note: This test case is duplicated with 5.1.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a DATA frame on the stream that is not in \"open\" or \"half-closed (local)\" state",
+		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(req.StreamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// If the length of the padding is the length of the frame payload
+	// or greater, the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a DATA frame with invalid pad length",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			headers = append(headers, spec.HeaderField("content-length", "4"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			// DATA frame:
+			// frame length: 5, pad length: 6
+			payload := []byte("\x06\x54\x65\x73\x74")
+			var flags http2.Flags
+			flags |= http2.FlagHeadersEndStream
+			flags |= http2.FlagHeadersPadded
+			conn.WriteRawFrame(http2.FrameData, flags, req.StreamID, payload)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_2_headers.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_2_headers.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Headers() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.2", "HEADERS")
+
+	// END_HEADERS (0x4):
+	// A HEADERS frame without the END_HEADERS flag set MUST be
+	// followed by a CONTINUATION frame for the same stream.
+	// A receiver MUST treat the receipt of any other type of frame
+	// or a frame on a different stream as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	//
+	// Note: This test case is duplicated with 4.3.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a HEADERS frame without the END_HEADERS flag, and a PRIORITY frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(req.StreamID, pp)
+
+			dummyHeaders := spec.DummyRespHeaders(c, 1)
+			conn.WriteContinuation(req.StreamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// HEADERS frames MUST be associated with a stream. If a HEADERS
+	// frame is received whose stream identifier field is 0x0, the
+	// recipient MUST respond with a connection error (Section 5.4.1)
+	// of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a HEADERS frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      0,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// The HEADERS frame can include padding. Padding fields and flags
+	// are identical to those defined for DATA frames (Section 6.1).
+	// Padding that exceeds the size remaining for the header block
+	// fragment MUST be treated as a PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a HEADERS frame with invalid pad length",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+
+			// HEADERS frame:
+			// frame length: 16, pad length: 17
+			var flags http2.Flags
+			flags |= http2.FlagHeadersPadded
+			payload := append([]byte("\x11"), conn.EncodeHeaders(headers)...)
+			conn.WriteRawFrame(http2.FrameHeaders, flags, req.StreamID, payload)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_3_priority.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_3_priority.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Priority() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.3", "PRIORITY")
+
+	// The PRIORITY frame always identifies a stream. If a PRIORITY
+	// frame is received with a stream identifier of 0x0, the recipient
+	// MUST respond with a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PRIORITY frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(0, pp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A PRIORITY frame with a length other than 5 octets MUST be
+	// treated as a stream error (Section 5.4.2) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PRIORITY frame with a length other than 5 octets",
+		Requirement: "The endpoint MUST respond with a stream error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// PRIORITY frame:
+			// length: 4, flags: 0x0, stream_id: 0x01
+			var flags http2.Flags
+			conn.WriteRawFrame(http2.FramePriority, flags, req.StreamID, []byte("\x80\x00\x00\x01"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_4_rst_stream.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_4_rst_stream.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func RSTStream() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.4", "RST_STREAM")
+
+	// RST_STREAM frames MUST be associated with a stream.  If a
+	// RST_STREAM frame is received with a stream identifier of 0x0,
+	// the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a RST_STREAM frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(0, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// RST_STREAM frames MUST NOT be sent for a stream in the "idle"
+	// state. If a RST_STREAM frame identifying an idle stream is
+	// received, the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a RST_STREAM frame on a idle stream",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(2, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A RST_STREAM frame with a length other than 4 octets MUST be
+	// treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a RST_STREAM frame with a length other than 4 octets",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// RST_STREAM frame:
+			// length: 3, flags: 0x0, stream_id: 0x01
+			var flags http2.Flags
+			conn.WriteRawFrame(http2.FrameRSTStream, flags, req.StreamID, []byte("\x00\x00\x00"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_5_2_defined_settings_parameters.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_5_2_defined_settings_parameters.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"errors"
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func DefinedSETTINGSParameters() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.5.2", "Defined SETTINGS Parameters")
+
+	// SETTINGS_INITIAL_WINDOW_SIZE (0x4):
+	// Values above the maximum flow-control window size of 2^31-1
+	// MUST be treated as a connection error (Section 5.4.1) of
+	// type FLOW_CONTROL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size",
+		Requirement: "The endpoint MUST treat this as a connection error of type FLOW_CONTROL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: 2147483648,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFlowControl)
+		},
+	})
+
+	// SETTINGS_MAX_FRAME_SIZE (0x5):
+	// The initial value is 2^14 (16,384) octets. The value advertised
+	// by an endpoint MUST be between this initial value and the
+	// maximum allowed frame size (2^24-1 or 16,777,215 octets),
+	// inclusive. Values outside this range MUST be treated as a
+	// connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value below the initial value",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingMaxFrameSize,
+				Val: 16383,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// SETTINGS_MAX_FRAME_SIZE (0x5):
+	// The initial value is 2^14 (16,384) octets. The value advertised
+	// by an endpoint MUST be between this initial value and the
+	// maximum allowed frame size (2^24-1 or 16,777,215 octets),
+	// inclusive. Values outside this range MUST be treated as a
+	// connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value above the maximum allowed frame size",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingMaxFrameSize,
+				Val: 16777216,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// An endpoint that receives a SETTINGS frame with any unknown
+	// or unsupported identifier MUST ignore that setting.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a SETTINGS frame with unknown identifier",
+		Requirement: "The endpoint MUST ignore that setting.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			setting := http2.Setting{
+				ID:  0xFF,
+				Val: 1,
+			}
+			conn.WriteSettings(setting)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_5_3_settings_synchronization.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_5_3_settings_synchronization.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"errors"
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func SettingsSynchronization() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.5.3", "Settings Synchronization")
+
+	// Once all values have been processed, the recipient MUST
+	// immediately emit a SETTINGS frame with the ACK flag set.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a SETTINGS frame without ACK flag",
+		Requirement: "The endpoint MUST immediately emit a SETTINGS frame with the ACK flag set.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingMaxConcurrentStreams,
+				Val: 100,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifySettingsFrameWithAck(conn)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_5_settings.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_5_settings.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"errors"
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Settings() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.5", "SETTINGS")
+
+	// ACK (0x1):
+	// When set, bit 0 indicates that this frame acknowledges receipt
+	// and application of the peer's SETTINGS frame. When this bit is
+	// set, the payload of the SETTINGS frame MUST be empty. Receipt of
+	// a SETTINGS frame with the ACK flag set and a length field value
+	// other than 0 MUST be treated as a connection error (Section 5.4.1)
+	// of type FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a SETTINGS frame with ACK flag and payload",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			// SETTINGS frame:
+			// length: 0, flags: 0x1, stream_id: 0x0
+			conn.Send([]byte("\x00\x00\x01\x04\x01\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	// SETTINGS frames always apply to a connection, never a single
+	// stream. The stream identifier for a SETTINGS frame MUST be
+	// zero (0x0). If an endpoint receives a SETTINGS frame whose
+	// stream identifier field is anything other than 0x0, the
+	// endpoint MUST respond with a connection error (Section 5.4.1)
+	// of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a SETTINGS frame with a stream identifier other than 0x0",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			// SETTINGS frame:
+			// length: 6, flags: 0x0, stream_id: 0x1
+			conn.Send([]byte("\x00\x00\x06\x04\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x03\x00\x00\x00\x64"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// The SETTINGS frame affects connection state. A badly formed or
+	// incomplete SETTINGS frame MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	//
+	// A SETTINGS frame with a length other than a multiple of 6 octets
+	// MUST be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a SETTINGS frame with a length other than a multiple of 6 octets",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
+			// SETTINGS frame:
+			// length: 3, flags: 0x0, stream_id: 0x0
+			conn.Send([]byte("\x00\x00\x03\x04\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x03\x00"))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeProtocol,
+				http2.ErrCodeFrameSize,
+			}
+			return spec.VerifyStreamError(conn, codes...)
+		},
+	})
+
+	tg.AddTestGroup(DefinedSETTINGSParameters())
+	tg.AddTestGroup(SettingsSynchronization())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_7_ping.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_7_ping.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Ping() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.7", "PING")
+
+	// Receivers of a PING frame that does not include an ACK flag MUST
+	// send a PING frame with the ACK flag set in response, with an
+	// identical payload.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PING frame",
+		Requirement: "The endpoint MUST sends a PING frame with ACK, with an identical payload.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// ACK (0x1):
+	// When set, bit 0 indicates that this PING frame is a PING
+	// response. An endpoint MUST set this flag in PING responses.
+	// An endpoint MUST NOT respond to PING frames containing this
+	// flag.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PING frame with ACK",
+		Requirement: "The endpoint MUST NOT respond to PING frames with ACK.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			unexpectedData := [8]byte{'i', 'n', 'v', 'a', 'l', 'i', 'd'}
+			expectedData := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(true, unexpectedData)
+			conn.WritePing(false, expectedData)
+
+			return spec.VerifyPingFrameWithAck(conn, expectedData)
+		},
+	})
+
+	// If a PING frame is received with a stream identifier field value
+	// other than 0x0, the recipient MUST respond with a connection
+	// error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PING frame with a stream identifier field value other than 0x0",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame:
+			// length: 8, flags: 0x0, stream_id: 1
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// Receipt of a PING frame with a length field value other than 8
+	// MUST be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a PING frame with a length field value other than 8",
+		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame:
+			// length: 8, flags: 0x0, stream_id: 1
+			conn.Send([]byte("\x00\x00\x06\x06\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_8_goaway.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_8_goaway.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func GoAway() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.8", "GOAWAY")
+
+	// An endpoint MUST treat a GOAWAY frame with a stream identifier
+	// other than 0x0 as a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a GOAWAY frame with a stream identifier other than 0x0",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// GOAWAY frame:
+			// length: 8, flags: 0x0, stream_id: 1
+			conn.Send([]byte("\x00\x00\x08\x07\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_9_1_the_flow_control_window.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_9_1_the_flow_control_window.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func TheFlowControlWindow() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.9.1", "The Flow-Control Window")
+
+	// A sender MUST NOT allow a flow-control window to exceed 2^31-1
+	// octets. If a sender receives a WINDOW_UPDATE that causes a
+	// flow-control window to exceed this maximum, it MUST terminate
+	// either the stream or the connection, as appropriate.
+	// For streams, the sender sends a RST_STREAM with an error code
+	// of FLOW_CONTROL_ERROR; for the connection, a GOAWAY frame with
+	// an error code of FLOW_CONTROL_ERROR is sent.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1",
+		Requirement: "The endpoint MUST sends a GOAWAY frame with a FLOW_CONTROL_ERROR code.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(0, 2147483647)
+			conn.WriteWindowUpdate(0, 2147483647)
+
+			actual, passed := conn.WaitEventByType(spec.EventGoAwayFrame)
+			switch event := actual.(type) {
+			case spec.GoAwayFrameEvent:
+				passed = (event.ErrCode == http2.ErrCodeFlowControl)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("GOAWAY Frame (Error Code: %s)", http2.ErrCodeFlowControl),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// A sender MUST NOT allow a flow-control window to exceed 2^31-1
+	// octets. If a sender receives a WINDOW_UPDATE that causes a
+	// flow-control window to exceed this maximum, it MUST terminate
+	// either the stream or the connection, as appropriate.
+	// For streams, the sender sends a RST_STREAM with an error code
+	// of FLOW_CONTROL_ERROR; for the connection, a GOAWAY frame with
+	// an error code of FLOW_CONTROL_ERROR is sent.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream",
+		Requirement: "The endpoint MUST sends a RST_STREAM frame with a FLOW_CONTROL_ERROR code.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(req.StreamID, 2147483647)
+			conn.WriteWindowUpdate(req.StreamID, 2147483647)
+
+			actual, passed := conn.WaitEventByType(spec.EventRSTStreamFrame)
+			switch event := actual.(type) {
+			case spec.RSTStreamFrameEvent:
+				if event.Header().StreamID == req.StreamID {
+					passed = (event.ErrCode == http2.ErrCodeFlowControl)
+				}
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("RST_STREAM Frame (Error Code: %s)", http2.ErrCodeFlowControl),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_9_window_update.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_9_window_update.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func WindowUpdate() *spec.ClientTestGroup {
+	tg := NewTestGroup("6.9", "WINDOW_UPDATE")
+
+	// A receiver MUST treat the receipt of a WINDOW_UPDATE frame with
+	// an flow-control window increment of 0 as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR; errors on the connection
+	// flow-control window MUST be treated as a connection error
+	// (Section 5.4.1).
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(0, 0)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A receiver MUST treat the receipt of a WINDOW_UPDATE frame with
+	// an flow-control window increment of 0 as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR; errors on the connection
+	// flow-control window MUST be treated as a connection error
+	// (Section 5.4.1).
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonRespHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      req.StreamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(req.StreamID, 0)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A WINDOW_UPDATE frame with a length other than 4 octets MUST
+	// be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.ClientTestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a length other than 4 octets",
+		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// WINDOW_UPDATE frame:
+			// length: 3, flags: 0x0, stream_id: 0
+			conn.Send([]byte("\x00\x00\x03\x08\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x01"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	tg.AddTestGroup(TheFlowControlWindow())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/6_frame_definitions.go
+++ b/vendor/github.com/summerwind/h2spec/client/6_frame_definitions.go
@@ -1,0 +1,19 @@
+package client
+
+import "github.com/summerwind/h2spec/spec"
+
+func FrameDefinitions() *spec.ClientTestGroup {
+	tg := NewTestGroup("6", "Frame Definitions")
+
+	tg.AddTestGroup(Data())
+	tg.AddTestGroup(Headers())
+	tg.AddTestGroup(Priority())
+	tg.AddTestGroup(RSTStream())
+	tg.AddTestGroup(Settings())
+	tg.AddTestGroup(Ping())
+	tg.AddTestGroup(GoAway())
+	tg.AddTestGroup(WindowUpdate())
+	tg.AddTestGroup(Continuation())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/client/client.go
+++ b/vendor/github.com/summerwind/h2spec/client/client.go
@@ -1,0 +1,27 @@
+package client
+
+import "github.com/summerwind/h2spec/spec"
+
+var key = "client"
+
+func NewTestGroup(section string, name string) *spec.ClientTestGroup {
+	return &spec.ClientTestGroup{
+		Key:     key,
+		Section: section,
+		Name:    name,
+	}
+}
+
+func Spec() *spec.ClientTestGroup {
+	tg := &spec.ClientTestGroup{
+		Key:  key,
+		Name: "Generic tests for HTTP/2 client",
+	}
+
+	tg.AddTestGroup(StartingHTTP2())
+	tg.AddTestGroup(HTTPFrames())
+	tg.AddTestGroup(StreamsAndMultiplexing())
+	tg.AddTestGroup(FrameDefinitions())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/config/config.go
+++ b/vendor/github.com/summerwind/h2spec/config/config.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	RunModeAll = iota
+	RunModeGroup
+	RunModeNone
+)
+
+// Config represents the configuration of h2spec.
+type Config struct {
+	Host         string
+	Port         int
+	Path         string
+	Timeout      time.Duration
+	MaxHeaderLen int
+	JUnitReport  string
+	Strict       bool
+	DryRun       bool
+	TLS          bool
+	Ciphers      string
+	Insecure     bool
+	Verbose      bool
+	Sections     []string
+	targetMap    map[string]bool
+	CertFile     string
+	CertKeyFile  string
+	Exec         string
+	FromPort     int
+}
+
+// Addr returns the string concatenated with hostname and port number.
+func (c *Config) Addr() string {
+	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+}
+
+func (c *Config) Scheme() string {
+	if c.TLS {
+		return "https"
+	} else {
+		return "http"
+	}
+}
+
+func CiphersuiteByName(name string) uint16 {
+	switch name {
+	case "TLS_RSA_WITH_RC4_128_SHA":
+		return tls.TLS_RSA_WITH_RC4_128_SHA
+	case "TLS_RSA_WITH_3DES_EDE_CBC_SHA":
+		return tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA
+	case "TLS_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_RSA_WITH_AES_128_CBC_SHA
+	case "TLS_RSA_WITH_AES_128_CBC_SHA256":
+		return tls.TLS_RSA_WITH_AES_128_CBC_SHA256
+	case "TLS_RSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_RSA_WITH_AES_256_GCM_SHA384
+	case "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+	case "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+	case "TLS_ECDHE_RSA_WITH_RC4_128_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA
+	case "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+	case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+	case "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+	case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+	case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+	case "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	case "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+	case "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":
+		return tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+	case "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":
+		return tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+	}
+	return 0
+}
+
+// Decode the user-defined list of allowed cipher suites from string
+// representation.
+// TODO: now Golang doesn't provide a way to convert ciphersuite name to ID,
+// thus manual implementation is required.
+func (c *Config) GetCiphersuites() []uint16 {
+	var ids []uint16
+
+	for _, name := range strings.Split(c.Ciphers, ":") {
+		id := CiphersuiteByName(name)
+		if id != 0 {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// TLSConfig returns a tls.Config based on the configuration of h2spec.
+func (c *Config) TLSConfig() (*tls.Config, error) {
+	if !c.TLS {
+		return nil, nil
+	}
+
+	config := tls.Config{
+		InsecureSkipVerify: c.Insecure,
+		CipherSuites: c.GetCiphersuites(),
+	}
+
+	if config.NextProtos == nil {
+		config.NextProtos = append(config.NextProtos, "h2", "h2-16")
+	}
+
+	if c.CertFile != "" && c.CertKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(c.CertFile, c.CertKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		config.Certificates = []tls.Certificate{cert}
+	}
+
+	return &config, nil
+}
+
+// RunMode returns a run mode of specified the section number.
+// This is used to decide whether to run test cases.
+func (c *Config) RunMode(section string) int {
+	if c.targetMap == nil {
+		c.buildTargetMap()
+	}
+
+	if len(c.targetMap) == 0 {
+		return RunModeAll
+	}
+
+	comps := strings.Split(section, "/")
+	compLen := len(comps)
+
+	if compLen == 0 || compLen > 3 {
+		return RunModeNone
+	}
+
+	keys := []string{comps[0]}
+
+	if compLen > 1 {
+		nums := strings.Split(comps[1], ".")
+		for i, _ := range nums {
+			key := fmt.Sprintf("%s/%s", comps[0], strings.Join(nums[:i+1], "."))
+			keys = append(keys, key)
+		}
+	}
+
+	if compLen > 2 {
+		keys = append(keys, section)
+	}
+
+	var result int
+	for _, key := range keys {
+		val, ok := c.targetMap[key]
+		if ok {
+			if val {
+				return RunModeAll
+			}
+			result = RunModeGroup
+		} else {
+			result = RunModeNone
+		}
+	}
+
+	return result
+}
+
+func (c *Config) buildTargetMap() {
+	c.targetMap = map[string]bool{}
+
+	for _, section := range c.Sections {
+		comps := strings.Split(section, "/")
+		compLen := len(comps)
+
+		// Validate the format of the section string.
+		if compLen == 0 || compLen > 3 {
+			fmt.Printf("Invalid section: %s", section)
+			continue
+		}
+
+		// Check the section string is root section or not.
+		if compLen == 1 {
+			c.targetMap[comps[0]] = true
+			continue
+		}
+
+		_, ok := c.targetMap[comps[0]]
+		if !ok {
+			c.targetMap[comps[0]] = false
+		}
+
+		// The parent group of the test case associated with this section
+		// must only run test cases included in the group.
+		nums := strings.Split(comps[1], ".")
+		for i, _ := range nums {
+			key := fmt.Sprintf("%s/%s", comps[0], strings.Join(nums[:i+1], "."))
+			c.targetMap[key] = false
+		}
+
+		// The test case associated with this section string must be run.
+		c.targetMap[section] = true
+	}
+}
+
+func (c *Config) IsBrowserMode() bool {
+	return c.Exec == ""
+}

--- a/vendor/github.com/summerwind/h2spec/generic/1_starting_http2.go
+++ b/vendor/github.com/summerwind/h2spec/generic/1_starting_http2.go
@@ -1,0 +1,53 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StartingHTTP2() *spec.TestGroup {
+	tg := NewTestGroup("1", "Starting HTTP/2")
+
+	// RFC7540, 3.2:
+	// The first HTTP/2 frame sent by the server MUST be a server connection
+	// preface (Section 3.5) consisting of a SETTINGS frame (Section 6.5).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a client connection preface",
+		Requirement: "The endpoint MUST accept client connection preface.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var passed bool
+
+			setting := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: spec.DefaultWindowSize,
+			}
+
+			conn.Send([]byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
+			conn.WriteSettings(setting)
+
+			actual := conn.WaitEvent()
+			switch event := actual.(type) {
+			case spec.SettingsFrameEvent:
+				passed = !event.IsAck()
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					"SETTINGS Frame (flags:0x00)",
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/2_streams_and_multiplexing.go
+++ b/vendor/github.com/summerwind/h2spec/generic/2_streams_and_multiplexing.go
@@ -1,0 +1,203 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamsAndMultiplexing() *spec.TestGroup {
+	tg := NewTestGroup("2", "Streams and Multiplexing")
+
+	// RFC7540, 5.1, idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame on idle stream",
+		Requirement: "The endpoint MUST accept PRIORITY frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(1, pp)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// RFC7540, 5.1, half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame on half-closed (remote) stream",
+		Requirement: "The endpoint MUST accept WINDOW_UPDATE frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from
+			// closing the stream.
+			settings := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: 0,
+			}
+			conn.WriteSettings(settings)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(streamID, 1)
+
+			return spec.VerifyEventType(conn, spec.EventDataFrame)
+		},
+	})
+
+	// RFC7540, 5.1, half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame on half-closed (remote) stream",
+		Requirement: "The endpoint MUST accept PRIORITY frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from
+			// closing the stream.
+			settings := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: 0,
+			}
+			conn.WriteSettings(settings)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, pp)
+
+			conn.WriteWindowUpdate(streamID, 1)
+
+			return spec.VerifyEventType(conn, spec.EventDataFrame)
+		},
+	})
+
+	// RFC7540, 5.1, half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame on half-closed (remote) stream",
+		Requirement: "The endpoint MUST accept RST_STREAM frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(streamID, http2.ErrCodeCancel)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// RFC7540, 5.1, closed:
+	// An endpoint MUST NOT send frames other than PRIORITY on a closed
+	// stream. An endpoint that receives any frame other than PRIORITY
+	// after receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame on closed stream",
+		Requirement: "The endpoint MUST accept PRIORITY frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			err = spec.VerifyStreamClose(conn)
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, pp)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_10_continuation.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_10_continuation.go
@@ -1,0 +1,83 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Continuation() *spec.TestGroup {
+	tg := NewTestGroup("3.10", "CONTINUATION")
+
+	// RFC7540, 6.10:
+	// The CONTINUATION frame (type=0x9) is used to continue a sequence
+	// of header block fragments (Section 4.3). Any number of
+	// CONTINUATION frames can be sent, as long as the preceding frame
+	// is on the same stream and is a HEADERS, PUSH_PROMISE, or
+	// CONTINUATION frame without the END_HEADERS flag set.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST accept CONTINUATION frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headerBlock := conn.EncodeHeaders(headers)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: headerBlock[:5],
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteContinuation(streamID, true, headerBlock[5:])
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.10:
+	// The CONTINUATION frame (type=0x9) is used to continue a sequence
+	// of header block fragments (Section 4.3). Any number of
+	// CONTINUATION frames can be sent, as long as the preceding frame
+	// is on the same stream and is a HEADERS, PUSH_PROMISE, or
+	// CONTINUATION frame without the END_HEADERS flag set.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple CONTINUATION frames",
+		Requirement: "The endpoint MUST accept multiple CONTINUATION frames.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headerBlock := conn.EncodeHeaders(headers)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: headerBlock[:5],
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteContinuation(streamID, false, headerBlock[5:10])
+			conn.WriteContinuation(streamID, true, headerBlock[10:])
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_1_data.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_1_data.go
@@ -1,0 +1,113 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Data() *spec.TestGroup {
+	tg := NewTestGroup("3.1", "DATA")
+
+	// RFC7540, 6.1:
+	// DATA frames (type=0x0) convey arbitrary, variable-length
+	// sequences of octets associated with a stream. One or more
+	// DATA frames are used, for instance, to carry HTTP request
+	// or response payloads.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame",
+		Requirement: "The endpoint MUST accept DATA frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.1:
+	// DATA frames (type=0x0) convey arbitrary, variable-length
+	// sequences of octets associated with a stream. One or more
+	// DATA frames are used, for instance, to carry HTTP request
+	// or response payloads.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple DATA frames",
+		Requirement: "The endpoint MUST accept multiple DATA frames.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, false, []byte("test"))
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.1:
+	// DATA frames MAY also contain padding. Padding can be added to
+	// DATA frames to obscure the size of messages. Padding is a
+	// security feature; see Section 10.7.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame with padding",
+		Requirement: "The endpoint MUST accept DATA frame with padding.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteDataPadded(streamID, true, []byte("test"), []byte("\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_2_headers.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_2_headers.go
@@ -1,0 +1,109 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Headers() *spec.TestGroup {
+	tg := NewTestGroup("3.2", "HEADERS")
+
+	// RFC7540, 6.2:
+	// The HEADERS frame (type=0x1) is used to open a stream
+	// (Section 5.1), and additionally carries a header block fragment.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame",
+		Requirement: "The endpoint MUST accept HEADERS frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.2:
+	// The HEADERS frame can include padding. Padding fields and flags
+	// are identical to those defined for DATA frames (Section 6.1).
+	// Padding that exceeds the size remaining for the header block
+	// fragment MUST be treated as a PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with padding",
+		Requirement: "The endpoint MUST accept HEADERS frame with padding.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+				PadLength:     8,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.2:
+	// Prioritization information in a HEADERS frame is logically
+	// equivalent to a separate PRIORITY frame, but inclusion in
+	// HEADERS avoids the potential for churn in stream prioritization
+	// when new streams are created. Prioritization fields in HEADERS
+	// frames subsequent to the first on a stream reprioritize the
+	// stream (Section 5.3.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with priority",
+		Requirement: "The endpoint MUST accept HEADERS frame with priority.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+				Priority:      pp,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_3_priority.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_3_priority.go
@@ -1,0 +1,188 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Priority() *spec.TestGroup {
+	tg := NewTestGroup("3.3", "PRIORITY")
+
+	// RFC7540, 6.3:
+	// The PRIORITY frame (type=0x2) specifies the sender-advised
+	// priority of a stream (Section 5.3). It can be sent in any
+	// stream state, including idle or closed streams.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with priority 1",
+		Requirement: "The endpoint MUST accept PRIORITY frame with priority 1.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    0,
+			}
+			conn.WritePriority(streamID, pp)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.3:
+	// The PRIORITY frame (type=0x2) specifies the sender-advised
+	// priority of a stream (Section 5.3). It can be sent in any
+	// stream state, including idle or closed streams.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with priority 256",
+		Requirement: "The endpoint MUST accept PRIORITY frame with priority 256.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, pp)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.3, Stream Dependency:
+	// A 31-bit stream identifier for the stream that this stream
+	// depends on (see Section 5.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with stream dependency",
+		Requirement: "The endpoint MUST accept PRIORITY frame with stream dependency.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: streamID,
+				Exclusive: false,
+				Weight:    0,
+			}
+			conn.WritePriority(streamID+2, pp)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.3, E:
+	// A single-bit flag indicating that the stream dependency is
+	// exclusive (see Section 5.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with exclusive",
+		Requirement: "The endpoint MUST accept PRIORITY frame with exclusive.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: true,
+				Weight:    0,
+			}
+			conn.WritePriority(streamID, pp)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 6.3:
+	// The PRIORITY frame can be sent for a stream in the "idle" or
+	// "closed" state. This allows for the reprioritization of a group
+	// of dependent streams by altering the priority of an unused or
+	// closed parent stream.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame for an idle stream, then send a HEADER frame for a lower stream ID",
+		Requirement: "The endpoint MUST respond the HEADER frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID+2, pp)
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_4_rst_stream.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_4_rst_stream.go
@@ -1,0 +1,47 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func RSTStream() *spec.TestGroup {
+	tg := NewTestGroup("3.4", "RST_STREAM")
+
+	// RFC7540, 6.4:
+	// The RST_STREAM frame (type=0x3) allows for immediate termination
+	// of a stream. RST_STREAM is sent to request cancellation of a
+	// stream or to indicate that an error condition has occurred.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame",
+		Requirement: "The endpoint MUST accept RST_STREAM frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(streamID, http2.ErrCodeCancel)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_5_settings.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_5_settings.go
@@ -1,0 +1,61 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Settings() *spec.TestGroup {
+	tg := NewTestGroup("3.5", "SETTINGS")
+
+	// RFC7540, 6.5:
+	// he SETTINGS frame (type=0x4) conveys configuration parameters
+	// that affect how endpoints communicate, such as preferences and
+	// constraints on peer behavior. The SETTINGS frame is also used
+	// to acknowledge the receipt of those parameters. Individually,
+	// a SETTINGS parameter can also be referred to as a "setting".
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame",
+		Requirement: "The endpoint MUST accept SETTINGS frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			settings := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingHeaderTableSize,
+					Val: 4096,
+				},
+				http2.Setting{
+					ID:  http2.SettingEnablePush,
+					Val: 1,
+				},
+				http2.Setting{
+					ID:  http2.SettingMaxConcurrentStreams,
+					Val: 100,
+				},
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 65535,
+				},
+				http2.Setting{
+					ID:  http2.SettingMaxFrameSize,
+					Val: 16384,
+				},
+				http2.Setting{
+					ID:  http2.SettingMaxHeaderListSize,
+					Val: 100,
+				},
+			}
+			conn.WriteSettings(settings...)
+
+			return spec.VerifySettingsFrameWithAck(conn)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_7_ping.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_7_ping.go
@@ -1,0 +1,33 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Ping() *spec.TestGroup {
+	tg := NewTestGroup("3.7", "PING")
+
+	// RFC7540, 6.7:
+	// The PING frame (type=0x6) is a mechanism for measuring a minimal
+	// round-trip time from the sender, as well as determining whether
+	// an idle connection is still functional. PING frames can be sent
+	// from any endpoint.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PING frame",
+		Requirement: "The endpoint MUST accept PING frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_8_goaway.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_8_goaway.go
@@ -1,0 +1,38 @@
+package generic
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func GoAway() *spec.TestGroup {
+	tg := NewTestGroup("3.8", "GOAWAY")
+
+	// RFC7540, 6.8:
+	// The GOAWAY frame (type=0x7) is used to initiate shutdown of a
+	// connection or to signal serious error conditions. GOAWAY allows
+	// an endpoint to gracefully stop accepting new streams while
+	// still finishing processing of previously established streams.
+	// This enables administrative actions, like server maintenance.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a GOAWAY frame",
+		Requirement: "The endpoint MUST accept GOAWAY frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteGoAway(0, http2.ErrCodeNo, []byte("h2spec"))
+
+			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameOrConnectionClose(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_9_window_update.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_9_window_update.go
@@ -1,0 +1,69 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func WindowUpdate() *spec.TestGroup {
+	tg := NewTestGroup("3.9", "WINDOW_UPDATE")
+
+	// RFC7540, 6.9:
+	// The WINDOW_UPDATE frame (type=0x8) is used to implement flow
+	// control; see Section 5.2 for an overview.
+	//
+	// Flow control operates at two levels: on each individual stream
+	// and on the entire connection.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with stream ID 0",
+		Requirement: "The endpoint MUST accept WINDOW_UPDATE frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(0, 1)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// RFC7540, 6.9:
+	// The WINDOW_UPDATE frame (type=0x8) is used to implement flow
+	// control; see Section 5.2 for an overview.
+	//
+	// Flow control operates at two levels: on each individual stream
+	// and on the entire connection.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with stream ID 1",
+		Requirement: "The endpoint MUST accept WINDOW_UPDATE frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(streamID, 1)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/3_frame_definitions.go
+++ b/vendor/github.com/summerwind/h2spec/generic/3_frame_definitions.go
@@ -1,0 +1,19 @@
+package generic
+
+import "github.com/summerwind/h2spec/spec"
+
+func FrameDefinitions() *spec.TestGroup {
+	tg := NewTestGroup("3", "Frame Definitions")
+
+	tg.AddTestGroup(Data())
+	tg.AddTestGroup(Headers())
+	tg.AddTestGroup(Priority())
+	tg.AddTestGroup(RSTStream())
+	tg.AddTestGroup(Settings())
+	tg.AddTestGroup(Ping())
+	tg.AddTestGroup(GoAway())
+	tg.AddTestGroup(WindowUpdate())
+	tg.AddTestGroup(Continuation())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/4_http_message_exchanges.go
+++ b/vendor/github.com/summerwind/h2spec/generic/4_http_message_exchanges.go
@@ -1,0 +1,155 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func HTTPMessageExchanges() *spec.TestGroup {
+	tg := NewTestGroup("4", "HTTP Message Exchanges")
+
+	// RFC7540, 8.1:
+	// A client sends an HTTP request on a new stream, using a
+	// previously unused stream identifier (Section 5.1.1).
+	// A server sends an HTTP response on the same stream as the
+	// request.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a GET request",
+		Requirement: "The endpoint MUST respond to the request.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 8.1:
+	// A client sends an HTTP request on a new stream, using a
+	// previously unused stream identifier (Section 5.1.1).
+	// A server sends an HTTP response on the same stream as the
+	// request.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEAD request",
+		Requirement: "The endpoint MUST respond to the request.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "HEAD"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 8.1:
+	// A client sends an HTTP request on a new stream, using a
+	// previously unused stream identifier (Section 5.1.1).
+	// A server sends an HTTP response on the same stream as the
+	// request.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a POST request",
+		Requirement: "The endpoint MUST respond to the request.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC7540, 8.1:
+	// A client sends an HTTP request on a new stream, using a
+	// previously unused stream identifier (Section 5.1.1).
+	// A server sends an HTTP response on the same stream as the
+	// request.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a POST request with trailers",
+		Requirement: "The endpoint MUST respond to the request.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+			headers = append(headers, spec.HeaderField("trailer", "x-test"))
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp1)
+			conn.WriteData(streamID, false, []byte("test"))
+
+			trailers := []hpack.HeaderField{
+				spec.HeaderField("x-test", "ok"),
+			}
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(trailers),
+			}
+
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/5_hpack.go
+++ b/vendor/github.com/summerwind/h2spec/generic/5_hpack.go
@@ -1,0 +1,549 @@
+package generic
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func HPACK() *spec.TestGroup {
+	tg := NewTestGroup("5", "HPACK")
+
+	// RFC 7541, 6.1:
+	// An indexed header field representation identifies an entry in either
+	// the static table or the dynamic table (see Section 2.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a indexed header field representation",
+		Requirement: "The endpoint MUST accept indexed header field representation",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Indexed header field representation
+			// (user-agent: )
+			rep := []byte("\xba")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.1:
+	// A literal header field with incremental indexing representation
+	// results in appending a header field to the decoded header list and
+	// inserting it as a new entry into the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field with incremental indexing - indexed name",
+		Requirement: "The endpoint MUST accept literal header field with incremental indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field with incremental indexing - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x40\x87\xb5\x05\xb1\x61\xcc\x5a\x93\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.1:
+	// A literal header field with incremental indexing representation
+	// results in appending a header field to the decoded header list and
+	// inserting it as a new entry into the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field with incremental indexing - indexed name (with Huffman coding)",
+		Requirement: "The endpoint MUST accept literal header field with incremental indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field with incremental indexing - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x40\x0a\x75\x73\x65\x72\x2d\x61\x67\x65\x6e\x74\x06\x68\x32\x73\x70\x65\x63")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.1:
+	// A literal header field with incremental indexing representation
+	// results in appending a header field to the decoded header list and
+	// inserting it as a new entry into the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field with incremental indexing - new name",
+		Requirement: "The endpoint MUST accept literal header field with incremental indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field with incremental indexing - new name
+			// (x-test: h2spec)
+			rep := []byte("\x40\x06\x78\x2d\x74\x65\x73\x74\x06\x68\x32\x73\x70\x65\x63")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.1:
+	// A literal header field with incremental indexing representation
+	// results in appending a header field to the decoded header list and
+	// inserting it as a new entry into the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field with incremental indexing - new name (with Huffman coding)",
+		Requirement: "The endpoint MUST accept literal header field with incremental indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field with incremental indexing - new name
+			// (x-test: h2spec)
+			rep := []byte("\x40\x85\xf2\xb2\x4a\x84\xff\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.2:
+	// A literal header field without indexing representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field without indexing - indexed name",
+		Requirement: "The endpoint MUST accept literal header field without indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field without indexing - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x00\x0a\x75\x73\x65\x72\x2d\x61\x67\x65\x6e\x74\x06\x68\x32\x73\x70\x65\x63")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.2:
+	// A literal header field without indexing representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field without indexing - indexed name (with Huffman coding)",
+		Requirement: "The endpoint MUST accept literal header field without indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field without indexing - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x00\x87\xb5\x05\xb1\x61\xcc\x5a\x93\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.2:
+	// A literal header field without indexing representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field without indexing - new name",
+		Requirement: "The endpoint MUST accept literal header field without indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field without indexing - new name
+			// (x-test: h2spec)
+			rep := []byte("\x00\x06\x78\x2d\x74\x65\x73\x74\x06\x68\x32\x73\x70\x65\x63")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.2:
+	// A literal header field without indexing representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field without indexing - new name (huffman encoded)",
+		Requirement: "The endpoint MUST accept literal header field without indexing",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field without indexing - new name
+			// (x-test: h2spec)
+			rep := []byte("\x00\x85\xf2\xb2\x4a\x84\xff\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.3:
+	// A literal header field never-indexed representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.  Intermediaries MUST use the same representation
+	// for encoding this header field.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field never indexed - indexed name",
+		Requirement: "The endpoint MUST accept literal header field never indexed",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field never indexed - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x10\x0a\x75\x73\x65\x72\x2d\x61\x67\x65\x6e\x74\x06\x68\x32\x73\x70\x65\x63")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.3:
+	// A literal header field never-indexed representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.  Intermediaries MUST use the same representation
+	// for encoding this header field.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field never indexed - indexed name (huffman encoded)",
+		Requirement: "The endpoint MUST accept literal header field never indexed",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field never indexed - indexed name
+			// (user-agent: h2spec)
+			rep := []byte("\x10\x87\xb5\x05\xb1\x61\xcc\x5a\x93\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.3:
+	// A literal header field never-indexed representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.  Intermediaries MUST use the same representation
+	// for encoding this header field.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field never indexed - new name",
+		Requirement: "The endpoint MUST accept literal header field never indexed",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field never indexed - new name
+			// (x-test: h2spec)
+			rep := []byte("\x10\x85\xf2\xb2\x4a\x84\xff\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.2.3:
+	// A literal header field never-indexed representation results in
+	// appending a header field to the decoded header list without altering
+	// the dynamic table.  Intermediaries MUST use the same representation
+	// for encoding this header field.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field never indexed - new name (huffman encoded)",
+		Requirement: "The endpoint MUST accept literal header field never indexed",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal header field never indexed - new name
+			// (x-test: h2spec)
+			rep := []byte("\x10\x85\xf2\xb2\x4a\x84\xff\x84\x9c\x48\xac\xa4")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 6.3:
+	// A dynamic table size update signals a change to the size of the
+	// dynamic table.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a dynamic table size update",
+		Requirement: "The endpoint MUST accept dynamic table size update",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Change encoder's table size to 128. This sends dynamic table
+			// size update with value 128.
+			conn.SetMaxDynamicTableSize(128)
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// RFC 7541, 4.2:
+	// A change in the maximum size of the dynamic table is signaled via a
+	// dynamic table size update (see Section 6.3).  This dynamic table size
+	// update MUST occur at the beginning of the first header block
+	// following the change to the dynamic table size.  In HTTP/2, this
+	// follows a settings acknowledgment (see Section 6.5.3 of [HTTP2]).
+	//
+	// Multiple updates to the maximum table size can occur between the
+	// transmission of two header blocks.  In the case that this size is
+	// changed more than once in this interval, the smallest maximum table
+	// size that occurs in that interval MUST be signaled in a dynamic table
+	// size update.  The final maximum size is always signaled, resulting in
+	// at most two dynamic table size updates.  This ensures that the
+	// decoder is able to perform eviction based on reductions in dynamic
+	// table size (see Section 4.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple dynamic table size update",
+		Requirement: "The endpoint MUST accept multiple dynamic table size update",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// 2 Dynamic Table Size Updates, 128 and 4096.
+			tableSizeUpdate := []byte("\x3f\x61\x3f\xe1\x1f")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(tableSizeUpdate, blockFragment...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/generic/generic.go
+++ b/vendor/github.com/summerwind/h2spec/generic/generic.go
@@ -1,0 +1,28 @@
+package generic
+
+import "github.com/summerwind/h2spec/spec"
+
+var key = "generic"
+
+func NewTestGroup(section string, name string) *spec.TestGroup {
+	return &spec.TestGroup{
+		Key:     key,
+		Section: section,
+		Name:    name,
+	}
+}
+
+func Spec() *spec.TestGroup {
+	tg := &spec.TestGroup{
+		Key:  key,
+		Name: "Generic tests for HTTP/2 server",
+	}
+
+	tg.AddTestGroup(StartingHTTP2())
+	tg.AddTestGroup(StreamsAndMultiplexing())
+	tg.AddTestGroup(FrameDefinitions())
+	tg.AddTestGroup(HTTPMessageExchanges())
+	tg.AddTestGroup(HPACK())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/go.mod
+++ b/vendor/github.com/summerwind/h2spec/go.mod
@@ -1,0 +1,14 @@
+module github.com/summerwind/h2spec
+
+go 1.12
+
+require (
+	github.com/fatih/color v0.0.0-20161025120501-bf82308e8c85
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.0 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/spf13/cobra v0.0.0-20170118185516-dc208f4211e7
+	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/net v0.0.0-20161104230106-55a3084c9119
+	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
+)

--- a/vendor/github.com/summerwind/h2spec/go.sum
+++ b/vendor/github.com/summerwind/h2spec/go.sum
@@ -1,0 +1,16 @@
+github.com/fatih/color v0.0.0-20161025120501-bf82308e8c85 h1:g7ijd5QIEMWwZNVp/T/6kQ8RSh8rN+YNhghMcrET3qY=
+github.com/fatih/color v0.0.0-20161025120501-bf82308e8c85/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/mattn/go-colorable v0.1.0 h1:v2XXALHHh6zHfYTJ+cSkwtyffnaOyR1MXaA91mTrb8o=
+github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/spf13/cobra v0.0.0-20170118185516-dc208f4211e7 h1:/xfSxzUJXZPhOsBj5aCUvA3mOIc7ILcvvJpmvzhQk7w=
+github.com/spf13/cobra v0.0.0-20170118185516-dc208f4211e7/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+golang.org/x/net v0.0.0-20161104230106-55a3084c9119 h1:T/FVHYSpR0pXqxZ6zNrRnmk4iHorxWyidE9VCMGJ5rQ=
+golang.org/x/net v0.0.0-20161104230106-55a3084c9119/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503 h1:5SvYFrOM3W8Mexn9/oA44Ji7vhXAZQ9hiP+1Q/DMrWg=
+golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/github.com/summerwind/h2spec/h2spec.go
+++ b/vendor/github.com/summerwind/h2spec/h2spec.go
@@ -1,0 +1,104 @@
+package h2spec
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/summerwind/h2spec/client"
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/generic"
+	"github.com/summerwind/h2spec/hpack"
+	"github.com/summerwind/h2spec/http2"
+	"github.com/summerwind/h2spec/log"
+	"github.com/summerwind/h2spec/reporter"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Run(c *config.Config) (bool, error) {
+	total := 0
+	success := true
+
+	specs := []*spec.TestGroup{
+		generic.Spec(),
+		http2.Spec(),
+		hpack.Spec(),
+	}
+
+	start := time.Now()
+	for _, s := range specs {
+		s.Test(c)
+
+		if s.FailedCount > 0 {
+			success = false
+		}
+
+		total += s.FailedCount
+		total += s.SkippedCount
+		total += s.PassedCount
+	}
+	end := time.Now()
+	d := end.Sub(start)
+
+	if c.DryRun {
+		return true, nil
+	}
+
+	if total == 0 {
+		log.SetIndentLevel(0)
+		log.Println("No matched tests found.")
+		return true, nil
+	}
+
+	if !success {
+		log.SetIndentLevel(0)
+		reporter.FailedTests(specs)
+	}
+
+	log.SetIndentLevel(0)
+	log.Println(fmt.Sprintf("Finished in %.4f seconds", d.Seconds()))
+	reporter.Summary(specs)
+
+	if c.JUnitReport != "" {
+		err := reporter.JUnitReport(specs, c.JUnitReport)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return success, nil
+}
+
+func RunClientSpec(c *config.Config) error {
+	s := client.Spec()
+
+	server, err := spec.Listen(c, s)
+	if err != nil {
+		return err
+	}
+
+	if !c.IsBrowserMode() {
+		start := time.Now()
+		s.Test(c)
+		end := time.Now()
+		d := end.Sub(start)
+
+		if s.FailedCount > 0 {
+			log.SetIndentLevel(0)
+			reporter.PrintFailedClientTests(s)
+		}
+
+		log.SetIndentLevel(0)
+		log.Println(fmt.Sprintf("Finished in %.4f seconds", d.Seconds()))
+		reporter.PrintSummaryForClient(s)
+	} else {
+		// Block running
+		log.Println("--exec is not defined, enable BROWSER mode")
+
+		reportServer := reporter.NewWebReportServer(c, s)
+		log.Println(reportServer.RunForever())
+	}
+
+	defer server.Close()
+
+	return nil
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/2_3_3_index_address_space.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/2_3_3_index_address_space.go
@@ -1,0 +1,77 @@
+package hpack
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func IndexAddressSpace() *spec.TestGroup {
+	tg := NewTestGroup("2.3.3", "Index Address Space")
+
+	// Indices strictly greater than the sum of the lengths of both
+	// tables MUST be treated as a decoding error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a indexed header field representation with invalid index",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Indexed header field representation with index 70
+			indexedRep := []byte("\xC6")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, indexedRep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	// Indices strictly greater than the sum of the lengths of both
+	// tables MUST be treated as a decoding error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field representation with invalid index",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field with Incremental Indexing (index=70 & value=empty)
+			indexedRep := []byte("\x7F\x07\x00")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, indexedRep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/2_3_indexing_tables.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/2_3_indexing_tables.go
@@ -1,0 +1,11 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+func IndexingTables() *spec.TestGroup {
+	tg := NewTestGroup("2.3", "Indexing Tables")
+
+	tg.AddTestGroup(IndexAddressSpace())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/2_compression_process_overview.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/2_compression_process_overview.go
@@ -1,0 +1,11 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+func CompressionProcessOverview() *spec.TestGroup {
+	tg := NewTestGroup("2", "Compression Process Overview")
+
+	tg.AddTestGroup(IndexingTables())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/4_2_maximum_table_size.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/4_2_maximum_table_size.go
@@ -1,0 +1,49 @@
+package hpack
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func MaximumTableSize() *spec.TestGroup {
+	tg := NewTestGroup("4.2", "Maximum Table Size")
+
+	// A change in the maximum size of the dynamic table is signaled
+	// via a dynamic table size update (see Section 6.3). This dynamic
+	// table size update MUST occur at the beginning of the first
+	// header block following the change to the dynamic table size.
+	// In HTTP/2, this follows a settings acknowledgment (see Section
+	// 6.5.3 of [HTTP2]).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a dynamic table size update at the end of header block",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Dynamic table size update with value 1
+			tableSizeUpdate := []byte("\x21")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, tableSizeUpdate...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/4_dynamic_table_management.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/4_dynamic_table_management.go
@@ -1,0 +1,11 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+func DynamicTableManagement() *spec.TestGroup {
+	tg := NewTestGroup("4", "Dynamic Table Management")
+
+	tg.AddTestGroup(MaximumTableSize())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/5_2_string_literal_representation.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/5_2_string_literal_representation.go
@@ -1,0 +1,151 @@
+package hpack
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StringLiteralRepresentation() *spec.TestGroup {
+	tg := NewTestGroup("5.2", "String Literal Representation")
+
+	// As the Huffman-encoded data doesn't always end at an octet boundary,
+	// some padding is inserted after it, up to the next octet boundary.  To
+	// prevent this padding from being misinterpreted as part of the string
+	// literal, the most significant bits of the code corresponding to the
+	// EOS (end-of-string) symbol are used.
+	//
+	// Upon decoding, an incomplete code at the end of the encoded data is
+	// to be considered as padding and discarded.  A padding strictly longer
+	// than 7 bits MUST be treated as a decoding error.  A padding not
+	// corresponding to the most significant bits of the code for the EOS
+	// symbol MUST be treated as a decoding error.  A Huffman-encoded string
+	// literal containing the EOS symbol MUST be treated as a decoding
+	// error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a Huffman-encoded string literal representation with padding longer than 7 bits",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field without Indexing - New Name (x-test: test)
+			// This contains an extra 1 padding octet at the end
+			rep := []byte("\x00\x85\xf2\xb2\x4a\x84\xff\x84\x49\x50\x9f\xff")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	// As the Huffman-encoded data doesn't always end at an octet boundary,
+	// some padding is inserted after it, up to the next octet boundary.  To
+	// prevent this padding from being misinterpreted as part of the string
+	// literal, the most significant bits of the code corresponding to the
+	// EOS (end-of-string) symbol are used.
+	//
+	// Upon decoding, an incomplete code at the end of the encoded data is
+	// to be considered as padding and discarded.  A padding strictly longer
+	// than 7 bits MUST be treated as a decoding error.  A padding not
+	// corresponding to the most significant bits of the code for the EOS
+	// symbol MUST be treated as a decoding error.  A Huffman-encoded string
+	// literal containing the EOS symbol MUST be treated as a decoding
+	// error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a Huffman-encoded string literal representation padded by zero",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field without Indexing - New Name (x-test: test)
+			// This is padded by zero
+			rep := []byte("\x00\x85\xf2\xb2\x4a\x84\xff\x83\x49\x50\x90")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	// As the Huffman-encoded data doesn't always end at an octet boundary,
+	// some padding is inserted after it, up to the next octet boundary.  To
+	// prevent this padding from being misinterpreted as part of the string
+	// literal, the most significant bits of the code corresponding to the
+	// EOS (end-of-string) symbol are used.
+	//
+	// Upon decoding, an incomplete code at the end of the encoded data is
+	// to be considered as padding and discarded.  A padding strictly longer
+	// than 7 bits MUST be treated as a decoding error.  A padding not
+	// corresponding to the most significant bits of the code for the EOS
+	// symbol MUST be treated as a decoding error.  A Huffman-encoded string
+	// literal containing the EOS symbol MUST be treated as a decoding
+	// error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a Huffman-encoded string literal representation containing the EOS symbol",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field without Indexing - New Name (x-test: tes{EOS}t)
+			// This contains a EOS symbol in the middle:
+			//
+			// Header:       0000 0000
+			// Name Length:  1000 0101
+			// Name String:  1111 0010 1011 0010 0100 1010 1000 0100 1111 1111
+			// Value Length: 1000 0111
+			// Value String: 0100 1001 0101 0001 1111 1111 1111 1111 1111 1111 1111 1010 0111 1111
+			rep := []byte("\x00\x85\xf2\xb2\x4a\x84\xff\x87\x49\x51\xff\xff\xff\xfa\x7f")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/5_primitive_type_representations.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/5_primitive_type_representations.go
@@ -1,0 +1,11 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+func PrimitiveTypeRepresentations() *spec.TestGroup {
+	tg := NewTestGroup("5", "Primitive Type Representations")
+
+	tg.AddTestGroup(StringLiteralRepresentation())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/6_1_indexed_header_field_representation.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/6_1_indexed_header_field_representation.go
@@ -1,0 +1,45 @@
+package hpack
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func IndexedHeaderFieldRepresentation() *spec.TestGroup {
+	tg := NewTestGroup("6.1", "Indexed Header Field Representation")
+
+	// The index value of 0 is not used.  It MUST be treated as a decoding
+	// error if found in an indexed header field representation.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a indexed header field representation with index 0",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Indexed Header Field Representation
+			rep := []byte("\x80")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, rep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/6_3_dynamic_table_size_update.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/6_3_dynamic_table_size_update.go
@@ -1,0 +1,69 @@
+package hpack
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func DynamicTableSizeUpdate() *spec.TestGroup {
+	tg := NewTestGroup("6.3", "Dynamic Table Size Update")
+
+	// The new maximum size MUST be lower than or equal to the limit
+	// determined by the protocol using HPACK.  A value that exceeds this
+	// limit MUST be treated as a decoding error.  In HTTP/2, this limit is
+	// the last value of the SETTINGS_HEADER_TABLE_SIZE parameter (see
+	// Section 6.5.2 of [HTTP2]) received from the decoder and acknowledged
+	// by the encoder (see Section 6.5.3 of [HTTP2]).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a dynamic table size update larger than the value of SETTINGS_HEADER_TABLE_SIZE",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			maxTableSize, ok := conn.Settings[http2.SettingHeaderTableSize]
+			if !ok {
+				maxTableSize = uint32(4096)
+			}
+
+			tableSize := uint64(maxTableSize + 1)
+			rep := []byte{}
+
+			// Encode to dynamic table size update.
+			// This code is from golang.org/x/net/http2.
+			k := uint64((1 << 5) - 1)
+			if tableSize < k {
+				rep = append(rep, byte(tableSize))
+			} else {
+				rep = append(rep, byte(k))
+				tableSize -= k
+				for ; tableSize >= 128; tableSize >>= 7 {
+					rep = append(rep, byte(0x80|(tableSize&0x7f)))
+				}
+				rep = append(rep, byte(tableSize))
+			}
+			rep[0] |= 0x20
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(rep, blockFragment...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/6_binary_format.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/6_binary_format.go
@@ -1,0 +1,12 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+func BinaryFormat() *spec.TestGroup {
+	tg := NewTestGroup("6", "Binary Format")
+
+	tg.AddTestGroup(IndexedHeaderFieldRepresentation())
+	tg.AddTestGroup(DynamicTableSizeUpdate())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/hpack/hpack.go
+++ b/vendor/github.com/summerwind/h2spec/hpack/hpack.go
@@ -1,0 +1,27 @@
+package hpack
+
+import "github.com/summerwind/h2spec/spec"
+
+var key = "hpack"
+
+func NewTestGroup(section string, name string) *spec.TestGroup {
+	return &spec.TestGroup{
+		Key:     key,
+		Section: section,
+		Name:    name,
+	}
+}
+
+func Spec() *spec.TestGroup {
+	tg := &spec.TestGroup{
+		Key:  key,
+		Name: "HPACK: Header Compression for HTTP/2",
+	}
+
+	tg.AddTestGroup(CompressionProcessOverview())
+	tg.AddTestGroup(DynamicTableManagement())
+	tg.AddTestGroup(PrimitiveTypeRepresentations())
+	tg.AddTestGroup(BinaryFormat())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/3_5_http2_connection_preface.go
+++ b/vendor/github.com/summerwind/h2spec/http2/3_5_http2_connection_preface.go
@@ -1,0 +1,68 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func HTTP2ConnectionPreface() *spec.TestGroup {
+	tg := NewTestGroup("3.5", "HTTP/2 Connection Preface")
+
+	// The server connection preface consists of a potentially empty
+	// SETTINGS frame (Section 6.5) that MUST be the first frame
+	// the server sends in the HTTP/2 connection.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends client connection preface",
+		Requirement: "The server connection preface MUST be the first frame the server sends in the HTTP/2 connection.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var passed bool
+
+			setting := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: spec.DefaultWindowSize,
+			}
+
+			conn.Send([]byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
+			conn.WriteSettings(setting)
+
+			actual := conn.WaitEvent()
+			switch event := actual.(type) {
+			case spec.SettingsFrameEvent:
+				passed = !event.IsAck()
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					"SETTINGS Frame (flags:0x00)",
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// Clients and servers MUST treat an invalid connection preface as
+	// a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends invalid connection preface",
+		Requirement: "The endpoint MUST terminate the TCP connection.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Send([]byte("INVALID CONNECTION PREFACE\r\n\r\n"))
+			if err != nil {
+				return err
+			}
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/3_starting_http2.go
+++ b/vendor/github.com/summerwind/h2spec/http2/3_starting_http2.go
@@ -1,0 +1,11 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func StartingHTTP2() *spec.TestGroup {
+	tg := NewTestGroup("3", "Starting HTTP/2")
+
+	tg.AddTestGroup(HTTP2ConnectionPreface())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/4_1_frame_format.go
+++ b/vendor/github.com/summerwind/h2spec/http2/4_1_frame_format.go
@@ -1,0 +1,79 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func FrameFormat() *spec.TestGroup {
+	tg := NewTestGroup("4.1", "Frame Format")
+
+	// Type: The 8-bit type of the frame. The frame type determines
+	// the format and semantics of the frame. Implementations MUST
+	// ignore and discard any frame that has a type that is unknown.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a frame with unknown type",
+		Requirement: "The endpoint MUST ignore and discard any frame that has a type that is unknown.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// UNKONWN Frame:
+			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// Flags are assigned semantics specific to the indicated frame
+	// type. Flags that have no defined semantics for a particular
+	// frame type MUST be ignored and MUST be left unset (0x0) when
+	// sending.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a frame with undefined flag",
+		Requirement: "The endpoint MUST ignore any flags that is undefined.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING Frame:
+			// Length: 8, Type: 6, Flags: 255, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x06\x16\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyEventType(conn, spec.EventPingFrame)
+		},
+	})
+
+	// R: A reserved 1-bit field. The semantics of this bit are
+	// undefined, and the bit MUST remain unset (0x0) when sending
+	// and MUST be ignored when receiving.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a frame with reserved field bit",
+		Requirement: "The endpoint MUST ignore the value of reserved field.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING Frame:
+			// Length: 8, Type: 6, Flags: 255, R: 1, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x06\x16\x80\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyEventType(conn, spec.EventPingFrame)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/4_2_frame_size.go
+++ b/vendor/github.com/summerwind/h2spec/http2/4_2_frame_size.go
@@ -1,0 +1,112 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func FrameSize() *spec.TestGroup {
+	tg := NewTestGroup("4.2", "Frame Size")
+
+	// All implementations MUST be capable of receiving and minimally
+	// processing frames up to 2^14 octets in length, plus the 9-octet
+	// frame header (Section 4.1).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame with 2^14 octets in length",
+		Requirement: "The endpoint MUST be capable of receiving and minimally processing frames up to 2^14 octets in length.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			data := spec.DummyString(conn.MaxFrameSize())
+			conn.WriteData(streamID, true, []byte(data))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// An endpoint MUST send an error code of FRAME_SIZE_ERROR
+	// if a frame exceeds the size defined in SETTINGS_MAX_FRAME_SIZE,
+	// exceeds any limit defined for the frame type, or is too small
+	// to contain mandatory frame data.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a large size DATA frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
+		Requirement: "The endpoint MUST send an error code of FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			data := spec.DummyString(conn.MaxFrameSize() + 1)
+			conn.WriteData(streamID, true, []byte(data))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	// A frame size error in a frame that could alter the state of
+	// the entire connection MUST be treated as a connection error
+	// (Section 5.4.1); this includes any frame carrying a header block
+	// (Section 4.3) (that is, HEADERS, PUSH_PROMISE, and CONTINUATION),
+	// SETTINGS, and any frame with a stream identifier of 0.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a large size HEADERS frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.DummyHeaders(c, 5)...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/4_3_header_compression_and_decompression.go
+++ b/vendor/github.com/summerwind/h2spec/http2/4_3_header_compression_and_decompression.go
@@ -1,0 +1,111 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func HeaderCompressionAndDecompression() *spec.TestGroup {
+	tg := NewTestGroup("4.3", "Header Compression and Decompression")
+
+	// A decoding error in a header block MUST be treated as
+	// a connection error (Section 5.4.1) of type COMPRESSION_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends invalid header block fragment",
+		Requirement: "The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field with Incremental Indexing without
+			// Length and String segment.
+			err = conn.Send([]byte("\x00\x00\x01\x01\x05\x00\x00\x00\x01\x40"))
+			if err != nil {
+				return err
+			}
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	// Each header block is processed as a discrete unit. Header blocks
+	// MUST be transmitted as a contiguous sequence of frames, with no
+	// interleaved frames of any other type or from any other stream.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame while sending the header blocks",
+		Requirement: "The endpoint MUST terminate the connection with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, pp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// Each header block is processed as a discrete unit. Header blocks
+	// MUST be transmitted as a contiguous sequence of frames, with no
+	// interleaved frames of any other type or from any other stream.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame to another stream while sending the header blocks",
+		Requirement: "The endpoint MUST terminate the connection with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID + 2,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/4_http_frames.go
+++ b/vendor/github.com/summerwind/h2spec/http2/4_http_frames.go
@@ -1,0 +1,13 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func HTTPFrames() *spec.TestGroup {
+	tg := NewTestGroup("4", "HTTP Frames")
+
+	tg.AddTestGroup(FrameFormat())
+	tg.AddTestGroup(FrameSize())
+	tg.AddTestGroup(HeaderCompressionAndDecompression())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_1_1_stream_identifiers.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_1_1_stream_identifiers.go
@@ -1,0 +1,72 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamIdentifiers() *spec.TestGroup {
+	tg := NewTestGroup("5.1.1", "Stream Identifiers")
+
+	// An endpoint that receives an unexpected stream identifier
+	// MUST respond with a connection error (Section 5.4.1) of
+	// type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends even-numbered stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      2,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// An endpoint that receives an unexpected stream identifier
+	// MUST respond with a connection error (Section 5.4.1) of
+	// type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends stream identifier that is numerically smaller than previous",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      5,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      3,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_1_2_stream_concurrency.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_1_2_stream_concurrency.go
@@ -1,0 +1,65 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamConcurrency() *spec.TestGroup {
+	tg := NewTestGroup("5.1.2", "Stream Concurrency")
+
+	// An endpoint that receives a HEADERS frame that causes
+	// its advertised concurrent stream limit to be exceeded
+	// MUST treat this as a stream error (Section 5.4.2) of
+	// type PROTOCOL_ERROR or REFUSED_STREAM.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends HEADERS frames that causes their advertised concurrent stream limit to be exceeded",
+		Requirement: "The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR or REFUSED_STREAM.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Skip this test case when SETTINGS_MAX_CONCURRENT_STREAMS
+			// is unlimited.
+			maxStreams, ok := conn.Settings[http2.SettingMaxConcurrentStreams]
+			if !ok {
+				return spec.ErrSkipped
+			}
+
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from
+			// closing the stream.
+			settings := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: 0,
+			}
+			conn.WriteSettings(settings)
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+
+			for i := 0; i <= int(maxStreams); i++ {
+				hp := http2.HeadersFrameParam{
+					StreamID:      streamID,
+					EndStream:     true,
+					EndHeaders:    true,
+					BlockFragment: blockFragment,
+				}
+				conn.WriteHeaders(hp)
+				streamID += 2
+			}
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeProtocol,
+				http2.ErrCodeRefusedStream,
+			}
+			return spec.VerifyStreamError(conn, codes...)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_1_stream_states.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_1_stream_states.go
@@ -1,0 +1,413 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamStates() *spec.TestGroup {
+	tg := NewTestGroup("5.1", "Stream States")
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "idle: Sends a DATA frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteData(1, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "idle: Sends a RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(1, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "idle: Sends a WINDOW_UPDATE frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(1, 100)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// idle:
+	// Receiving any frame other than HEADERS or PRIORITY on a stream
+	// in this state MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "idle: Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			conn.WriteContinuation(1, true, blockFragment)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "half closed (remote): Sends a DATA frame",
+		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "half closed (remote): Sends a HEADERS frame",
+		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// half-closed (remote):
+	// If an endpoint receives additional frames, other than
+	// WINDOW_UPDATE, PRIORITY, or RST_STREAM, for a stream that is in
+	// this state, it MUST respond with a stream error (Section 5.4.2)
+	// of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "half closed (remote): Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteContinuation(streamID, true, blockFragment)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed, http2.ErrCodeProtocol)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a DATA frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(streamID, http2.ErrCodeCancel)
+
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a HEADERS frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			conn.WriteRSTStream(streamID, http2.ErrCodeCancel)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frame other than PRIORITY after
+	// receiving a RST_STREAM MUST treat that as a stream error
+	// (Section 5.4.2) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a CONTINUATION frame after sending RST_STREAM frame",
+		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteRSTStream(streamID, http2.ErrCodeCancel)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeStreamClosed,
+				http2.ErrCodeProtocol,
+			}
+			return spec.VerifyStreamError(conn, codes...)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a DATA frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			err = spec.VerifyStreamClose(conn)
+			if err != nil {
+				return err
+			}
+
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a HEADERS frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			err = spec.VerifyStreamClose(conn)
+			if err != nil {
+				return err
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// closed:
+	// An endpoint that receives any frames after receiving a frame
+	// with the END_STREAM flag set MUST treat that as a connection
+	// error (Section 6.4.1) of type STREAM_CLOSED.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "closed: Sends a CONTINUATION frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			err = spec.VerifyStreamClose(conn)
+			if err != nil {
+				return err
+			}
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeStreamClosed,
+				http2.ErrCodeProtocol,
+			}
+			return spec.VerifyConnectionError(conn, codes...)
+		},
+	})
+
+	tg.AddTestGroup(StreamIdentifiers())
+	tg.AddTestGroup(StreamConcurrency())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_3_1_stream_dependencies.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_3_1_stream_dependencies.go
@@ -1,0 +1,68 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func StreamDependencies() *spec.TestGroup {
+	tg := NewTestGroup("5.3.1", "Stream Dependencies")
+
+	// A stream cannot depend on itself. An endpoint MUST treat this
+	// as a stream error (Section 5.4.2) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends HEADERS frame that depends on itself",
+		Requirement: "The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+				Priority: http2.PriorityParam{
+					StreamDep: streamID,
+					Exclusive: false,
+					Weight:    255,
+				},
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A stream cannot depend on itself. An endpoint MUST treat this
+	// as a stream error (Section 5.4.2) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends PRIORITY frame that depend on itself",
+		Requirement: "The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			priorityParam := http2.PriorityParam{
+				StreamDep: streamID,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, priorityParam)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_3_stream_priority.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_3_stream_priority.go
@@ -1,0 +1,11 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func StreamPriority() *spec.TestGroup {
+	tg := NewTestGroup("5.3", "Stream Priority")
+
+	tg.AddTestGroup(StreamDependencies())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_4_1_connection_error_handling.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_4_1_connection_error_handling.go
@@ -1,0 +1,66 @@
+package http2
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func ConnectionErrorHandling() *spec.TestGroup {
+	tg := NewTestGroup("5.4.1", "Connection Error Handling")
+
+	// After sending the GOAWAY frame for an error condition,
+	// the endpoint MUST close the TCP connection.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends an invalid PING frame for connection close",
+		Requirement: "The endpoint MUST close the TCP connection",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame with invalid stream ID
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionClose(conn)
+		},
+	})
+
+	// An endpoint that encounters a connection error SHOULD first send
+	// a GOAWAY frame (Section 6.8) with the stream identifier of the last
+	// stream that it successfully received from its peer.
+	tg.AddTestCase(&spec.TestCase{
+		Strict:      true,
+		Desc:        "Sends an invalid PING frame to receive GOAWAY frame",
+		Requirement: "An endpoint that encounters a connection error SHOULD first send a GOAWAY frame",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame with invalid stream ID
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			actual, passed := conn.WaitEventByType(spec.EventGoAwayFrame)
+			if !passed {
+				return &spec.TestError{
+					Expected: []string{
+						fmt.Sprintf(spec.ExpectedGoAwayFrame, http2.ErrCodeProtocol),
+					},
+					Actual: actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_4_error_handling.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_4_error_handling.go
@@ -1,0 +1,11 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func ErrorHandling() *spec.TestGroup {
+	tg := NewTestGroup("5.4", "Error Handling")
+
+	tg.AddTestGroup(ConnectionErrorHandling())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_5_extending_http2.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_5_extending_http2.go
@@ -1,0 +1,71 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func ExtendingHTTP2() *spec.TestGroup {
+	tg := NewTestGroup("5.5", "Extending HTTP/2")
+
+	// Implementations MUST ignore unknown or unsupported values
+	// in all extensible protocol elements.
+	//
+	// Note: This test case is duplicated with 4.1.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends an unknown extension frame",
+		Requirement: "The endpoint MUST ignore unknown or unsupported values in all extensible protocol elements.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// UNKONWN Frame:
+			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// Extension frames that appear in the middle of a header block
+	// (Section 4.3) are not permitted; these MUST be treated as
+	// a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends an unknown extension frame in the middle of a header block",
+		Requirement: "The endpoint MUST treat as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// UNKONWN Frame:
+			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
+			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/5_streams_and_multiplexing.go
+++ b/vendor/github.com/summerwind/h2spec/http2/5_streams_and_multiplexing.go
@@ -1,0 +1,14 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func StreamsAndMultiplexing() *spec.TestGroup {
+	tg := NewTestGroup("5", "Streams and Multiplexing")
+
+	tg.AddTestGroup(StreamStates())
+	tg.AddTestGroup(StreamPriority())
+	tg.AddTestGroup(ErrorHandling())
+	tg.AddTestGroup(ExtendingHTTP2())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_10_continuation.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_10_continuation.go
@@ -1,0 +1,211 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Continuation() *spec.TestGroup {
+	tg := NewTestGroup("6.10", "CONTINUATION")
+
+	// The CONTINUATION frame (type=0x9) is used to continue a sequence
+	// of header block fragments (Section 4.3). Any number of
+	// CONTINUATION frames can be sent, as long as the preceding frame
+	// is on the same stream and is a HEADERS, PUSH_PROMISE,
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple CONTINUATION frames preceded by a HEADERS frame",
+		Requirement: "The endpoint must accept the frame.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyHeadersFrame(conn, streamID)
+		},
+	})
+
+	// END_HEADERS (0x4):
+	// If the END_HEADERS bit is not set, this frame MUST be followed
+	// by another CONTINUATION frame. A receiver MUST treat the receipt
+	// of any other type of frame or a frame on a different stream as
+	// a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame followed by any frame other than CONTINUATION",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// CONTINUATION frames MUST be associated with a stream. If a
+	// CONTINUATION frame is received whose stream identifier field is
+	// 0x0, the recipient MUST respond with a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(0, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a HEADERS frame with END_HEADERS flag",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a CONTINUATION frame with END_HEADERS flag",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE
+	// or CONTINUATION frame without the END_HEADERS flag set.
+	// A recipient that observes violation of this rule MUST respond
+	// with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a CONTINUATION frame preceded by a DATA frame",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, false, conn.EncodeHeaders(dummyHeaders))
+			conn.WriteContinuation(0, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_1_data.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_1_data.go
@@ -1,0 +1,102 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Data() *spec.TestGroup {
+	tg := NewTestGroup("6.1", "DATA")
+
+	// DATA frames MUST be associated with a stream. If a DATA frame is
+	// received whose stream identifier field is 0x0, the recipient
+	// MUST respond with a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteData(0, true, []byte("test"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// If a DATA frame is received whose stream is not in "open" or
+	// "half-closed (local)" state, the recipient MUST respond with
+	// a stream error (Section 5.4.2) of type STREAM_CLOSED.
+	//
+	// Note: This test case is duplicated with 5.1.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame on the stream that is not in \"open\" or \"half-closed (local)\" state",
+		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeStreamClosed)
+		},
+	})
+
+	// If the length of the padding is the length of the frame payload
+	// or greater, the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a DATA frame with invalid pad length",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+			headers = append(headers, spec.HeaderField("content-length", "4"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			// DATA frame:
+			// frame length: 5, pad length: 6
+			conn.Send([]byte("\x00\x00\x05\x00\x09\x00\x00\x00\x01"))
+			conn.Send([]byte("\x06\x54\x65\x73\x74"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_2_headers.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_2_headers.go
@@ -1,0 +1,157 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Headers() *spec.TestGroup {
+	tg := NewTestGroup("6.2", "HEADERS")
+
+	// END_HEADERS (0x4):
+	// A HEADERS frame without the END_HEADERS flag set MUST be
+	// followed by a CONTINUATION frame for the same stream.
+	// A receiver MUST treat the receipt of any other type of frame
+	// or a frame on a different stream as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	//
+	// Note: This test case is duplicated with 4.3.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame without the END_HEADERS flag, and a PRIORITY frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(streamID, pp)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// END_HEADERS (0x4):
+	// A HEADERS frame without the END_HEADERS flag set MUST be
+	// followed by a CONTINUATION frame for the same stream.
+	// A receiver MUST treat the receipt of any other type of frame
+	// or a frame on a different stream as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	//
+	// Note: This test case is duplicated with 4.3.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame to another stream while sending a HEADERS frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    false,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp1)
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID + 2,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp2)
+
+			dummyHeaders := spec.DummyHeaders(c, 1)
+			conn.WriteContinuation(streamID, true, conn.EncodeHeaders(dummyHeaders))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// HEADERS frames MUST be associated with a stream. If a HEADERS
+	// frame is received whose stream identifier field is 0x0, the
+	// recipient MUST respond with a connection error (Section 5.4.1)
+	// of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      0,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// The HEADERS frame can include padding. Padding fields and flags
+	// are identical to those defined for DATA frames (Section 6.1).
+	// Padding that exceeds the size remaining for the header block
+	// fragment MUST be treated as a PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with invalid pad length",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+
+			fh := []byte("\x00\x00\x00\x01\x0d\x00\x00\x00\x01")
+			fh[2] = byte(len(blockFragment) + 1)
+
+			// HEADERS frame:
+			// frame length: 16, pad length: 17
+			conn.Send(fh)
+			conn.Send([]byte{byte(len(blockFragment) + 2)})
+			conn.Send(blockFragment)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_3_priority.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_3_priority.go
@@ -1,0 +1,70 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Priority() *spec.TestGroup {
+	tg := NewTestGroup("6.3", "PRIORITY")
+
+	// The PRIORITY frame always identifies a stream. If a PRIORITY
+	// frame is received with a stream identifier of 0x0, the recipient
+	// MUST respond with a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			pp := http2.PriorityParam{
+				StreamDep: 0,
+				Exclusive: false,
+				Weight:    255,
+			}
+			conn.WritePriority(0, pp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A PRIORITY frame with a length other than 5 octets MUST be
+	// treated as a stream error (Section 5.4.2) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PRIORITY frame with a length other than 5 octets",
+		Requirement: "The endpoint MUST respond with a stream error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// PRIORITY frame:
+			// length: 4, flags: 0x0, stream_id: 0x01
+			conn.Send([]byte("\x00\x00\x04\x02\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x80\x00\x00\x01"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_4_rst_stream.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_4_rst_stream.go
@@ -1,0 +1,84 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func RSTStream() *spec.TestGroup {
+	tg := NewTestGroup("6.4", "RST_STREAM")
+
+	// RST_STREAM frames MUST be associated with a stream.  If a
+	// RST_STREAM frame is received with a stream identifier of 0x0,
+	// the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame with 0x0 stream identifier",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(0, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// RST_STREAM frames MUST NOT be sent for a stream in the "idle"
+	// state. If a RST_STREAM frame identifying an idle stream is
+	// received, the recipient MUST treat this as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame on a idle stream",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteRSTStream(1, http2.ErrCodeCancel)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A RST_STREAM frame with a length other than 4 octets MUST be
+	// treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame with a length other than 4 octets",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// RST_STREAM frame:
+			// length: 3, flags: 0x0, stream_id: 0x01
+			conn.Send([]byte("\x00\x00\x03\x03\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x00\x00"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_5_2_defined_settings_parameters.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_5_2_defined_settings_parameters.go
@@ -1,0 +1,134 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func DefinedSETTINGSParameters() *spec.TestGroup {
+	tg := NewTestGroup("6.5.2", "Defined SETTINGS Parameters")
+
+	// SETTINGS_ENABLE_PUSH (0x2):
+	// The initial value is 1, which indicates that server push is
+	// permitted. Any value other than 0 or 1 MUST be treated as a
+	// connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "SETTINGS_ENABLE_PUSH (0x2): Sends the value other than 0 or 1",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingEnablePush,
+				Val: 2,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// SETTINGS_INITIAL_WINDOW_SIZE (0x4):
+	// Values above the maximum flow-control window size of 2^31-1
+	// MUST be treated as a connection error (Section 5.4.1) of
+	// type FLOW_CONTROL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size",
+		Requirement: "The endpoint MUST treat this as a connection error of type FLOW_CONTROL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingInitialWindowSize,
+				Val: 2147483648,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFlowControl)
+		},
+	})
+
+	// SETTINGS_MAX_FRAME_SIZE (0x5):
+	// The initial value is 2^14 (16,384) octets. The value advertised
+	// by an endpoint MUST be between this initial value and the
+	// maximum allowed frame size (2^24-1 or 16,777,215 octets),
+	// inclusive. Values outside this range MUST be treated as a
+	// connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value below the initial value",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingMaxFrameSize,
+				Val: 16383,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// SETTINGS_MAX_FRAME_SIZE (0x5):
+	// The initial value is 2^14 (16,384) octets. The value advertised
+	// by an endpoint MUST be between this initial value and the
+	// maximum allowed frame size (2^24-1 or 16,777,215 octets),
+	// inclusive. Values outside this range MUST be treated as a
+	// connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value above the maximum allowed frame size",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingMaxFrameSize,
+				Val: 16777216,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// An endpoint that receives a SETTINGS frame with any unknown
+	// or unsupported identifier MUST ignore that setting.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame with unknown identifier",
+		Requirement: "The endpoint MUST ignore that setting.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  0xFF,
+				Val: 1,
+			}
+			conn.WriteSettings(setting)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_5_3_settings_synchronization.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_5_3_settings_synchronization.go
@@ -1,0 +1,108 @@
+package http2
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func SettingsSynchronization() *spec.TestGroup {
+	tg := NewTestGroup("6.5.3", "Settings Synchronization")
+
+	// The values in the SETTINGS frame MUST be processed in the order
+	// they appear, with no other frame processing between values.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple values of SETTINGS_INITIAL_WINDOW_SIZE",
+		Requirement: "The endpoint MUST process the values in the settings in the order they apper.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			// Skip this test case when the length of data is 0.
+			dataLen, err := spec.ServerDataLength(c)
+			if err != nil {
+				return err
+			}
+			if dataLen < 1 {
+				return spec.ErrSkipped
+			}
+
+			err = conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			settings := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 100,
+				},
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 1,
+				},
+			}
+			conn.WriteSettings(settings...)
+
+			err = spec.VerifySettingsFrameWithAck(conn)
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			actual, passed := conn.WaitEventByType(spec.EventDataFrame)
+			switch event := actual.(type) {
+			case spec.DataFrameEvent:
+				passed = (event.Header().Length == 1)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("DATA Frame (length:1, flags:0x00, stream_id:%d)", streamID),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// Once all values have been processed, the recipient MUST
+	// immediately emit a SETTINGS frame with the ACK flag set.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame without ACK flag",
+		Requirement: "The endpoint MUST immediately emit a SETTINGS frame with the ACK flag set.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			setting := http2.Setting{
+				ID:  http2.SettingEnablePush,
+				Val: 0,
+			}
+			conn.WriteSettings(setting)
+
+			return spec.VerifySettingsFrameWithAck(conn)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_5_settings.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_5_settings.go
@@ -1,0 +1,95 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Settings() *spec.TestGroup {
+	tg := NewTestGroup("6.5", "SETTINGS")
+
+	// ACK (0x1):
+	// When set, bit 0 indicates that this frame acknowledges receipt
+	// and application of the peer's SETTINGS frame. When this bit is
+	// set, the payload of the SETTINGS frame MUST be empty. Receipt of
+	// a SETTINGS frame with the ACK flag set and a length field value
+	// other than 0 MUST be treated as a connection error (Section 5.4.1)
+	// of type FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame with ACK flag and payload",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// SETTINGS frame:
+			// length: 0, flags: 0x1, stream_id: 0x0
+			conn.Send([]byte("\x00\x00\x01\x04\x01\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	// SETTINGS frames always apply to a connection, never a single
+	// stream. The stream identifier for a SETTINGS frame MUST be
+	// zero (0x0). If an endpoint receives a SETTINGS frame whose
+	// stream identifier field is anything other than 0x0, the
+	// endpoint MUST respond with a connection error (Section 5.4.1)
+	// of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame with a stream identifier other than 0x0",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// SETTINGS frame:
+			// length: 6, flags: 0x0, stream_id: 0x1
+			conn.Send([]byte("\x00\x00\x06\x04\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x03\x00\x00\x00\x64"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// The SETTINGS frame affects connection state. A badly formed or
+	// incomplete SETTINGS frame MUST be treated as a connection error
+	// (Section 5.4.1) of type PROTOCOL_ERROR.
+	//
+	// A SETTINGS frame with a length other than a multiple of 6 octets
+	// MUST be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame with a length other than a multiple of 6 octets",
+		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// SETTINGS frame:
+			// length: 3, flags: 0x0, stream_id: 0x0
+			conn.Send([]byte("\x00\x00\x03\x04\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x03\x00"))
+
+			codes := []http2.ErrCode{
+				http2.ErrCodeProtocol,
+				http2.ErrCodeFrameSize,
+			}
+			return spec.VerifyStreamError(conn, codes...)
+		},
+	})
+
+	tg.AddTestGroup(DefinedSETTINGSParameters())
+	tg.AddTestGroup(SettingsSynchronization())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_7_ping.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_7_ping.go
@@ -1,0 +1,98 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func Ping() *spec.TestGroup {
+	tg := NewTestGroup("6.7", "PING")
+
+	// Receivers of a PING frame that does not include an ACK flag MUST
+	// send a PING frame with the ACK flag set in response, with an
+	// identical payload.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PING frame",
+		Requirement: "The endpoint MUST sends a PING frame with ACK, with an identical payload.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	// ACK (0x1):
+	// When set, bit 0 indicates that this PING frame is a PING
+	// response. An endpoint MUST set this flag in PING responses.
+	// An endpoint MUST NOT respond to PING frames containing this
+	// flag.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PING frame with ACK",
+		Requirement: "The endpoint MUST NOT respond to PING frames with ACK.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			unexpectedData := [8]byte{'i', 'n', 'v', 'a', 'l', 'i', 'd'}
+			expectedData := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(true, unexpectedData)
+			conn.WritePing(false, expectedData)
+
+			return spec.VerifyPingFrameWithAck(conn, expectedData)
+		},
+	})
+
+	// If a PING frame is received with a stream identifier field value
+	// other than 0x0, the recipient MUST respond with a connection
+	// error (Section 5.4.1) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PING frame with a stream identifier field value other than 0x0",
+		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame:
+			// length: 8, flags: 0x0, stream_id: 1
+			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// Receipt of a PING frame with a length field value other than 8
+	// MUST be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PING frame with a length field value other than 8",
+		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// PING frame:
+			// length: 8, flags: 0x0, stream_id: 0
+			conn.Send([]byte("\x00\x00\x06\x06\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_8_goaway.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_8_goaway.go
@@ -1,0 +1,35 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func GoAway() *spec.TestGroup {
+	tg := NewTestGroup("6.8", "GOAWAY")
+
+	// An endpoint MUST treat a GOAWAY frame with a stream identifier
+	// other than 0x0 as a connection error (Section 5.4.1) of type
+	// PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a GOAWAY frame with a stream identifier other than 0x0",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// GOAWAY frame:
+			// length: 8, flags: 0x0, stream_id: 1
+			conn.Send([]byte("\x00\x00\x08\x07\x00\x00\x00\x00\x01"))
+			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_9_1_the_flow_control_window.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_9_1_the_flow_control_window.go
@@ -1,0 +1,185 @@
+package http2
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func TheFlowControlWindow() *spec.TestGroup {
+	tg := NewTestGroup("6.9.1", "The Flow-Control Window")
+
+	// The sender MUST NOT send a flow-controlled frame with a length
+	// that exceeds the space available in either of the flow-control
+	// windows advertised by the receiver.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends SETTINGS frame to set the initial window size to 1 and sends HEADERS frame",
+		Requirement: "The endpoint MUST NOT send a flow-controlled frame with a length that exceeds the space available.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+			var actual spec.Event
+
+			// Skip this test case when the length of data is 0.
+			dataLen, err := spec.ServerDataLength(c)
+			if err != nil {
+				return err
+			}
+			if dataLen < 1 {
+				return spec.ErrSkipped
+			}
+
+			err = conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			settings := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 1,
+				},
+			}
+			conn.WriteSettings(settings...)
+
+			err = spec.VerifySettingsFrameWithAck(conn)
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			actual, passed := conn.WaitEventByType(spec.EventDataFrame)
+			switch event := actual.(type) {
+			case spec.DataFrameEvent:
+				passed = (event.Header().Length == 1)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("DATA Frame (length:1, flags:0x00, stream_id:%d)", streamID),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// A sender MUST NOT allow a flow-control window to exceed 2^31-1
+	// octets. If a sender receives a WINDOW_UPDATE that causes a
+	// flow-control window to exceed this maximum, it MUST terminate
+	// either the stream or the connection, as appropriate.
+	// For streams, the sender sends a RST_STREAM with an error code
+	// of FLOW_CONTROL_ERROR; for the connection, a GOAWAY frame with
+	// an error code of FLOW_CONTROL_ERROR is sent.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1",
+		Requirement: "The endpoint MUST sends a GOAWAY frame with a FLOW_CONTROL_ERROR code.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var actual spec.Event
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(0, 2147483647)
+			conn.WriteWindowUpdate(0, 2147483647)
+
+			actual, passed := conn.WaitEventByType(spec.EventGoAwayFrame)
+			switch event := actual.(type) {
+			case spec.GoAwayFrameEvent:
+				passed = (event.ErrCode == http2.ErrCodeFlowControl)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("GOAWAY Frame (Error Code: %s)", http2.ErrCodeFlowControl),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// A sender MUST NOT allow a flow-control window to exceed 2^31-1
+	// octets. If a sender receives a WINDOW_UPDATE that causes a
+	// flow-control window to exceed this maximum, it MUST terminate
+	// either the stream or the connection, as appropriate.
+	// For streams, the sender sends a RST_STREAM with an error code
+	// of FLOW_CONTROL_ERROR; for the connection, a GOAWAY frame with
+	// an error code of FLOW_CONTROL_ERROR is sent.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream",
+		Requirement: "The endpoint MUST sends a RST_STREAM frame with a FLOW_CONTROL_ERROR code.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+			var actual spec.Event
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(streamID, 2147483647)
+			conn.WriteWindowUpdate(streamID, 2147483647)
+
+			actual, passed := conn.WaitEventByType(spec.EventRSTStreamFrame)
+			switch event := actual.(type) {
+			case spec.RSTStreamFrameEvent:
+				if event.Header().StreamID == streamID {
+					passed = (event.ErrCode == http2.ErrCodeFlowControl)
+				}
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("RST_STREAM Frame (Error Code: %s)", http2.ErrCodeFlowControl),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_9_2_initial_flow_control_window_size.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_9_2_initial_flow_control_window_size.go
@@ -1,0 +1,219 @@
+package http2
+
+import (
+	"fmt"
+
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func InitialFlowControlWindowSize() *spec.TestGroup {
+	tg := NewTestGroup("6.9.2", "Initial Flow-Control Window Size")
+
+	// When the value of SETTINGS_INITIAL_WINDOW_SIZE changes,
+	// a receiver MUST adjust the size of all stream flow-control
+	// windows that it maintains by the difference between the new
+	// value and the old value.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Changes SETTINGS_INITIAL_WINDOW_SIZE after sending HEADERS frame",
+		Requirement: "The endpoint MUST adjust the size of all stream flow-control windows.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+			var actual spec.Event
+
+			// Skip this test case when the length of data is 0.
+			dataLen, err := spec.ServerDataLength(c)
+			if err != nil {
+				return err
+			}
+			if dataLen < 1 {
+				return spec.ErrSkipped
+			}
+
+			err = conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Set SETTINGS_INITIAL_WINDOW_SIZE to 0 to prevent sending
+			// DATA frame.
+			settings1 := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 0,
+				},
+			}
+			conn.WriteSettings(settings1...)
+
+			err = spec.VerifySettingsFrameWithAck(conn)
+			if err != nil {
+				return err
+			}
+
+			// Send a HEADERS frame.
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// Set SETTINGS_INITIAL_WINDOW_SIZE to 1 so that the server
+			// can send DATA frame.
+			settings2 := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 1,
+				},
+			}
+			conn.WriteSettings(settings2...)
+
+			// Wait for DATA frame...
+			actual, passed := conn.WaitEventByType(spec.EventDataFrame)
+			switch event := actual.(type) {
+			case spec.DataFrameEvent:
+				passed = (event.Header().Length == 1)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("DATA Frame (length:1, flags:0x00, stream_id:%d)", streamID),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// A sender MUST track the negative flow-control window and
+	// MUST NOT send new flow-controlled frames until it receives
+	// WINDOW_UPDATE frames that cause the flow-control window to
+	// become positive.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS frame for window size to be negative",
+		Requirement: "The endpoint MUST track the negative flow-control window.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+			var actual spec.Event
+
+			// Skip this test case when the length of data is 0.
+			dataLen, err := spec.ServerDataLength(c)
+			if err != nil {
+				return err
+			}
+			if dataLen < 5 {
+				return spec.ErrSkipped
+			}
+
+			err = conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Set SETTINGS_INITIAL_WINDOW_SIZE to 3 to prevent sending
+			// all of DATA frame.
+			settings1 := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 3,
+				},
+			}
+			conn.WriteSettings(settings1...)
+
+			err = spec.VerifySettingsFrameWithAck(conn)
+			if err != nil {
+				return err
+			}
+
+			// Send a HEADERS frame.
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			// Verify reception of DATA frame.
+			err = spec.VerifyEventType(conn, spec.EventDataFrame)
+			if err != nil {
+				return err
+			}
+
+			// Set SETTINGS_INITIAL_WINDOW_SIZE to 2 to make the window
+			// size negative.
+			settings2 := []http2.Setting{
+				http2.Setting{
+					ID:  http2.SettingInitialWindowSize,
+					Val: 2,
+				},
+			}
+			conn.WriteSettings(settings2...)
+
+			err = spec.VerifySettingsFrameWithAck(conn)
+			if err != nil {
+				return err
+			}
+
+			// Send WINDOW_UPDATE with increment size 2.
+			conn.WriteWindowUpdate(streamID, 2)
+
+			// Wait for DATA frame...
+			actual, passed := conn.WaitEventByType(spec.EventDataFrame)
+			switch event := actual.(type) {
+			case spec.DataFrameEvent:
+				passed = (event.Header().Length == 1)
+			default:
+				passed = false
+			}
+
+			if !passed {
+				expected := []string{
+					fmt.Sprintf("DATA Frame (length:1, flags:0x00, stream_id:%d)", streamID),
+				}
+
+				return &spec.TestError{
+					Expected: expected,
+					Actual:   actual.String(),
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// An endpoint MUST treat a change to SETTINGS_INITIAL_WINDOW_SIZE
+	// that causes any flow-control window to exceed the maximum size
+	// as a connection error (Section 5.4.1) of type FLOW_CONTROL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a SETTINGS_INITIAL_WINDOW_SIZE settings with an exceeded maximum window size value",
+		Requirement: "The endpoint MUST treat this as a connection error of type FLOW_CONTROL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// SETTINGS frame:
+			// SETTINGS_INITIAL_WINDOW_SIZE: 2147483648
+			conn.Send([]byte("\x00\x00\x06\x04\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x04\x80\x00\x00\x00"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFlowControl)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_9_window_update.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_9_window_update.go
@@ -1,0 +1,89 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func WindowUpdate() *spec.TestGroup {
+	tg := NewTestGroup("6.9", "WINDOW_UPDATE")
+
+	// A receiver MUST treat the receipt of a WINDOW_UPDATE frame with
+	// an flow-control window increment of 0 as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR; errors on the connection
+	// flow-control window MUST be treated as a connection error
+	// (Section 5.4.1).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteWindowUpdate(0, 0)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A receiver MUST treat the receipt of a WINDOW_UPDATE frame with
+	// an flow-control window increment of 0 as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR; errors on the connection
+	// flow-control window MUST be treated as a connection error
+	// (Section 5.4.1).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+			conn.WriteHeaders(hp)
+
+			conn.WriteWindowUpdate(streamID, 0)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A WINDOW_UPDATE frame with a length other than 4 octets MUST
+	// be treated as a connection error (Section 5.4.1) of type
+	// FRAME_SIZE_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a WINDOW_UPDATE frame with a length other than 4 octets",
+		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// WINDOW_UPDATE frame:
+			// length: 3, flags: 0x0, stream_id: 0
+			conn.Send([]byte("\x00\x00\x03\x08\x00\x00\x00\x00\x00"))
+			conn.Send([]byte("\x00\x00\x01"))
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)
+		},
+	})
+
+	tg.AddTestGroup(TheFlowControlWindow())
+	tg.AddTestGroup(InitialFlowControlWindowSize())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/6_frame_definitions.go
+++ b/vendor/github.com/summerwind/h2spec/http2/6_frame_definitions.go
@@ -1,0 +1,19 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func FrameDefinitions() *spec.TestGroup {
+	tg := NewTestGroup("6", "Frame Definitions")
+
+	tg.AddTestGroup(Data())
+	tg.AddTestGroup(Headers())
+	tg.AddTestGroup(Priority())
+	tg.AddTestGroup(RSTStream())
+	tg.AddTestGroup(Settings())
+	tg.AddTestGroup(Ping())
+	tg.AddTestGroup(GoAway())
+	tg.AddTestGroup(WindowUpdate())
+	tg.AddTestGroup(Continuation())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/7_error_codes.go
+++ b/vendor/github.com/summerwind/h2spec/http2/7_error_codes.go
@@ -1,0 +1,69 @@
+package http2
+
+import (
+	"golang.org/x/net/http2"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+)
+
+func ErrorCodes() *spec.TestGroup {
+	tg := NewTestGroup("7", "Error Codes")
+
+	// Unknown or unsupported error codes MUST NOT trigger any special
+	// behavior. These MAY be treated by an implementation as being
+	// equivalent to INTERNAL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a GOAWAY frame with unknown error code",
+		Requirement: "The endpoint MUST NOT trigger any special behavior.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			conn.WriteGoAway(0, 0xff, []byte{})
+
+			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameOrConnectionClose(conn, data)
+		},
+	})
+
+	// Unknown or unsupported error codes MUST NOT trigger any special
+	// behavior. These MAY be treated by an implementation as being
+	// equivalent to INTERNAL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a RST_STREAM frame with unknown error code",
+		Requirement: "The endpoint MUST NOT trigger any special behavior.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteRSTStream(streamID, 0xff)
+
+			data := [8]byte{}
+			conn.WritePing(false, data)
+
+			return spec.VerifyPingFrameWithAck(conn, data)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_2_1_pseudo_header_fields.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_2_1_pseudo_header_fields.go
@@ -1,0 +1,164 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func PseudoHeaderFields() *spec.TestGroup {
+	tg := NewTestGroup("8.1.2.1", "Pseudo-Header Fields")
+
+	// Pseudo-header fields are only valid in the context in which
+	// they are defined. Pseudo-header fields defined for requests
+	// MUST NOT appear in responses; pseudo-header fields defined
+	// for responses MUST NOT appear in requests. Pseudo-header
+	// fields MUST NOT appear in trailers. Endpoints MUST treat
+	// a request or response that contains undefined or invalid
+	// pseudo-header fields as malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains a unknown pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField(":test", "ok"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// Pseudo-header fields are only valid in the context in which
+	// they are defined. Pseudo-header fields defined for requests
+	// MUST NOT appear in responses; pseudo-header fields defined
+	// for responses MUST NOT appear in requests. Pseudo-header
+	// fields MUST NOT appear in trailers. Endpoints MUST treat
+	// a request or response that contains undefined or invalid
+	// pseudo-header fields as malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains the pseudo-header field defined for response",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField(":status", "200"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// Pseudo-header fields are only valid in the context in which
+	// they are defined. Pseudo-header fields defined for requests
+	// MUST NOT appear in responses; pseudo-header fields defined
+	// for responses MUST NOT appear in requests. Pseudo-header
+	// fields MUST NOT appear in trailers. Endpoints MUST treat
+	// a request or response that contains undefined or invalid
+	// pseudo-header fields as malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains a pseudo-header field as trailers",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp1)
+			conn.WriteData(streamID, false, []byte("test"))
+
+			trailers := []hpack.HeaderField{
+				spec.HeaderField(":method", "POST"),
+			}
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(trailers),
+			}
+
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All pseudo-header fields MUST appear in the header block before
+	// regular header fields. Any request or response that contains
+	// a pseudo-header field that appears in a header block after
+	// a regular header field MUST be treated as malformed
+	// (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains a pseudo-header field that appears in a header block after a regular header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := []hpack.HeaderField{
+				spec.HeaderField("x-test", "ok"),
+			}
+			headers = append(headers, spec.CommonHeaders(c)...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_2_2_connection_specific_header_fields.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_2_2_connection_specific_header_fields.go
@@ -1,0 +1,75 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func ConnectionSpecificHeaderFields() *spec.TestGroup {
+	tg := NewTestGroup("8.1.2.2", "Connection-Specific Header Fields")
+
+	// An endpoint MUST NOT generate an HTTP/2 message containing
+	// connection-specific header fields; any message containing
+	// connection-specific header fields MUST be treated as
+	// malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains the connection-specific header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField("connection", "keep-alive"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// The only exception to this is the TE header field, which MAY be
+	// present in an HTTP/2 request; when it is, it MUST NOT contain
+	// any value other than "trailers".
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains the TE header field with any value other than \"trailers\"",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField("trailers", "test"))
+			headers = append(headers, spec.HeaderField("te", "trailers, deflate"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_2_3_request_pseudo_header_fields.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_2_3_request_pseudo_header_fields.go
@@ -1,0 +1,242 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func RequestPseudoHeaderFields() *spec.TestGroup {
+	tg := NewTestGroup("8.1.2.3", "Request Pseudo-Header Fields")
+
+	// The ":path" pseudo-header field includes the path and query
+	// parts of the target URI (the "path-absolute" production and
+	// optionally a '?' character followed by the "query" production
+	// (see Sections 3.3 and 3.4 of [RFC3986]). A request in asterisk
+	// form includes the value '*' for the ":path" pseudo-header field.
+	//
+	// This pseudo-header field MUST NOT be empty for "http" or "https"
+	// URIs; "http" or "https" URIs that do not contain a path
+	// component MUST include a value of '/'.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with empty \":path\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[2].Value = ""
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that omits \":method\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = []hpack.HeaderField{
+				headers[1], // :scheme
+				headers[2], // :path
+				headers[3], // :authority
+			}
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers[1:]),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that omits \":scheme\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = []hpack.HeaderField{
+				headers[0], // :method
+				headers[2], // :path
+				headers[3], // :authority
+			}
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that omits \":path\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = []hpack.HeaderField{
+				headers[0], // :method
+				headers[1], // :scheme
+				headers[3], // :authority
+			}
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with duplicated \":method\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField(":method", headers[0].Value))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with duplicated \":scheme\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField(":scheme", headers[1].Value))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// All HTTP/2 requests MUST include exactly one valid value for
+	// the ":method", ":scheme", and ":path" pseudo-header fields,
+	// unless it is a CONNECT request (Section 8.3).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with duplicated \":path\" pseudo-header field",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField(":path", headers[2].Value))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_2_6_malformed_requests_and_responses.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_2_6_malformed_requests_and_responses.go
@@ -1,0 +1,100 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func MalformedRequestsAndResponses() *spec.TestGroup {
+	tg := NewTestGroup("8.1.2.6", "Malformed Requests and Responses")
+
+	// A request or response that includes a payload body can include
+	// a content-length header field. A request or response is also
+	// malformed if the value of a content-length header field does
+	// not equal the sum of the DATA frame payload lengths that form
+	// the body. A response that is defined to have no payload, as
+	// described in [RFC7230], Section 3.3.2, can have a non-zero
+	// content-length header field, even though no content is included
+	// in DATA frames.
+	//
+	// Intermediaries that process HTTP requests or responses (i.e.,
+	// any intermediary not acting as a tunnel) MUST NOT forward a
+	// malformed request or response. Malformed requests or responses
+	// that are detected MUST be treated as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with the \"content-length\" header field which does not equal the DATA frame payload length",
+		Requirement: "The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+			headers = append(headers, spec.HeaderField("content-length", "1"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	// A request or response that includes a payload body can include
+	// a content-length header field. A request or response is also
+	// malformed if the value of a content-length header field does
+	// not equal the sum of the DATA frame payload lengths that form
+	// the body. A response that is defined to have no payload, as
+	// described in [RFC7230], Section 3.3.2, can have a non-zero
+	// content-length header field, even though no content is included
+	// in DATA frames.
+	//
+	// Intermediaries that process HTTP requests or responses (i.e.,
+	// any intermediary not acting as a tunnel) MUST NOT forward a
+	// malformed request or response. Malformed requests or responses
+	// that are detected MUST be treated as a stream error
+	// (Section 5.4.2) of type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame with the \"content-length\" header field which does not equal the sum of the multiple DATA frames payload length",
+		Requirement: "The endpoint MUST treat this as a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+			headers = append(headers, spec.HeaderField("content-length", "1"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+			conn.WriteData(streamID, false, []byte("test"))
+			conn.WriteData(streamID, true, []byte("test"))
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_2_http_header_fields.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_2_http_header_fields.go
@@ -1,0 +1,51 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func HTTPHeaderFields() *spec.TestGroup {
+	tg := NewTestGroup("8.1.2", "HTTP Header Fields")
+
+	// Just as in HTTP/1.x, header field names are strings of ASCII
+	// characters that are compared in a case-insensitive fashion.
+	// However, header field names MUST be converted to lowercase
+	// prior to their encoding in HTTP/2. A request or response
+	// containing uppercase header field names MUST be treated as
+	// malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a HEADERS frame that contains the header field name in uppercase letters",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers = append(headers, spec.HeaderField("X-TEST", "ok"))
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	tg.AddTestGroup(PseudoHeaderFields())
+	tg.AddTestGroup(ConnectionSpecificHeaderFields())
+	tg.AddTestGroup(RequestPseudoHeaderFields())
+	tg.AddTestGroup(MalformedRequestsAndResponses())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_1_http_request_response_exchange.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_1_http_request_response_exchange.go
@@ -1,0 +1,61 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func HTTPRequestResponseExchange() *spec.TestGroup {
+	tg := NewTestGroup("8.1", "HTTP Request/Response Exchange")
+
+	// An endpoint that receives a HEADERS frame without the
+	// END_STREAM flag set after receiving a final (non-informational)
+	// status code MUST treat the corresponding request or response
+	// as malformed (Section 8.1.2.6).
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a second HEADERS frame without the END_STREAM flag",
+		Requirement: "The endpoint MUST respond with a stream error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
+			hp1 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WriteHeaders(hp1)
+			conn.WriteData(streamID, false, []byte("test"))
+
+			trailers := []hpack.HeaderField{
+				spec.HeaderField("x-test", "ok"),
+			}
+
+			hp2 := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     false,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(trailers),
+			}
+
+			conn.WriteHeaders(hp2)
+
+			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	tg.AddTestGroup(HTTPHeaderFields())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_2_server_push.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_2_server_push.go
@@ -1,0 +1,45 @@
+package http2
+
+import (
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/spec"
+	"golang.org/x/net/http2"
+)
+
+func ServerPush() *spec.TestGroup {
+	tg := NewTestGroup("8.2", "Server Push")
+
+	// A client cannot push. Thus, servers MUST treat the receipt of
+	// a PUSH_PROMISE frame as a connection error (Section 5.4.1) of
+	// type PROTOCOL_ERROR. Clients MUST reject any attempt to change
+	// the SETTINGS_ENABLE_PUSH setting to a value other than 0 by
+	// treating the message as a connection error (Section 5.4.1) of
+	// type PROTOCOL_ERROR.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a PUSH_PROMISE frame",
+		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			headers := spec.CommonHeaders(c)
+
+			pp := http2.PushPromiseParam{
+				StreamID:      streamID,
+				PromiseID:     3,
+				EndHeaders:    true,
+				BlockFragment: conn.EncodeHeaders(headers),
+			}
+
+			conn.WritePushPromise(pp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
+		},
+	})
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/8_http_message_exchanges.go
+++ b/vendor/github.com/summerwind/h2spec/http2/8_http_message_exchanges.go
@@ -1,0 +1,12 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+func HTTPMessageExchanges() *spec.TestGroup {
+	tg := NewTestGroup("8", "HTTP Message Exchanges")
+
+	tg.AddTestGroup(HTTPRequestResponseExchange())
+	tg.AddTestGroup(ServerPush())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/http2/http2.go
+++ b/vendor/github.com/summerwind/h2spec/http2/http2.go
@@ -1,0 +1,29 @@
+package http2
+
+import "github.com/summerwind/h2spec/spec"
+
+var key = "http2"
+
+func NewTestGroup(section string, name string) *spec.TestGroup {
+	return &spec.TestGroup{
+		Key:     key,
+		Section: section,
+		Name:    name,
+	}
+}
+
+func Spec() *spec.TestGroup {
+	tg := &spec.TestGroup{
+		Key:  key,
+		Name: "Hypertext Transfer Protocol Version 2 (HTTP/2)",
+	}
+
+	tg.AddTestGroup(StartingHTTP2())
+	tg.AddTestGroup(HTTPFrames())
+	tg.AddTestGroup(StreamsAndMultiplexing())
+	tg.AddTestGroup(FrameDefinitions())
+	tg.AddTestGroup(ErrorCodes())
+	tg.AddTestGroup(HTTPMessageExchanges())
+
+	return tg
+}

--- a/vendor/github.com/summerwind/h2spec/log/log.go
+++ b/vendor/github.com/summerwind/h2spec/log/log.go
@@ -1,0 +1,40 @@
+package log
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	// IndentLevel is the value of current indent level.
+	IndentLevel int = 0
+	// Indent is the string of current indent level.
+	Indent string = ""
+)
+
+// SetIndentLevel sets the current indent level by integer.
+func SetIndentLevel(level int) {
+	IndentLevel = level
+	Indent = strings.Repeat("  ", level)
+}
+
+// Print writes the specified string with indent.
+func Print(a ...interface{}) {
+	fmt.Printf("%s%s", Indent, fmt.Sprint(a...))
+}
+
+// Println writes the specified string. Indent is added and a newline
+// is appended.
+func Println(a ...interface{}) {
+	fmt.Printf("%s%s", Indent, fmt.Sprintln(a...))
+}
+
+// PrintBlankLine writes empty line.
+func PrintBlankLine() {
+	fmt.Println("")
+}
+
+// Resetline cancels the previous line.
+func ResetLine() {
+	fmt.Printf("\r")
+}

--- a/vendor/github.com/summerwind/h2spec/reporter/client_reporter.go
+++ b/vendor/github.com/summerwind/h2spec/reporter/client_reporter.go
@@ -1,0 +1,64 @@
+package reporter
+
+import (
+	"fmt"
+
+	"github.com/summerwind/h2spec/log"
+	"github.com/summerwind/h2spec/spec"
+)
+
+// SummaryForClient outputs the summary of test result that includes
+// the number of passsed, skipped and failed.
+func SummaryForClient(group *spec.ClientTestGroup) string {
+	passed := group.PassedCount
+	failed := group.FailedCount
+	skipped := group.SkippedCount
+
+	total := passed + failed + skipped
+	tmp := "%d tests, %d passed, %d skipped, %d failed"
+	return fmt.Sprintf(tmp, total, passed, skipped, failed)
+}
+
+func PrintSummaryForClient(group *spec.ClientTestGroup) {
+	log.Println(SummaryForClient(group))
+}
+
+// PrintFailedClientTests outputs the report of failed tests.
+func PrintFailedClientTests(group *spec.ClientTestGroup) {
+	log.Print("Failures: \n\n")
+
+	printClientFailed(group)
+}
+
+func printClientFailed(tg *spec.ClientTestGroup) {
+	if tg.FailedCount == 0 {
+		return
+	}
+
+	level := tg.Level()
+
+	log.SetIndentLevel(level)
+	log.Println(tg.Title())
+	log.SetIndentLevel(level + 1)
+
+	failed := false
+
+	for _, tc := range tg.Tests {
+		if tc.Result == nil {
+			continue
+		}
+
+		if tc.Result.Failed {
+			tc.Result.Print()
+			failed = true
+		}
+	}
+
+	if failed {
+		log.PrintBlankLine()
+	}
+
+	for _, g := range tg.Groups {
+		printClientFailed(g)
+	}
+}

--- a/vendor/github.com/summerwind/h2spec/reporter/junit_report.go
+++ b/vendor/github.com/summerwind/h2spec/reporter/junit_report.go
@@ -1,0 +1,143 @@
+package reporter
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/summerwind/h2spec/spec"
+)
+
+// JUnitReport represents the JUnit XML format.
+type JUnitTestReport struct {
+	XMLName    xml.Name          `xml:"testsuites"`
+	TestSuites []*JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestSuite represents the testsuite element of JUnit XML format.
+type JUnitTestSuite struct {
+	XMLName   xml.Name         `xml:"testsuite"`
+	Name      string           `xml:"name,attr"`
+	Package   string           `xml:"package,attr"`
+	ID        string           `xml:"id,attr"`
+	Tests     int              `xml:"tests,attr"`
+	Skipped   int              `xml:"skipped,attr"`
+	Failures  int              `xml:"failures,attr"`
+	Errors    int              `xml:"errors,attr"`
+	TestCases []*JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase represents the testcase element of JUnit XML format.
+type JUnitTestCase struct {
+	XMLName   xml.Name      `xml:"testcase"`
+	Package   string        `xml:"package,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Time      string        `xml:"time,attr"`
+	Failure   *JUnitFailure `xml:"failure"`
+	Skipped   *JUnitSkipped `xml:"skipped"`
+	Error     *JUnitError   `xml:"error"`
+}
+
+// JUnitFailure represents the failure element of JUnit XML format.
+type JUnitFailure struct {
+	XMLName xml.Name `xml:"failure"`
+	Content string   `xml:",innerxml"`
+}
+
+// JUnitSkipped represents the skipped element of JUnit XML format.
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+	Content string   `xml:",innerxml"`
+}
+
+// JUnitSkipped represents the error element of JUnit XML format.
+type JUnitError struct {
+	XMLName xml.Name `xml:"error"`
+	Content string   `xml:",innerxml"`
+}
+
+// JUnitReport writes a file which contains the JUnit report generated
+// by test result of h2spec.
+func JUnitReport(groups []*spec.TestGroup, filePath string) error {
+	report := JUnitTestReport{
+		TestSuites: convertJUnitReport(groups),
+	}
+
+	buf, err := xml.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf("%s%s", xml.Header, buf)
+	return ioutil.WriteFile(filePath, []byte(body), os.ModePerm)
+}
+
+func convertJUnitReport(groups []*spec.TestGroup) []*JUnitTestSuite {
+	ts := make([]*JUnitTestSuite, 20)
+
+	for _, tg := range groups {
+		tests := append(tg.Tests, tg.StrictTests...)
+		if len(tests) == 0 {
+			ts = append(ts, convertJUnitReport(tg.Groups)...)
+			continue
+		}
+
+		jts := &JUnitTestSuite{
+			Package:   tg.ID(),
+			Name:      fmt.Sprintf("%s. %s", tg.Section, tg.Name),
+			ID:        tg.Section,
+			Tests:     0,
+			Skipped:   0,
+			Failures:  0,
+			Errors:    0,
+			TestCases: make([]*JUnitTestCase, 20),
+		}
+
+		for _, tc := range tests {
+			if tc.Result == nil {
+				continue
+			}
+
+			jtc := &JUnitTestCase{
+				Package:   tg.ID(),
+				ClassName: tc.Desc,
+				Time:      fmt.Sprintf("%.04f", tc.Result.Duration.Seconds()),
+			}
+
+			jts.Tests += 1
+			if tc.Result.Skipped {
+				jts.Skipped += 1
+				jtc.Skipped = &JUnitSkipped{}
+			} else if tc.Result.Failed {
+				switch tc.Result.Error.(type) {
+				case spec.TestError:
+					jts.Failures += 1
+
+					err := tc.Result.Error.(*spec.TestError)
+					expected := strings.Join(err.Expected, "\n")
+					actual := err.Actual
+
+					jtc.Failure = &JUnitFailure{
+						Content: fmt.Sprintf("Expect:\n%s\nActual:\n%s", expected, actual),
+					}
+				default:
+					jts.Errors += 1
+
+					err := tc.Result.Error
+					jtc.Error = &JUnitError{
+						Content: err.Error(),
+					}
+				}
+			}
+
+			jts.TestCases = append(jts.TestCases, jtc)
+		}
+
+		ts = append(ts, jts)
+		ts = append(ts, convertJUnitReport(tg.Groups)...)
+	}
+
+	return ts
+}

--- a/vendor/github.com/summerwind/h2spec/reporter/reporter.go
+++ b/vendor/github.com/summerwind/h2spec/reporter/reporter.go
@@ -1,0 +1,67 @@
+package reporter
+
+import (
+	"fmt"
+
+	"github.com/summerwind/h2spec/log"
+	"github.com/summerwind/h2spec/spec"
+)
+
+// Summary outputs the summary of test result that includes
+// the number of passsed, skipped and failed.
+func Summary(groups []*spec.TestGroup) {
+	var passed, failed, skipped, total int
+
+	for _, tg := range groups {
+		passed += tg.PassedCount
+		failed += tg.FailedCount
+		skipped += tg.SkippedCount
+	}
+
+	total = passed + failed + skipped
+	tmp := "%d tests, %d passed, %d skipped, %d failed"
+	log.Println(fmt.Sprintf(tmp, total, passed, skipped, failed))
+}
+
+// FailedTests outputs the report of failed tests.
+func FailedTests(groups []*spec.TestGroup) {
+	log.Print("Failures: \n\n")
+
+	for _, tg := range groups {
+		printFailed(tg)
+	}
+}
+
+func printFailed(tg *spec.TestGroup) {
+	if tg.FailedCount == 0 {
+		return
+	}
+
+	level := tg.Level()
+
+	log.SetIndentLevel(level)
+	log.Println(tg.Title())
+	log.SetIndentLevel(level + 1)
+
+	tests := append(tg.Tests, tg.StrictTests...)
+	failed := false
+
+	for _, tc := range tests {
+		if tc.Result == nil {
+			continue
+		}
+
+		if tc.Result.Failed {
+			tc.Result.Print()
+			failed = true
+		}
+	}
+
+	if failed {
+		log.PrintBlankLine()
+	}
+
+	for _, g := range tg.Groups {
+		printFailed(g)
+	}
+}

--- a/vendor/github.com/summerwind/h2spec/reporter/web_reporter.go
+++ b/vendor/github.com/summerwind/h2spec/reporter/web_reporter.go
@@ -1,0 +1,165 @@
+package reporter
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/log"
+	"github.com/summerwind/h2spec/spec"
+)
+
+const homeTemplate string = `
+<html>
+<head><title>h2specd Report</title></head>
+<body>
+<script>
+function runTests() {
+	var links = document.getElementsByTagName("a");
+	for (var i = 0; i < links.length; i++) {
+		var link = links[i].getAttribute("href");
+		console.log(link);
+		try {
+			var xhr = new XMLHttpRequest();
+			xhr.open("GET", link, false);
+			xhr.send();
+		} catch(err) {
+		}
+	}
+
+	var xhr = new XMLHttpRequest();
+	xhr.open("GET", "/report", false);
+	xhr.send();
+	document.getElementById("report").innerHTML = xhr.responseText;
+}
+</script>
+<button type="button" onclick="runTests()">Run Tests</button>
+<div id="report">
+  %s
+</div>
+</body>
+</html>
+`
+
+type WebReportServer struct {
+	http.Server
+
+	config *config.Config
+	spec   *spec.ClientTestGroup
+}
+
+func NewWebReportServer(config *config.Config, spec *spec.ClientTestGroup) *WebReportServer {
+	server := &WebReportServer{
+		Server: http.Server{Addr: config.Addr()},
+		config: config,
+		spec:   spec,
+	}
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", server.home)
+	handler.HandleFunc("/report", server.report)
+
+	server.Handler = handler
+
+	return server
+}
+
+func (server *WebReportServer) RunForever() error {
+	log.Println(fmt.Sprintf("Report server is listened at http://%s", server.config.Addr()))
+	return server.ListenAndServe()
+}
+
+func (server *WebReportServer) home(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, homeTemplate, htmlReport(server.spec, server.config))
+}
+
+func (server *WebReportServer) report(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, htmlReport(server.spec, server.config))
+}
+
+func htmlReport(tg *spec.ClientTestGroup, c *config.Config) string {
+	var buffer bytes.Buffer
+
+	passed := tg.PassedCount
+	failed := tg.FailedCount
+	skipped := tg.SkippedCount
+
+	total := passed + failed + skipped
+	tmp := "<div>%d tests, %d passed, %d skipped, %d failed</div>"
+	buffer.WriteString(fmt.Sprintf(tmp, total, passed, skipped, failed))
+
+	buffer.WriteString(htmlReportForTestGroup(tg, c))
+	return buffer.String()
+}
+
+func htmlReportForTestGroup(tg *spec.ClientTestGroup, c *config.Config) string {
+	mode := c.RunMode(tg.ID())
+	if mode == config.RunModeNone {
+		return ""
+	}
+
+	var buffer bytes.Buffer
+
+	buffer.WriteString(fmt.Sprintf("<div>%s</div>", tg.Title()))
+
+	for _, tc := range tg.Tests {
+		buffer.WriteString(htmlReportForTestCase(tc, c))
+	}
+
+	for _, g := range tg.Groups {
+		buffer.WriteString(htmlReportForTestGroup(g, c))
+	}
+
+	buffer.WriteString("<br>")
+	return buffer.String()
+}
+
+func htmlReportForTestCase(tc *spec.ClientTestCase, c *config.Config) string {
+	formatter := "<div>%s<a href=\"%s\" target=\"_blank\">%s</a>%s</div>"
+
+	tr := tc.Result
+
+	if tr == nil {
+		resultLabel := "<span style=\"color: red;\">&nbsp;&nbsp;</span>"
+		return fmt.Sprintf(formatter, resultLabel, tc.FullPath(c), tc.FullPath(c), tc.Desc)
+	}
+
+	if !tr.Failed {
+		resultLabel := "<span style=\"color: green;\">✔</span>"
+		return fmt.Sprintf(formatter, resultLabel, tc.FullPath(c), tc.FullPath(c), tc.Desc)
+	}
+
+	var buffer bytes.Buffer
+
+	resultLabel := "<span style=\"color: red;\">✖</span>"
+	buffer.WriteString(fmt.Sprintf(formatter, resultLabel, tc.FullPath(c), tc.FullPath(c), tc.Desc))
+
+	err, ok := tr.Error.(*spec.TestError)
+	formatter = "<div style=\"padding-left: %dpx; color: %s\">%s</div>"
+	if ok {
+		msg := fmt.Sprintf("-> %s", tc.Requirement)
+		buffer.WriteString(fmt.Sprintf(formatter, 20, "red", msg))
+
+		label := "Expected:"
+		for i, ex := range err.Expected {
+			if i != 0 {
+				label = strings.Repeat("&nbsp;", len(label))
+			}
+			msg = fmt.Sprintf("%s&nbsp;%s", label, ex)
+			buffer.WriteString(fmt.Sprintf(formatter, 30, "yellow", msg))
+		}
+		msg = fmt.Sprintf("&nbsp;&nbsp;Actual:&nbsp;%s", err.Actual)
+		buffer.WriteString(fmt.Sprintf(formatter, 30, "green", msg))
+
+	} else if err != nil {
+		errMsg := fmt.Sprintf("Error: %v", err)
+		buffer.WriteString(fmt.Sprintf(formatter, 20, "red", errMsg))
+	} else {
+		errMsg := fmt.Sprintf("Error: %v", tr.Error.Error())
+		buffer.WriteString(fmt.Sprintf(formatter, 20, "red", errMsg))
+	}
+
+	return buffer.String()
+}

--- a/vendor/github.com/summerwind/h2spec/spec/connection.go
+++ b/vendor/github.com/summerwind/h2spec/spec/connection.go
@@ -1,0 +1,706 @@
+package spec
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"reflect"
+	"runtime"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/log"
+)
+
+const (
+	// DefaultWindowSize is the value of default connection window size.
+	DefaultWindowSize = 65535
+	// DefaultFrameSize is the value of default frame size.
+	DefaultFrameSize = 16384
+)
+
+// Conn represent a HTTP/2 connection.
+// This struct contains settings information, current window size,
+// encoder of HPACK and frame encoder.
+type Conn struct {
+	net.Conn
+
+	Settings map[http2.SettingID]uint32
+	Timeout  time.Duration
+	Verbose  bool
+	Closed   bool
+
+	WindowUpdate bool
+	WindowSize   map[uint32]int
+
+	framer     *http2.Framer
+	encoder    *hpack.Encoder
+	encoderBuf *bytes.Buffer
+	decoder    *hpack.Decoder
+
+	debugFramer    *http2.Framer
+	debugFramerBuf *bytes.Buffer
+
+	server bool
+}
+
+// Dial connects to the server based on configuration.
+func Dial(c *config.Config) (*Conn, error) {
+	var baseConn net.Conn
+	var err error
+
+	if c.TLS {
+		dialer := &net.Dialer{}
+		dialer.Timeout = c.Timeout
+
+		tlsConfig, err := c.TLSConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConn, err := tls.DialWithDialer(dialer, "tcp", c.Addr(), tlsConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		cs := tlsConn.ConnectionState()
+		if !cs.NegotiatedProtocolIsMutual {
+			return nil, errors.New("Protocol negotiation failed")
+		}
+
+		baseConn = tlsConn
+	} else {
+		baseConn, err = net.DialTimeout("tcp", c.Addr(), c.Timeout)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	settings := map[http2.SettingID]uint32{}
+
+	framer := http2.NewFramer(baseConn, baseConn)
+	framer.AllowIllegalWrites = true
+	framer.AllowIllegalReads = true
+
+	var encoderBuf bytes.Buffer
+	encoder := hpack.NewEncoder(&encoderBuf)
+
+	decoder := hpack.NewDecoder(4096, func(f hpack.HeaderField) {})
+
+	conn := Conn{
+		Conn:     baseConn,
+		Settings: settings,
+		Timeout:  c.Timeout,
+		Verbose:  c.Verbose,
+		Closed:   false,
+
+		WindowUpdate: true,
+		WindowSize:   map[uint32]int{0: DefaultWindowSize},
+
+		framer:     framer,
+		encoder:    encoder,
+		encoderBuf: &encoderBuf,
+		decoder:    decoder,
+
+		server: false,
+	}
+
+	if conn.Verbose {
+		conn.debugFramerBuf = new(bytes.Buffer)
+		conn.debugFramer = http2.NewFramer(conn.debugFramerBuf, conn.debugFramerBuf)
+		conn.debugFramer.AllowIllegalWrites = true
+		conn.debugFramer.AllowIllegalReads = true
+	}
+
+	return &conn, nil
+}
+
+func Accept(c *config.Config, baseConn net.Conn) (*Conn, error) {
+	settings := map[http2.SettingID]uint32{}
+
+	framer := http2.NewFramer(baseConn, baseConn)
+	framer.AllowIllegalWrites = true
+	framer.AllowIllegalReads = true
+
+	var encoderBuf bytes.Buffer
+	encoder := hpack.NewEncoder(&encoderBuf)
+
+	decoder := hpack.NewDecoder(4096, func(f hpack.HeaderField) {})
+
+	conn := Conn{
+		Conn:     baseConn,
+		Settings: settings,
+		Timeout:  c.Timeout,
+		Verbose:  c.Verbose,
+		Closed:   false,
+
+		WindowUpdate: true,
+		WindowSize:   map[uint32]int{0: DefaultWindowSize},
+
+		framer:     framer,
+		encoder:    encoder,
+		encoderBuf: &encoderBuf,
+		decoder:    decoder,
+
+		server: true,
+	}
+
+	if conn.Verbose {
+		conn.debugFramerBuf = new(bytes.Buffer)
+		conn.debugFramer = http2.NewFramer(conn.debugFramerBuf, conn.debugFramerBuf)
+		conn.debugFramer.AllowIllegalWrites = true
+		conn.debugFramer.AllowIllegalReads = true
+	}
+
+	return &conn, nil
+}
+
+// Handshake performs HTTP/2 handshake with the server.
+func (conn *Conn) Handshake() error {
+	if conn.server {
+		return conn.handshakeAsServer()
+	} else {
+		return conn.handshakeAsClient()
+	}
+}
+
+// MaxFrameSize returns value of Handshake performs HTTP/2 handshake
+// with the server.
+func (conn *Conn) MaxFrameSize() int {
+	val, ok := conn.Settings[http2.SettingMaxFrameSize]
+	if !ok {
+		return DefaultFrameSize
+	}
+	return int(val)
+}
+
+// EncodeHeaders encodes header and returns encoded bytes. Conn
+// retains encoding context and next call of EncodeHeaders will be
+// performed using the same encoding context.
+func (conn *Conn) EncodeHeaders(headers []hpack.HeaderField) []byte {
+	conn.encoderBuf.Reset()
+
+	for _, hf := range headers {
+		conn.encoder.WriteField(hf)
+	}
+
+	dst := make([]byte, conn.encoderBuf.Len())
+	copy(dst, conn.encoderBuf.Bytes())
+
+	return dst
+}
+
+// SetMaxDynamicTableSize changes the dynamic header table size to v.
+func (conn *Conn) SetMaxDynamicTableSize(v uint32) {
+	conn.encoder.SetMaxDynamicTableSize(v)
+}
+
+// Send sends a byte sequense. This function is used to send a raw
+// data in tests.
+func (conn *Conn) Send(payload []byte) error {
+	conn.vlog(RawDataEvent{payload}, true)
+	_, err := conn.Write(payload)
+	return err
+}
+
+// WriteData sends a DATA frame.
+func (conn *Conn) WriteData(streamID uint32, endStream bool, data []byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteData(streamID, endStream, data)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteData(streamID, endStream, data)
+}
+
+// WriteDataPadded sends a DATA frame with padding.
+func (conn *Conn) WriteDataPadded(streamID uint32, endStream bool, data, pad []byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteDataPadded(streamID, endStream, data, pad)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteDataPadded(streamID, endStream, data, pad)
+}
+
+// WriteHeaders sends a HEADERS frame.
+func (conn *Conn) WriteHeaders(p http2.HeadersFrameParam) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteHeaders(p)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteHeaders(p)
+}
+
+// WritePriority sends a PRIORITY frame.
+func (conn *Conn) WritePriority(streamID uint32, p http2.PriorityParam) error {
+	if conn.Verbose {
+		conn.debugFramer.WritePriority(streamID, p)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WritePriority(streamID, p)
+}
+
+// WriteRSTStream sends a RST_STREAM frame.
+func (conn *Conn) WriteRSTStream(streamID uint32, code http2.ErrCode) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteRSTStream(streamID, code)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteRSTStream(streamID, code)
+}
+
+// WriteSettings sends a SETTINGS frame.
+func (conn *Conn) WriteSettings(settings ...http2.Setting) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteSettings(settings...)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteSettings(settings...)
+}
+
+// WriteSettingsAck sends a SETTINGS frame with ACK flag.
+func (conn *Conn) WriteSettingsAck() error {
+	if conn.Verbose {
+		conn.debugFramer.WriteSettingsAck()
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteSettingsAck()
+}
+
+// WritePushPromise sends a PUSH_PROMISE frame.
+func (conn *Conn) WritePushPromise(p http2.PushPromiseParam) error {
+	if conn.Verbose {
+		conn.debugFramer.WritePushPromise(p)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WritePushPromise(p)
+}
+
+// WritePing sends a PING frame.
+func (conn *Conn) WritePing(ack bool, data [8]byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WritePing(ack, data)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WritePing(ack, data)
+}
+
+// WriteGoAway sends a GOAWAY frame.
+func (conn *Conn) WriteGoAway(maxStreamID uint32, code http2.ErrCode, debugData []byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteGoAway(maxStreamID, code, debugData)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteGoAway(maxStreamID, code, debugData)
+}
+
+// WriteWindowUpdate sends a WINDOW_UPDATE frame.
+func (conn *Conn) WriteWindowUpdate(streamID, incr uint32) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteWindowUpdate(streamID, incr)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteWindowUpdate(streamID, incr)
+}
+
+// WriteContinuation sends a CONTINUATION frame.
+func (conn *Conn) WriteContinuation(streamID uint32, endHeaders bool, headerBlockFragment []byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteContinuation(streamID, endHeaders, headerBlockFragment)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteContinuation(streamID, endHeaders, headerBlockFragment)
+}
+
+func (conn *Conn) WriteRawFrame(t http2.FrameType, flags http2.Flags, streamID uint32, payload []byte) error {
+	if conn.Verbose {
+		conn.debugFramer.WriteRawFrame(t, flags, streamID, payload)
+		conn.logFrameSend()
+	}
+
+	return conn.framer.WriteRawFrame(t, flags, streamID, payload)
+}
+
+func (conn *Conn) WriteSuccessResponse(streamID uint32, c *config.Config) {
+	hp := http2.HeadersFrameParam{
+		StreamID:      streamID,
+		EndStream:     false,
+		EndHeaders:    true,
+		BlockFragment: conn.EncodeHeaders(CommonRespHeaders(c)),
+	}
+	conn.WriteHeaders(hp)
+	conn.WriteData(streamID, true, []byte("success"))
+}
+
+// WaitEvent returns a event occured on connection. This function is
+// used to wait the next event on the connection.
+func (conn *Conn) WaitEvent() Event {
+	var ev Event
+
+	rd := time.Now().Add(conn.Timeout)
+	conn.SetReadDeadline(rd)
+
+	f, err := conn.framer.ReadFrame()
+	if err != nil {
+		conn.Closed = true
+
+		if err == io.EOF {
+			ev = ConnectionClosedEvent{}
+			conn.vlog(ev, false)
+			return ev
+		}
+
+		opErr, ok := err.(*net.OpError)
+		if ok {
+			if opErr.Err == syscall.ECONNRESET {
+				ev = ConnectionClosedEvent{}
+				conn.vlog(ev, false)
+				return ev
+			}
+
+			if runtime.GOOS == "windows" {
+				scErr, ok := opErr.Err.(*os.SyscallError)
+				if ok {
+					const WSAECONNABORTED = 10053
+					const WSAECONNRESET = 10054
+
+					rv := reflect.ValueOf(scErr.Err)
+					if rv.Kind() == reflect.Uintptr {
+						n := uintptr(rv.Uint())
+						if n == WSAECONNRESET || n == WSAECONNABORTED {
+							ev = ConnectionClosedEvent{}
+							conn.vlog(ev, false)
+							return ev
+						}
+					}
+				}
+			}
+
+			if opErr.Timeout() {
+				ev = TimeoutEvent{}
+				conn.vlog(ev, false)
+				return ev
+			}
+		}
+
+		ev = ErrorEvent{err}
+		conn.vlog(ev, false)
+		return ev
+	}
+
+	_, ok := f.(*http2.DataFrame)
+	if ok {
+		conn.updateWindowSize(f)
+	}
+
+	ev = getEventByFrame(f)
+	conn.vlog(ev, false)
+
+	return ev
+}
+
+// WaitEventByType returns a specified event occured on connection.
+// This function is used to wait the next event that has specified
+// type on the connection.
+func (conn *Conn) WaitEventByType(evt EventType) (Event, bool) {
+	var lastEvent Event
+
+	for !conn.Closed {
+		ev := conn.WaitEvent()
+
+		if ev.Type() == evt {
+			return ev, true
+		}
+
+		if ev.Type() == EventTimeout && lastEvent != nil {
+			break
+		}
+
+		lastEvent = ev
+	}
+
+	return lastEvent, false
+}
+
+type Request struct {
+	StreamID uint32
+	Headers  []hpack.HeaderField
+}
+
+func (conn *Conn) ReadRequest() (*Request, error) {
+	headers := make([]hpack.HeaderField, 0, 256)
+	conn.decoder.SetEmitFunc(func(f hpack.HeaderField) {
+		headers = append(headers, f)
+	})
+
+	done := false
+	streamID := uint32(0)
+
+	for !done {
+		f, ok := conn.WaitEventByType(EventHeadersFrame)
+		if !ok {
+			return nil, errors.New("No HEADER frame received")
+		}
+
+		hf, _ := f.(HeadersFrameEvent)
+
+		if streamID == uint32(0) {
+			streamID = hf.Header().StreamID
+		} else if streamID != hf.Header().StreamID {
+			return nil, errors.New("Encountered different StreamID")
+		}
+
+		_, err := conn.decoder.Write(hf.HeaderBlockFragment())
+		if err != nil {
+			return nil, err
+		}
+
+		done = hf.HeadersEnded()
+	}
+
+	request := &Request{
+		StreamID: streamID,
+		Headers:  headers,
+	}
+	return request, nil
+}
+
+// updateWindowSize calculates the current window size based on the
+// information in the given HTTP/2 frame.
+func (conn *Conn) updateWindowSize(f http2.Frame) {
+	if !conn.WindowUpdate {
+		return
+	}
+
+	len := int(f.Header().Length)
+	streamID := f.Header().StreamID
+
+	_, ok := conn.WindowSize[streamID]
+	if !ok {
+		conn.WindowSize[streamID] = DefaultWindowSize
+	}
+
+	conn.WindowSize[streamID] -= len
+	if conn.WindowSize[streamID] <= 0 {
+		incr := DefaultWindowSize + (conn.WindowSize[streamID] * -1)
+		conn.WriteWindowUpdate(streamID, uint32(incr))
+		conn.WindowSize[streamID] += incr
+	}
+
+	conn.WindowSize[0] -= len
+	if conn.WindowSize[0] <= 0 {
+		incr := DefaultWindowSize + (conn.WindowSize[0] * -1)
+		conn.WriteWindowUpdate(0, uint32(incr))
+		conn.WindowSize[0] += incr
+	}
+}
+
+// logFrameSend writes a log of the frame to be sent.
+func (conn *Conn) logFrameSend() {
+	f, err := conn.debugFramer.ReadFrame()
+	if err != nil {
+		// http2 package does not parse DATA frame with stream ID: 0x0.
+		// So we are going to log the information that sent some frame.
+		if conn.Verbose {
+			log.Println(gray(fmt.Sprintf("     [send] ??? Frame (Failed to parse the frame)")))
+		}
+		return
+	}
+
+	ev := getEventByFrame(f)
+	conn.vlog(ev, true)
+}
+
+// vlog writes a verbose log.
+func (conn *Conn) vlog(ev Event, send bool) {
+	if !conn.Verbose {
+		return
+	}
+
+	if send {
+		log.Println(gray(fmt.Sprintf("     [send] %s", ev)))
+	} else {
+		log.Println(gray(fmt.Sprintf("     [recv] %s", ev)))
+	}
+}
+
+// getEventByFrame returns an event based on given HTTP/2 frame.
+func getEventByFrame(f http2.Frame) Event {
+	var ev Event
+
+	switch f := f.(type) {
+	case *http2.DataFrame:
+		ev = DataFrameEvent{*f}
+	case *http2.HeadersFrame:
+		ev = HeadersFrameEvent{*f}
+	case *http2.PriorityFrame:
+		ev = PriorityFrameEvent{*f}
+	case *http2.RSTStreamFrame:
+		ev = RSTStreamFrameEvent{*f}
+	case *http2.SettingsFrame:
+		ev = SettingsFrameEvent{*f}
+	case *http2.PushPromiseFrame:
+		ev = PushPromiseFrameEvent{*f}
+	case *http2.PingFrame:
+		ev = PingFrameEvent{*f}
+	case *http2.GoAwayFrame:
+		ev = GoAwayFrameEvent{*f}
+	case *http2.WindowUpdateFrame:
+		ev = WindowUpdateFrameEvent{*f}
+	case *http2.ContinuationFrame:
+		ev = ContinuationFrameEvent{*f}
+		//default:
+		//	ev = EventUnknownFrame(f)
+	}
+
+	return ev
+}
+
+func (conn *Conn) handshakeAsClient() error {
+	done := make(chan error)
+
+	fmt.Fprintf(conn, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+
+	go func() {
+		local := false
+		remote := false
+
+		setting := http2.Setting{
+			ID:  http2.SettingInitialWindowSize,
+			Val: DefaultWindowSize,
+		}
+		conn.WriteSettings(setting)
+
+		for !(local && remote) {
+			f, err := conn.framer.ReadFrame()
+			if err != nil {
+				done <- err
+				return
+			}
+
+			ev := getEventByFrame(f)
+			conn.vlog(ev, false)
+
+			sf, ok := f.(*http2.SettingsFrame)
+			if !ok {
+				continue
+			}
+
+			if sf.IsAck() {
+				local = true
+			} else {
+				remote = true
+				sf.ForeachSetting(func(setting http2.Setting) error {
+					conn.Settings[setting.ID] = setting.Val
+					return nil
+				})
+				conn.WriteSettingsAck()
+			}
+		}
+
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+	case <-time.After(conn.Timeout):
+		return ErrTimeout
+	}
+
+	return nil
+}
+
+func (conn *Conn) handshakeAsServer() error {
+	done := make(chan error)
+
+	go func() {
+		_, err := conn.ReadClientPreface()
+		if err != nil {
+			done <- err
+			return
+		}
+
+		f, err := conn.framer.ReadFrame()
+		if err != nil {
+			done <- err
+			return
+		}
+
+		_, ok := f.(*http2.SettingsFrame)
+		if !ok {
+			done <- errors.New("First frame must be SETTINGS frame")
+			return
+		}
+
+		setting := http2.Setting{
+			ID:  http2.SettingInitialWindowSize,
+			Val: DefaultWindowSize,
+		}
+		conn.WriteSettings(setting)
+		conn.WriteSettingsAck()
+
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+	case <-time.After(conn.Timeout):
+		return ErrTimeout
+	}
+	return nil
+}
+
+func (conn *Conn) ReadClientPreface() (string, error) {
+	prefaceBytes, err := conn.readBytes(24)
+	if err != nil {
+		return "", err
+	}
+
+	preface := string(prefaceBytes[:])
+	if preface != "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" {
+		return "", errors.New("Illegal preface")
+	}
+	return preface, nil
+}
+
+func (conn *Conn) readBytes(size int) ([]byte, error) {
+	var remain = size
+	buffer := make([]byte, 0, size)
+
+	for remain > 0 {
+		tmp := make([]byte, remain)
+		n, err := conn.Read(tmp)
+		if err != nil {
+			return nil, err
+		}
+
+		buffer = append(buffer, tmp[:n]...)
+		remain = remain - n
+	}
+	return buffer, nil
+}

--- a/vendor/github.com/summerwind/h2spec/spec/event.go
+++ b/vendor/github.com/summerwind/h2spec/spec/event.go
@@ -1,0 +1,242 @@
+package spec
+
+import (
+	"fmt"
+	"math"
+
+	"golang.org/x/net/http2"
+)
+
+var (
+	DefaultLength  uint32        = math.MaxUint32
+	DefaultFlags   http2.Flags   = math.MaxUint8
+	DefaultErrCode http2.ErrCode = math.MaxUint8
+)
+
+type EventType uint8
+
+const (
+	EventDataFrame         EventType = 0x0
+	EventHeadersFrame      EventType = 0x1
+	EventPriorityFrame     EventType = 0x2
+	EventRSTStreamFrame    EventType = 0x3
+	EventSettingsFrame     EventType = 0x4
+	EventPushPromiseFrame  EventType = 0x5
+	EventPingFrame         EventType = 0x6
+	EventGoAwayFrame       EventType = 0x7
+	EventWindowUpdateFrame EventType = 0x8
+	EventContinuationFrame EventType = 0x9
+	EventRawData           EventType = 0x10
+	EventConnectionClosed  EventType = 0x11
+	EventError             EventType = 0x12
+	EventTimeout           EventType = 0x13
+)
+
+var eventName = map[EventType]string{
+	EventDataFrame:         "DATA frame",
+	EventHeadersFrame:      "HEADERS frame",
+	EventPriorityFrame:     "PRIORITY frame",
+	EventRSTStreamFrame:    "RST_STREAM frame",
+	EventSettingsFrame:     "SETTINGS frame",
+	EventPushPromiseFrame:  "PUSH_PROMISE frame",
+	EventPingFrame:         "PING frame",
+	EventGoAwayFrame:       "GOAWAY frame",
+	EventWindowUpdateFrame: "WINDOW_UPDATE frame",
+	EventContinuationFrame: "CONTINUATION frame",
+	EventRawData:           "Raw data",
+	EventConnectionClosed:  "Connection closed",
+	EventError:             "Error",
+	EventTimeout:           "Timeout",
+}
+
+func (et EventType) String() string {
+	s, ok := eventName[et]
+	if ok {
+		return s
+	}
+	return fmt.Sprintf("Unknown event (%d)", uint8(et))
+}
+
+type Event interface {
+	Type() EventType
+	String() string
+}
+
+type EventFrame interface {
+	String() string
+	Header() http2.FrameHeader
+}
+
+type ConnectionClosedEvent struct{}
+
+func (ev ConnectionClosedEvent) Type() EventType {
+	return EventConnectionClosed
+}
+
+func (ev ConnectionClosedEvent) String() string {
+	return "Connection closed"
+}
+
+type ErrorEvent struct {
+	Error error
+}
+
+func (ev ErrorEvent) Type() EventType {
+	return EventError
+}
+
+func (ev ErrorEvent) String() string {
+	return fmt.Sprintf("Error: %v", ev.Error)
+}
+
+type TimeoutEvent struct{}
+
+func (ev TimeoutEvent) Type() EventType {
+	return EventTimeout
+}
+
+func (ev TimeoutEvent) String() string {
+	return "Timeout"
+}
+
+type RawDataEvent struct {
+	Payload []byte
+}
+
+func (ev RawDataEvent) Type() EventType {
+	return EventRawData
+}
+
+func (ev RawDataEvent) String() string {
+	return fmt.Sprintf("Raw Data (0x%x)", ev.Payload)
+}
+
+type DataFrameEvent struct {
+	http2.DataFrame
+}
+
+func (ev DataFrameEvent) Type() EventType {
+	return EventDataFrame
+}
+
+func (ev DataFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type HeadersFrameEvent struct {
+	http2.HeadersFrame
+}
+
+func (ev HeadersFrameEvent) Type() EventType {
+	return EventHeadersFrame
+}
+
+func (ev HeadersFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type PriorityFrameEvent struct {
+	http2.PriorityFrame
+}
+
+func (ev PriorityFrameEvent) Type() EventType {
+	return EventPriorityFrame
+}
+
+func (ev PriorityFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type RSTStreamFrameEvent struct {
+	http2.RSTStreamFrame
+}
+
+func (ev RSTStreamFrameEvent) Type() EventType {
+	return EventRSTStreamFrame
+}
+
+func (ev RSTStreamFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type SettingsFrameEvent struct {
+	http2.SettingsFrame
+}
+
+func (ev SettingsFrameEvent) Type() EventType {
+	return EventSettingsFrame
+}
+
+func (ev SettingsFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type PushPromiseFrameEvent struct {
+	http2.PushPromiseFrame
+}
+
+func (ev PushPromiseFrameEvent) Type() EventType {
+	return EventPushPromiseFrame
+}
+
+func (ev PushPromiseFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type PingFrameEvent struct {
+	http2.PingFrame
+}
+
+func (ev PingFrameEvent) Type() EventType {
+	return EventPingFrame
+}
+
+func (ev PingFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type GoAwayFrameEvent struct {
+	http2.GoAwayFrame
+}
+
+func (ev GoAwayFrameEvent) Type() EventType {
+	return EventGoAwayFrame
+}
+
+func (ev GoAwayFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type WindowUpdateFrameEvent struct {
+	http2.WindowUpdateFrame
+}
+
+func (ev WindowUpdateFrameEvent) Type() EventType {
+	return EventWindowUpdateFrame
+}
+
+func (ev WindowUpdateFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+type ContinuationFrameEvent struct {
+	http2.ContinuationFrame
+}
+
+func (ev ContinuationFrameEvent) Type() EventType {
+	return EventContinuationFrame
+}
+
+func (ev ContinuationFrameEvent) String() string {
+	return frameString(ev.Header())
+}
+
+func frameString(header http2.FrameHeader) string {
+	return fmt.Sprintf(
+		"%s Frame (length:%d, flags:0x%02x, stream_id:%d)",
+		header.Type,
+		header.Length,
+		header.Flags,
+		header.StreamID,
+	)
+}

--- a/vendor/github.com/summerwind/h2spec/spec/server.go
+++ b/vendor/github.com/summerwind/h2spec/spec/server.go
@@ -1,0 +1,127 @@
+package spec
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/log"
+	"golang.org/x/net/http2"
+)
+
+type Server struct {
+	listeners []net.Listener
+	config    *config.Config
+	spec      *ClientTestGroup
+}
+
+func Listen(c *config.Config, tg *ClientTestGroup) (*Server, error) {
+	testCases := make(map[int]*ClientTestCase)
+	tg.ClientTestCases(testCases, c, c.FromPort)
+
+	server := &Server{
+		listeners: make([]net.Listener, 0),
+		config:    c,
+	}
+
+	for port, tc := range testCases {
+		var err error
+		var listener net.Listener
+
+		addr := fmt.Sprintf("%s:%d", c.Host, port)
+
+		if c.TLS {
+			tlsConfig, err := c.TLSConfig()
+			if err != nil {
+				return nil, err
+			}
+
+			listener, err = tls.Listen("tcp", addr, tlsConfig)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			listener, err = net.Listen("tcp", addr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		server.listeners = append(server.listeners, listener)
+		go server.RunListener(listener, tc)
+	}
+
+	return server, nil
+}
+
+func (server *Server) RunListener(listener net.Listener, tc *ClientTestCase) {
+	for {
+		baseConn, err := listener.Accept()
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		conn, err := Accept(server.config, baseConn)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		go server.handleConn(conn, tc)
+	}
+}
+
+func (server *Server) Close() {
+	for _, listener := range server.listeners {
+		listener.Close()
+	}
+}
+
+func (server *Server) handleConn(conn *Conn, tc *ClientTestCase) {
+	if server.config.IsBrowserMode() {
+		// Only log here when browser mode
+		log.Println(groupNames(tc.Parent))
+	}
+
+	start := time.Now()
+	err := tc.Run(server.config, conn)
+	end := time.Now()
+
+	// Ensure that connection had been closed
+	go closeConn(conn)
+
+	tr := NewClientTestResult(tc, err, end.Sub(start))
+
+	if server.config.IsBrowserMode() {
+		// Only log here when browser mode
+		tr.Print()
+	}
+
+	if tc.Result != nil {
+		tc.Parent.IncRecursive(tc.Result.Failed, tc.Result.Skipped, -1)
+	}
+
+	tc.Result = tr
+	tc.Parent.IncRecursive(tc.Result.Failed, tc.Result.Skipped, 1)
+	tc.Done <- true
+}
+
+func groupNames(tg *ClientTestGroup) string {
+	if tg.IsRoot() {
+		return tg.Title()
+	}
+	parentGroupNames := groupNames(tg.Parent)
+	return fmt.Sprintf("%s -> %s", parentGroupNames, tg.Title())
+}
+
+func closeConn(conn *Conn) {
+	if !conn.Closed {
+		conn.WriteGoAway(0, http2.ErrCodeNo, make([]byte, 0))
+		time.Sleep(1 * time.Second)
+	}
+
+	conn.Close()
+}

--- a/vendor/github.com/summerwind/h2spec/spec/spec.go
+++ b/vendor/github.com/summerwind/h2spec/spec/spec.go
@@ -1,0 +1,297 @@
+package spec
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/log"
+)
+
+var (
+	// ErrTimeout is used when the test times out.
+	ErrTimeout = errors.New("Timeout")
+	// ErrSkipped is used when the test skipped.
+	ErrSkipped = errors.New("Skipped")
+)
+
+// TestGroup represents a group of test case.
+type TestGroup struct {
+	Key         string
+	Section     string
+	Name        string
+	Strict      bool
+	Parent      *TestGroup
+	Groups      []*TestGroup
+	Tests       []*TestCase
+	StrictTests []*TestCase
+
+	PassedCount  int
+	FailedCount  int
+	SkippedCount int
+}
+
+// IsRoot returns bool as to whether it is the parent of all groups.
+func (tg *TestGroup) IsRoot() bool {
+	return tg.Parent == nil
+}
+
+// ID returns the unique ID of this group.
+func (tg *TestGroup) ID() string {
+	if tg.IsRoot() {
+		return tg.Key
+	}
+
+	return fmt.Sprintf("%s/%s", tg.Key, tg.Section)
+}
+
+// Title returns the title of this group.
+func (tg *TestGroup) Title() string {
+	if tg.IsRoot() {
+		return fmt.Sprintf("%s", tg.Name)
+	} else {
+		return fmt.Sprintf("%s. %s", tg.Section, tg.Name)
+	}
+}
+
+// Level returns a number. Level is determined by Key and the number
+// of "." included in Section.
+func (tg *TestGroup) Level() int {
+	if tg.IsRoot() {
+		return 0
+	}
+
+	return strings.Count(tg.Section, ".") + 1
+}
+
+// Test runs all the tests included in this group.
+func (tg *TestGroup) Test(c *config.Config) {
+	level := tg.Level()
+
+	if tg.Strict && !c.Strict {
+		return
+	}
+
+	mode := c.RunMode(tg.ID())
+	if mode == config.RunModeNone {
+		return
+	}
+
+	log.SetIndentLevel(level)
+	log.Println(tg.Title())
+	log.SetIndentLevel(level + 1)
+
+	tests := append(tg.Tests, tg.StrictTests...)
+	tested := false
+
+	for i, tc := range tests {
+		seq := i + 1
+
+		err := tc.Test(c, seq)
+		if err != nil {
+			fmt.Printf("\nError: %v\n", err)
+			os.Exit(1)
+		}
+
+		if tc.Result != nil {
+			if tc.Result.Failed {
+				tg.FailedCount += 1
+			} else if tc.Result.Skipped {
+				tg.SkippedCount += 1
+			} else {
+				tg.PassedCount += 1
+			}
+
+			tested = true
+		}
+	}
+
+	if tested {
+		log.PrintBlankLine()
+	}
+
+	for _, g := range tg.Groups {
+		g.Test(c)
+		tg.FailedCount += g.FailedCount
+		tg.SkippedCount += g.SkippedCount
+		tg.PassedCount += g.PassedCount
+	}
+}
+
+// AddTestGroup registers a group to this group.
+func (tg *TestGroup) AddTestGroup(stg *TestGroup) {
+	stg.Parent = tg
+	if tg.Strict {
+		stg.Strict = true
+	}
+	tg.Groups = append(tg.Groups, stg)
+}
+
+// AddTestCase registers a test to this group.
+func (tg *TestGroup) AddTestCase(tc *TestCase) {
+	tc.Parent = tg
+	if tg.Strict {
+		tc.Strict = true
+		tg.StrictTests = append(tg.StrictTests, tc)
+	} else {
+		tg.Tests = append(tg.Tests, tc)
+	}
+}
+
+// TestCase represents a test case.
+type TestCase struct {
+	Desc        string
+	Requirement string
+	Strict      bool
+	Parent      *TestGroup
+	Result      *TestResult
+	Run         func(c *config.Config, conn *Conn) error
+}
+
+// Test runs itself as a test case.
+func (tc *TestCase) Test(c *config.Config, seq int) error {
+	if tc.Strict && !c.Strict {
+		return nil
+	}
+
+	mode := c.RunMode(fmt.Sprintf("%s/%d", tc.Parent.ID(), seq))
+	if mode == config.RunModeNone {
+		return nil
+	}
+
+	if c.DryRun {
+		msg := fmt.Sprintf("%s %s", seqStr(seq), tc.Desc)
+		log.Println(msg)
+		tc.Result = NewTestResult(tc, seq, nil, time.Duration(0), nil)
+		return nil
+	}
+
+	if !c.Verbose {
+		msg := gray(fmt.Sprintf("  %s %s", seqStr(seq), tc.Desc))
+		log.Print(msg)
+	}
+
+	conn, err := Dial(c)
+	if err != nil {
+		msg := red(fmt.Sprintf("%s %s %s", "×", seqStr(seq), tc.Desc))
+		log.ResetLine()
+		log.Println(msg)
+		return err
+	}
+	defer conn.Close()
+
+	start := time.Now()
+	err = tc.Run(c, conn)
+	end := time.Now()
+
+	log.ResetLine()
+
+	tr := NewTestResult(tc, seq, err, end.Sub(start), conn.LocalAddr())
+	tr.Print()
+	tc.Result = tr
+
+	return nil
+}
+
+// TestError represents a error result of test case and implements
+// type error.
+type TestError struct {
+	Expected []string
+	Actual   string
+}
+
+// Error returns a string containing the reason of the error.
+func (e TestError) Error() string {
+	return fmt.Sprintf("%s\n%s", strings.Join(e.Expected, "\n"), e.Actual)
+}
+
+// TestResult represents a result of test case.
+type TestResult struct {
+	TestCase   *TestCase
+	Sequence   int
+	Error      error
+	Duration   time.Duration
+	SourceAddr net.Addr
+
+	Skipped bool
+	Failed  bool
+}
+
+// NewTestResult returns a TestResult.
+func NewTestResult(tc *TestCase, seq int, err error, d time.Duration, addr net.Addr) *TestResult {
+	skipped := false
+	failed := false
+
+	if err != nil {
+		if err == ErrSkipped {
+			skipped = true
+		} else {
+			failed = true
+		}
+	}
+
+	tr := TestResult{
+		TestCase:   tc,
+		Sequence:   seq,
+		Error:      err,
+		Duration:   d,
+		SourceAddr: addr,
+		Skipped:    skipped,
+		Failed:     failed,
+	}
+
+	return &tr
+}
+
+// Print prints the result of test case.
+func (tr *TestResult) Print() {
+	tc := tr.TestCase
+	desc := tc.Desc
+	seq := seqStr(tr.Sequence)
+
+	if tr.Skipped {
+		log.Println(cyan(fmt.Sprintf("%s %s", seq, desc)))
+		return
+	}
+
+	if !tr.Failed {
+		log.Println(fmt.Sprintf("%s %s %s", green("✔"), gray(seq), gray(desc)))
+		return
+	}
+
+	log.Println(red(fmt.Sprintf("using source address %s", tr.SourceAddr)))
+	log.Println(red(fmt.Sprintf("%s %s %s", "×", seq, desc)))
+	err, ok := tr.Error.(*TestError)
+	if ok {
+		level := log.IndentLevel
+		log.SetIndentLevel(level + 1)
+		defer func() {
+			log.SetIndentLevel(level)
+		}()
+
+		log.Println(red(fmt.Sprintf("-> %s", tc.Requirement)))
+		label := "Expected: "
+		for i, ex := range err.Expected {
+			if i != 0 {
+				label = strings.Repeat(" ", len(label))
+			}
+			log.Println(yellow(fmt.Sprintf("   %s%s", label, ex)))
+		}
+		log.Println(green(fmt.Sprintf("     Actual: %s", err.Actual)))
+
+		return
+	}
+	if err == nil {
+		log.Println(red(fmt.Sprintf("Error: %v", tr.Error.Error())))
+	} else {
+		log.Println(red(fmt.Sprintf("Error: %v", err)))
+	}
+}
+
+func seqStr(seq int) string {
+	return fmt.Sprintf("%d:", seq)
+}

--- a/vendor/github.com/summerwind/h2spec/spec/specd.go
+++ b/vendor/github.com/summerwind/h2spec/spec/specd.go
@@ -1,0 +1,268 @@
+package spec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/summerwind/h2spec/config"
+	"github.com/summerwind/h2spec/log"
+)
+
+// ClientTestGroup represents a group of test case.
+type ClientTestGroup struct {
+	Key     string
+	Section string
+	Name    string
+	Parent  *ClientTestGroup
+	Groups  []*ClientTestGroup
+	Tests   []*ClientTestCase
+
+	PassedCount  int
+	FailedCount  int
+	SkippedCount int
+}
+
+// IsRoot returns bool as to whether it is the parent of all groups.
+func (tg *ClientTestGroup) IsRoot() bool {
+	return tg.Parent == nil
+}
+
+// ID returns the unique ID of this group.
+func (tg *ClientTestGroup) ID() string {
+	if tg.IsRoot() {
+		return tg.Key
+	}
+
+	return fmt.Sprintf("%s/%s", tg.Key, tg.Section)
+}
+
+// Title returns the title of this group.
+func (tg *ClientTestGroup) Title() string {
+	if tg.IsRoot() {
+		return fmt.Sprintf("%s", tg.Name)
+	} else {
+		return fmt.Sprintf("%s. %s", tg.Section, tg.Name)
+	}
+}
+
+// Level returns a number. Level is determined by Key and the number
+// of "." included in Section.
+func (tg *ClientTestGroup) Level() int {
+	if tg.IsRoot() {
+		return 0
+	}
+
+	return strings.Count(tg.Section, ".") + 1
+}
+
+// Test runs all the tests included in this group.
+func (tg *ClientTestGroup) Test(c *config.Config) {
+	mode := c.RunMode(tg.ID())
+	if mode == config.RunModeNone {
+		return
+	}
+
+	level := tg.Level()
+
+	log.SetIndentLevel(level)
+	log.Println(tg.Title())
+	log.SetIndentLevel(level + 1)
+
+	for _, tc := range tg.Tests {
+		err := tc.Test(c)
+		if err != nil {
+			fmt.Printf("\nError: %v\n", err)
+			os.Exit(1)
+		}
+
+		if tc.Result == nil {
+			// No TestResult found, means the server cannot
+			// receive the first request
+			fmt.Println("\nError: the server didn't receive the request")
+			os.Exit(1)
+		}
+	}
+
+	for _, g := range tg.Groups {
+		g.Test(c)
+	}
+
+	log.PrintBlankLine()
+}
+
+// AddTestGroup registers a group to this group.
+func (tg *ClientTestGroup) AddTestGroup(stg *ClientTestGroup) {
+	stg.Parent = tg
+	tg.Groups = append(tg.Groups, stg)
+}
+
+// AddTestCase registers a test to this group.
+func (tg *ClientTestGroup) AddTestCase(tc *ClientTestCase) {
+	tc.Parent = tg
+	tc.Seq = len(tg.Tests) + 1
+	tg.Tests = append(tg.Tests, tc)
+}
+
+func (tg *ClientTestGroup) ClientTestCases(testCases map[int]*ClientTestCase, c *config.Config, currentPort int) int {
+	mode := c.RunMode(tg.ID())
+	if mode == config.RunModeNone {
+		return currentPort
+	}
+
+	for _, tc := range tg.Tests {
+		tc.Port = currentPort
+		testCases[currentPort] = tc
+		currentPort += 1
+	}
+
+	for _, g := range tg.Groups {
+		currentPort = g.ClientTestCases(testCases, c, currentPort)
+	}
+
+	return currentPort
+}
+
+func (tg *ClientTestGroup) IncRecursive(failed bool, skipped bool, inc int) {
+	if failed {
+		tg.FailedCount += inc
+	} else if skipped {
+		tg.SkippedCount += inc
+	} else {
+		tg.PassedCount += inc
+	}
+
+	if tg.Parent != nil {
+		tg.Parent.IncRecursive(failed, skipped, inc)
+	}
+}
+
+// ClientTestCase represents a test case.
+type ClientTestCase struct {
+	Seq         int
+	Desc        string
+	Requirement string
+	Parent      *ClientTestGroup
+	Result      *ClientTestResult
+	Run         func(c *config.Config, conn *Conn) error
+
+	Port int
+	Done chan bool
+}
+
+// Test runs itself as a test case.
+func (tc *ClientTestCase) Test(c *config.Config) error {
+	tc.Done = make(chan bool)
+	done := make(chan error)
+	go func() {
+		split := strings.Split(c.Exec, " ")
+
+		binary := split[0]
+		args := append(split[1:], tc.FullPath(c))
+
+		cmd := exec.Command(binary, args...)
+		if c.Verbose {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
+		err := cmd.Run()
+		<-tc.Done
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		// command failed with non-zero exit code is accept
+		if tc.Result != nil {
+			log.ResetLine()
+			tc.Result.Print()
+		}
+		return nil
+	case <-time.After(time.Duration(3) * time.Second):
+		return ErrTimeout
+	}
+}
+
+func (tc *ClientTestCase) FullPath(c *config.Config) string {
+	return fmt.Sprintf("%s://%s:%d/", c.Scheme(), c.Host, tc.Port)
+}
+
+// ClientTestResult represents a result of test case.
+type ClientTestResult struct {
+	ClientTestCase *ClientTestCase
+	Error          error
+	Duration       time.Duration
+
+	Skipped bool
+	Failed  bool
+}
+
+// NewClientTestResult returns a ClientTestResult.
+func NewClientTestResult(tc *ClientTestCase, err error, d time.Duration) *ClientTestResult {
+	skipped := false
+	failed := false
+
+	if err != nil {
+		if err == ErrSkipped {
+			skipped = true
+		} else {
+			failed = true
+		}
+	}
+
+	tr := ClientTestResult{
+		ClientTestCase: tc,
+		Error:          err,
+		Duration:       d,
+		Skipped:        skipped,
+		Failed:         failed,
+	}
+
+	return &tr
+}
+
+// Print prints the result of test case.
+func (tr *ClientTestResult) Print() {
+	tc := tr.ClientTestCase
+	desc := tc.Desc
+	seq := seqStr(tc.Seq)
+
+	if tr.Skipped {
+		log.Println(cyan(fmt.Sprintf("%s %s", seq, desc)))
+		return
+	}
+
+	if !tr.Failed {
+		log.Println(fmt.Sprintf("%s %s %s", green("✔"), gray(seq), gray(desc)))
+		return
+	}
+
+	log.Println(red(fmt.Sprintf("%s %s %s", "×", seq, desc)))
+	err, ok := tr.Error.(*TestError)
+	if ok {
+		level := log.IndentLevel
+		log.SetIndentLevel(level + 1)
+		defer func() {
+			log.SetIndentLevel(level)
+		}()
+
+		log.Println(red(fmt.Sprintf("-> %s", tc.Requirement)))
+		label := "Expected: "
+		for i, ex := range err.Expected {
+			if i != 0 {
+				label = strings.Repeat(" ", len(label))
+			}
+			log.Println(yellow(fmt.Sprintf("   %s%s", label, ex)))
+		}
+		log.Println(green(fmt.Sprintf("     Actual: %s", err.Actual)))
+
+		return
+	}
+	if err == nil {
+		log.Println(red(fmt.Sprintf("Error: %v", tr.Error.Error())))
+	} else {
+		log.Println(red(fmt.Sprintf("Error: %v", err)))
+	}
+}

--- a/vendor/github.com/summerwind/h2spec/spec/util.go
+++ b/vendor/github.com/summerwind/h2spec/spec/util.go
@@ -1,0 +1,158 @@
+package spec
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/summerwind/h2spec/config"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+var (
+	gray   = color.New(color.FgHiBlack).SprintFunc()
+	green  = color.New(color.FgGreen).SprintFunc()
+	red    = color.New(color.FgRed).SprintFunc()
+	yellow = color.New(color.FgYellow).SprintFunc()
+	cyan   = color.New(color.FgCyan).SprintFunc()
+)
+
+// DummyString returns a dummy string with specified length.
+func DummyString(len int) string {
+	var buffer bytes.Buffer
+	for i := 0; i < len; i++ {
+		buffer.WriteString("x")
+	}
+	return buffer.String()
+}
+
+// DummyBytes returns a array of byte with specified length.
+func DummyBytes(len int) []byte {
+	var buffer bytes.Buffer
+	for i := 0; i < len; i++ {
+		buffer.WriteString("x")
+	}
+	return buffer.Bytes()
+}
+
+// HeaderField returns a header field of HPACK with specified
+// name and value.
+func HeaderField(name, value string) hpack.HeaderField {
+	return hpack.HeaderField{Name: name, Value: value}
+}
+
+// CommonHeaders returns a array of header field of HPACK contained
+// common http headers used in various test case.
+func CommonHeaders(c *config.Config) []hpack.HeaderField {
+	var scheme, authority string
+	defaultPort := false
+
+	if c.TLS {
+		scheme = "https"
+		if c.Port == 443 {
+			defaultPort = true
+		}
+	} else {
+		scheme = "http"
+		if c.Port == 80 {
+			defaultPort = true
+		}
+	}
+
+	if defaultPort {
+		authority = c.Host
+	} else {
+		authority = c.Addr()
+	}
+
+	return []hpack.HeaderField{
+		HeaderField(":method", "GET"),
+		HeaderField(":scheme", scheme),
+		HeaderField(":path", c.Path),
+		HeaderField(":authority", authority),
+	}
+}
+
+// CommonRespHeaders returns a array of header field of HPACK contained
+// common http headers used in various test case.
+func CommonRespHeaders(c *config.Config) []hpack.HeaderField {
+	return []hpack.HeaderField{
+		HeaderField(":status", "200"),
+		HeaderField("access-control-allow-origin", "*"),
+	}
+}
+
+// DummyHeaders returns a array of header field of HPACK contained
+// dummy string values.
+func DummyHeaders(c *config.Config, len int) []hpack.HeaderField {
+	headers := make([]hpack.HeaderField, 0, len)
+	dummy := DummyString(c.MaxHeaderLen)
+
+	for i := 0; i < len; i++ {
+		name := fmt.Sprintf("x-dummy%d", i)
+		headers = append(headers, HeaderField(name, dummy))
+	}
+
+	return headers
+}
+
+func DummyRespHeaders(c *config.Config, len int) []hpack.HeaderField {
+	headers := make([]hpack.HeaderField, 0, len)
+	dummy := DummyString(c.MaxHeaderLen)
+
+	for i := 0; i < len; i++ {
+		name := fmt.Sprintf("x-dummy%d", i)
+		headers = append(headers, HeaderField(name, dummy))
+	}
+
+	return headers
+}
+
+// ServerDataLength returns the total length of the DATA frame of /.
+func ServerDataLength(c *config.Config) (int, error) {
+	conn, err := Dial(c)
+	if err != nil {
+		return 0, err
+	}
+
+	err = conn.Handshake()
+	if err != nil {
+		return 0, err
+	}
+
+	headers := CommonHeaders(c)
+	hp := http2.HeadersFrameParam{
+		StreamID:      1,
+		EndStream:     true,
+		EndHeaders:    true,
+		BlockFragment: conn.EncodeHeaders(headers),
+	}
+	conn.WriteHeaders(hp)
+
+	len := 0
+	done := false
+	for !conn.Closed {
+		ev := conn.WaitEvent()
+
+		switch event := ev.(type) {
+		case DataFrameEvent:
+			len += int(event.Header().Length)
+			done = event.StreamEnded()
+		case HeadersFrameEvent:
+			done = event.StreamEnded()
+		}
+
+		if done {
+			break
+		}
+	}
+
+	if !done {
+		return 0, errors.New("Unable to get server data length")
+	}
+
+	return len, nil
+}

--- a/vendor/github.com/summerwind/h2spec/spec/verifier.go
+++ b/vendor/github.com/summerwind/h2spec/spec/verifier.go
@@ -1,0 +1,360 @@
+package spec
+
+import (
+	"fmt"
+	"reflect"
+
+	"golang.org/x/net/http2"
+)
+
+const (
+	ExpectedConnectionClosed = "Connection closed"
+	ExpectedStreamClosed     = "Stream closed"
+	ExpectedGoAwayFrame      = "GOAWAY Frame (Error Code: %s)"
+	ExpectedRSTStreamFrame   = "RST_STREAM Frame (Error Code: %s)"
+)
+
+// VerifyConnectionClose verifies whether the connection was closed.
+func VerifyConnectionClose(conn *Conn) error {
+	var actual Event
+
+	passed := false
+	for !conn.Closed {
+		event := conn.WaitEvent()
+
+		switch ev := event.(type) {
+		case ConnectionClosedEvent:
+			passed = true
+		case TimeoutEvent:
+			if actual == nil {
+				actual = ev
+			}
+		default:
+			actual = ev
+		}
+
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		return &TestError{
+			Expected: []string{ExpectedConnectionClosed},
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyConnectionError verifies whether a connection error of HTTP/2
+// has occurred.
+func VerifyConnectionError(conn *Conn, codes ...http2.ErrCode) error {
+	var actual Event
+
+	passed := false
+	for !conn.Closed {
+		ev := conn.WaitEvent()
+
+		switch event := ev.(type) {
+		case ConnectionClosedEvent:
+			passed = true
+		case GoAwayFrameEvent:
+			passed = VerifyErrorCode(codes, event.ErrCode)
+		case TimeoutEvent:
+			if actual == nil {
+				actual = event
+			}
+		default:
+			actual = event
+		}
+
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		expected := []string{}
+		for _, code := range codes {
+			expected = append(expected, fmt.Sprintf(ExpectedGoAwayFrame, code))
+		}
+		expected = append(expected, ExpectedConnectionClosed)
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyStreamError verifies whether a stream error of HTTP/2
+// has occurred.
+func VerifyStreamError(conn *Conn, codes ...http2.ErrCode) error {
+	var actual Event
+
+	passed := false
+	for !conn.Closed {
+		ev := conn.WaitEvent()
+
+		switch event := ev.(type) {
+		case ConnectionClosedEvent:
+			passed = true
+		case GoAwayFrameEvent:
+			passed = VerifyErrorCode(codes, event.ErrCode)
+		case RSTStreamFrameEvent:
+			passed = VerifyErrorCode(codes, event.ErrCode)
+		case TimeoutEvent:
+			if actual == nil {
+				actual = event
+			}
+		default:
+			actual = event
+		}
+
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		expected := []string{}
+		for _, code := range codes {
+			expected = append(expected, fmt.Sprintf(ExpectedGoAwayFrame, code))
+			expected = append(expected, fmt.Sprintf(ExpectedRSTStreamFrame, code))
+		}
+		expected = append(expected, ExpectedConnectionClosed)
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyStreamClose verifies whether a stream close of HTTP/2
+// has occurred.
+func VerifyStreamClose(conn *Conn) error {
+	var actual Event
+
+	passed := false
+	for !conn.Closed {
+		ev := conn.WaitEvent()
+
+		switch event := ev.(type) {
+		case DataFrameEvent:
+			if event.StreamEnded() {
+				passed = true
+			}
+		case HeadersFrameEvent:
+			if event.StreamEnded() {
+				passed = true
+			}
+		case RSTStreamFrameEvent:
+			if event.ErrCode == http2.ErrCodeNo {
+				passed = true
+			}
+		case TimeoutEvent:
+			if actual == nil {
+				actual = event
+			}
+		default:
+			actual = event
+		}
+
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		return &TestError{
+			Expected: []string{ExpectedStreamClosed},
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyHeadersFrame verifies whether a HEADERS frame with specified
+// stream ID has received.
+func VerifyHeadersFrame(conn *Conn, streamID uint32) error {
+	actual, passed := conn.WaitEventByType(EventHeadersFrame)
+	switch event := actual.(type) {
+	case HeadersFrameEvent:
+		passed = (event.Header().StreamID == streamID)
+	default:
+		passed = false
+	}
+
+	if !passed {
+		expected := []string{
+			fmt.Sprintf("HEADERS Frame (stream_id:%d)", streamID),
+		}
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifySettingsFrameWithAck verifies whether a SETTINGS frame with
+// ACK flag has received.
+func VerifySettingsFrameWithAck(conn *Conn) error {
+	actual, passed := conn.WaitEventByType(EventSettingsFrame)
+	switch event := actual.(type) {
+	case SettingsFrameEvent:
+		passed = event.IsAck()
+	default:
+		passed = false
+	}
+
+	if !passed {
+		expected := []string{
+			"SETTINGS Frame (length:0, flags:0x01, stream_id:0)",
+		}
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyPingFrameWithAck verifies whether a PING frame with ACK flag
+// has received.
+func VerifyPingFrameWithAck(conn *Conn, data [8]byte) error {
+	actual, passed := conn.WaitEventByType(EventPingFrame)
+	switch event := actual.(type) {
+	case PingFrameEvent:
+		passed = event.IsAck() && reflect.DeepEqual(event.Data, data)
+	default:
+		passed = false
+	}
+
+	if !passed {
+		var actualStr string
+
+		expected := []string{
+			fmt.Sprintf("PING Frame (length:8, flags:0x01, stream_id:0, opaque_data:%s)", data),
+		}
+
+		f, ok := actual.(PingFrameEvent)
+		if ok {
+			header := f.Header()
+			actualStr = fmt.Sprintf(
+				"PING Frame ((length:%d, flags:0x%02x, stream_id:%d, opaque_data: %s)",
+				header.Length,
+				header.Flags,
+				header.StreamID,
+				f.Data,
+			)
+		} else {
+			actualStr = actual.String()
+		}
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actualStr,
+		}
+	}
+
+	return nil
+}
+
+// VerifyPingFrameOrConnectionClose verifies whether a PING frame with
+// ACK flag has received or the connection was closed.
+func VerifyPingFrameOrConnectionClose(conn *Conn, data [8]byte) error {
+	var actual Event
+
+	passed := false
+	for !conn.Closed {
+		event := conn.WaitEvent()
+
+		switch ev := event.(type) {
+		case ConnectionClosedEvent:
+			passed = true
+		case PingFrameEvent:
+			passed = ev.IsAck() && reflect.DeepEqual(ev.Data, data)
+		case TimeoutEvent:
+			if actual == nil {
+				actual = ev
+			}
+		default:
+			actual = ev
+		}
+
+		if passed {
+			break
+		}
+	}
+
+	if !passed {
+		var actualStr string
+
+		expected := []string{
+			ExpectedConnectionClosed,
+			fmt.Sprintf("PING Frame (length:8, flags:0x01, stream_id:0, opaque_data:%s)", data),
+		}
+
+		f, ok := actual.(PingFrameEvent)
+		if ok {
+			header := f.Header()
+			actualStr = fmt.Sprintf(
+				"PING Frame ((length:%d, flags:0x%02x, stream_id:%d, opaque_data: %s)",
+				header.Length,
+				header.Flags,
+				header.StreamID,
+				f.Data,
+			)
+		} else {
+			actualStr = actual.String()
+		}
+
+		return &TestError{
+			Expected: expected,
+			Actual:   actualStr,
+		}
+	}
+
+	return nil
+}
+
+// VerifyEventType verifies whether a frame with specified type
+// has received.
+func VerifyEventType(conn *Conn, et EventType) error {
+	var actual Event
+
+	actual, passed := conn.WaitEventByType(et)
+
+	if !passed {
+		return &TestError{
+			Expected: []string{et.String()},
+			Actual:   actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// VerifyErrorCode verifies whether the specified error code is
+// the expected error code.
+func VerifyErrorCode(codes []http2.ErrCode, code http2.ErrCode) bool {
+	for _, c := range codes {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -245,6 +245,17 @@ github.com/spf13/pflag
 # github.com/stretchr/testify v1.6.1
 ## explicit
 github.com/stretchr/testify/assert
+# github.com/summerwind/h2spec v0.0.0-20200804131034-70ac22940108
+## explicit
+github.com/summerwind/h2spec
+github.com/summerwind/h2spec/client
+github.com/summerwind/h2spec/config
+github.com/summerwind/h2spec/generic
+github.com/summerwind/h2spec/hpack
+github.com/summerwind/h2spec/http2
+github.com/summerwind/h2spec/log
+github.com/summerwind/h2spec/reporter
+github.com/summerwind/h2spec/spec
 # github.com/tcnksm/go-httpstat v0.2.1-0.20191008022543-e866bb274419
 ## explicit
 github.com/tcnksm/go-httpstat


### PR DESCRIPTION
Add h2spec subcommand.

h2spec is a "Conformance testing tool for HTTP/2 implementations" and is used by the origin tests.
