### PR TITLE
Bug 1946788: ingressclass: Don't set default annotation

### DIFF
--- a/pkg/operator/controller/ingressclass/ingressclass.go
+++ b/pkg/operator/controller/ingressclass/ingressclass.go
@@ -77,21 +77,27 @@ func desiredIngressClass(ingresscontrollerName string, ingressclasses []networki
 	// When creating an IngressClass for the "default" IngressController,
 	// annotate the IngressClass as the default IngressClass if no other
 	// IngressClass has the annotation.
-	if ingresscontrollerName == "default" {
-		const defaultAnnotation = "ingressclass.kubernetes.io/is-default-class"
-		someIngressClassIsDefault := false
-		for _, class := range ingressclasses {
-			if class.Annotations[defaultAnnotation] == "true" {
-				someIngressClassIsDefault = true
-				break
-			}
-		}
-		if !someIngressClassIsDefault {
-			class.ObjectMeta.Annotations = map[string]string{
-				defaultAnnotation: "true",
-			}
-		}
-	}
+	//
+	// TODO This is commented out because it breaks "[sig-network]
+	// IngressClass [Feature:Ingress] should not set default value if no
+	// default IngressClass"; we need to fix that test and then re-enable
+	// this logic.
+	//
+	// if ingresscontrollerName == "default" {
+	// 	const defaultAnnotation = "ingressclass.kubernetes.io/is-default-class"
+	// 	someIngressClassIsDefault := false
+	// 	for _, class := range ingressclasses {
+	// 		if class.Annotations[defaultAnnotation] == "true" {
+	// 			someIngressClassIsDefault = true
+	// 			break
+	// 		}
+	// 	}
+	// 	if !someIngressClassIsDefault {
+	// 		class.ObjectMeta.Annotations = map[string]string{
+	// 			defaultAnnotation: "true",
+	// 		}
+	// 	}
+	// }
 	return true, class
 }
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -176,15 +176,20 @@ func TestDefaultIngressClass(t *testing.T) {
 	if err := kclient.Get(context.TODO(), name, ingressclass); err != nil {
 		t.Errorf("failed to get ingressclass %q: %v", name, err)
 	}
-	const (
-		defaultAnnotation = "ingressclass.kubernetes.io/is-default-class"
-		expected          = "true"
-	)
-	if actual, ok := ingressclass.Annotations[defaultAnnotation]; !ok {
-		t.Fatalf("ingressclass %q has no %q annotation", name, defaultAnnotation)
-	} else if actual != expected {
-		t.Fatalf("expected %q annotation to have value %q, found %q", defaultAnnotation, expected, actual)
-	}
+	// TODO This is commented out because it breaks "[sig-network]
+	// IngressClass [Feature:Ingress] should not set default value if no
+	// default IngressClass"; we need to fix that test and then re-enable
+	// this one.
+	//
+	// const (
+	// 	defaultAnnotation = "ingressclass.kubernetes.io/is-default-class"
+	// 	expected          = "true"
+	// )
+	// if actual, ok := ingressclass.Annotations[defaultAnnotation]; !ok {
+	// 	t.Fatalf("ingressclass %q has no %q annotation", name, defaultAnnotation)
+	// } else if actual != expected {
+	// 	t.Fatalf("expected %q annotation to have value %q, found %q", defaultAnnotation, expected, actual)
+	// }
 }
 
 func TestUserDefinedIngressController(t *testing.T) {


### PR DESCRIPTION
Comment out the logic that sets marks the default ingresscontroller's ingressclass as the default ingressclass because it breaks the "[sig-network] IngressClass [Feature:Ingress] should not set default value if no default IngressClass" test.

* `pkg/operator/controller/ingressclass/ingressclass.go` `(`desiredIngressClass): Don't set default annotation.
* `test/e2e/operator_test.go` (`TestDefaultIngressClass`): Don't check for default annotation.