### PR TITLE
configurable_route_test: Preserve ingress spec

### DIFF
--- a/test/e2e/configurable_route_test.go
+++ b/test/e2e/configurable_route_test.go
@@ -30,6 +30,9 @@ const (
 // roles and roleBindings based on the componentRoutes defined in the ingress resource.
 func TestConfigurableRouteRBAC(t *testing.T) {
 	ingress := &configv1.Ingress{}
+	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
+		t.Fatalf("failed to get ingress resource: %v", err)
+	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
 			t.Fatalf("failed to get ingress resource: %v", err)
@@ -186,6 +189,9 @@ func TestConfigurableRouteRBAC(t *testing.T) {
 // for componentRoutes that include an empty servingCertKeyPairSecret name.
 func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 	ingress := &configv1.Ingress{}
+	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
+		t.Fatalf("failed to get ingress resource: %v", err)
+	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
 			t.Fatalf("failed to get ingress resource: %v", err)
@@ -282,6 +288,9 @@ func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 func TestConfigurableRouteNoConsumingUserNoRBAC(t *testing.T) {
 	// Get the cluster ingress resource.
 	ingress := &configv1.Ingress{}
+	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
+		t.Fatalf("failed to get ingress resource: %v", err)
+	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
 			t.Fatalf("failed to get ingress resource: %v", err)


### PR DESCRIPTION
When updating the `ingresses.config.openshift.io/cluster` object, get the current object before updating it so that we don't blank out fields that are already set.

* `test/e2e/configurable_route_test.go` (`TestConfigurableRouteRBAC`, `TestConfigurableRouteNoSecretNoRBAC`, `TestConfigurableRouteNoConsumingUserNoRBAC`): Get the ingress cluster config object before updating it.

---

This change is intended to resolve the following error condition from the authentication operator:

```
Operator degraded (APIServerDeployment_UnavailablePod::IngressConfig_Invalid::OAuthClientsController_SyncError::OAuthServerRouteEndpointAccessibleController_SyncError::RouterCerts_NoIngressDomain): APIServerDeploymentDegraded: 1 of 3 requested instances are unavailable for apiserver.openshift-oauth-apiserver (2 containers are waiting in pending apiserver-6f8fb57556-xbhgw pod)
IngressConfigDegraded: The ingress config domain cannot be empty
OAuthClientsControllerDegraded: the ingress config domain cannot be empty
OAuthServerRouteEndpointAccessibleControllerDegraded: ingress config domain cannot be empty
RouterCertsDegraded: ingresses.config.openshift.io/cluster: no spec.domain specified
```

@awgreene, could you make sure this change makes sense?  