### PR TITLE
Replace selflink with name, ns, and GVK in logs

### DIFF
--- a/pkg/operator/controller/certificate-publisher/controller.go
+++ b/pkg/operator/controller/certificate-publisher/controller.go
@@ -103,11 +103,11 @@ func (r *reconciler) secretToIngressController(o client.Object) []reconcile.Requ
 	requests := []reconcile.Request{}
 	controllers, err := r.ingressControllersWithSecret(o.GetName())
 	if err != nil {
-		log.Error(err, "failed to list ingresscontrollers for secret", "related", o.GetSelfLink())
+		log.Error(err, "failed to list ingresscontrollers", "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		return requests
 	}
 	for _, ic := range controllers {
-		log.Info("queueing ingresscontroller", "name", ic.Name, "related", o.GetSelfLink())
+		log.Info("queueing ingresscontroller", "name", ic.Name, "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: ic.Namespace,
@@ -134,7 +134,7 @@ func (r *reconciler) ingressControllersWithSecret(secretName string) ([]operator
 func (r *reconciler) secretIsInUse(meta metav1.Object) bool {
 	controllers, err := r.ingressControllersWithSecret(meta.GetName())
 	if err != nil {
-		log.Error(err, "failed to list ingresscontrollers for secret", "related", meta.GetSelfLink())
+		log.Error(err, "failed to list ingresscontrollers", "relatedName", meta.GetName(), "relatedNamespace", meta.GetNamespace(), "relatedGVK", corev1.SchemeGroupVersion.WithKind("Secret"))
 		return false
 	}
 	return len(controllers) > 0
@@ -150,7 +150,7 @@ func (r *reconciler) hasSecret(meta metav1.Object, o runtime.Object) bool {
 		if errors.IsNotFound(err) {
 			return false
 		}
-		log.Error(err, "failed to look up secret for ingresscontroller", "name", secretName, "related", meta.GetSelfLink())
+		log.Error(err, "failed to look up secret", "name", secretName, "relatedName", meta.GetName(), "relatedNamespace", meta.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 	}
 	return true
 }

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -431,11 +431,11 @@ func (r *reconciler) ToDNSRecords(o client.Object) []reconcile.Request {
 	var requests []reconcile.Request
 	records := &operatoringressv1.DNSRecordList{}
 	if err := r.cache.List(context.Background(), records, client.InNamespace(r.config.Namespace)); err != nil {
-		log.Error(err, "failed to list dnsrecords", "related", o.GetSelfLink())
+		log.Error(err, "failed to list dnsrecords", "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		return requests
 	}
 	for _, record := range records.Items {
-		log.Info("queueing dnsrecord", "name", record.Name, "related", o.GetSelfLink())
+		log.Info("queueing dnsrecord", "name", record.Name, "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: record.Namespace,

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -101,11 +101,11 @@ func (r *reconciler) ingressConfigToIngressController(o client.Object) []reconci
 	var requests []reconcile.Request
 	controllers := &operatorv1.IngressControllerList{}
 	if err := r.cache.List(context.Background(), controllers, client.InNamespace(r.config.Namespace)); err != nil {
-		log.Error(err, "failed to list ingresscontrollers for ingress", "related", o.GetSelfLink())
+		log.Error(err, "failed to list ingresscontrollers", "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		return requests
 	}
 	for _, ic := range controllers.Items {
-		log.Info("queueing ingresscontroller", "name", ic.Name, "related", o.GetSelfLink())
+		log.Info("queueing ingresscontroller", "name", ic.Name, "relatedName", o.GetName(), "relatedNamespace", o.GetNamespace(), "relatedGVK", o.GetObjectKind().GroupVersionKind())
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: ic.Namespace,
@@ -122,7 +122,7 @@ func enqueueRequestForOwningIngressController(namespace string) handler.EventHan
 		func(a client.Object) []reconcile.Request {
 			labels := a.GetLabels()
 			if ingressName, ok := labels[manifests.OwningIngressControllerLabel]; ok {
-				log.Info("queueing ingress", "name", ingressName, "related", a.GetSelfLink())
+				log.Info("queueing ingress", "name", ingressName, "relatedName", a.GetName(), "relatedNamespace", a.GetNamespace(), "relatedGVK", a.GetObjectKind().GroupVersionKind())
 				return []reconcile.Request{
 					{
 						NamespacedName: types.NamespacedName{


### PR DESCRIPTION
Change log messages that logged objects' selflinks instead to log name, namespace, and group-version-kind.

OpenShift 4.8 turns off selflinks in the API, with the result that these log messages had empty selflinks.

* `pkg/operator/controller/certificate-publisher/controller.go` (`secretToIngressController`, `secretIsInUse`, `hasSecret`):
* `pkg/operator/controller/dns/controller.go` (`ToDNSRecords`):
* `pkg/operator/controller/ingress/controller.go` (`ingressConfigToIngressController`, `enqueueRequestForOwningIngressController`): Replace selflink in log messages with name, namespace, and GVK.