### PR TITLE
Bug 1949435: ingressclass: Fix API group name in watch predicate

### DIFF
--- a/pkg/operator/controller/ingressclass/controller.go
+++ b/pkg/operator/controller/ingressclass/controller.go
@@ -63,7 +63,7 @@ func ingressClassHasIngressController(o client.Object) bool {
 	return class.Spec.Controller == routev1.IngressToRouteIngressClassControllerName &&
 		class.Spec.Parameters != nil &&
 		class.Spec.Parameters.APIGroup != nil &&
-		*class.Spec.Parameters.APIGroup == operatorv1.GroupVersion.String() &&
+		*class.Spec.Parameters.APIGroup == operatorv1.GroupName &&
 		class.Spec.Parameters.Kind == "IngressController"
 }
 


### PR DESCRIPTION
Use the correct group name in the predicate for the watch on ingressclasses in the ingressclass controller so that the controller reconciles events for ingressclasses that reference the ingress-to-route controller.

* `pkg/operator/controller/ingressclass/controller.go` (`ingressClassHasIngressController`): Use the correct string for the group name.
* `test/e2e/operator_test.go` (`TestDefaultIngressClass`): Verify that the ingressclass controller recreates the ingressclass should it be deleted.