### PR TITLE
Change status message to have a capital d in desired 

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -40,7 +40,7 @@ const (
 	CanaryImageVersionName       = "canary-server"
 	UnknownVersionValue          = "unknown"
 
-	ingressesEqualConditionMessage = "desired and current number of IngressControllers are equal"
+	ingressesEqualConditionMessage = "Desired and current number of IngressControllers are equal"
 
 	controllerName = "status_controller"
 )


### PR DESCRIPTION
Change status message to have a capital d in 'desired' to be consistent with other openshift operators 'ok' message. 

Looks better in my opinion, and as mentioned adds consistency in first char capitalization among operators status message.