### PR TITLE
Bug 1947498: policy v1 beta1 PodDisruptionBudget is deprecated

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -39,7 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -651,7 +651,7 @@ func TestPodDisruptionBudgetExists(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	pdb := &policyv1beta1.PodDisruptionBudget{}
+	pdb := &policyv1.PodDisruptionBudget{}
 	if err := kclient.Get(context.TODO(), controller.RouterPodDisruptionBudgetName(ic), pdb); err != nil {
 		t.Fatalf("failed to get default ingresscontroller poddisruptionbudget: %v", err)
 	}


### PR DESCRIPTION
Bring imports up to date with k8s 1.21 so that deprecation messages go away.

pkg/operator/controller/ingress/poddisruptionbudget.go
test/e2e/operator_test.go
