### PR TITLE
Bug 1901648: Canonical router hostname not correct

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -413,7 +413,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	})
 
 	if len(ci.Status.Domain) > 0 {
-		env = append(env, corev1.EnvVar{Name: "ROUTER_CANONICAL_HOSTNAME", Value: ci.Status.Domain})
+		env = append(env, corev1.EnvVar{Name: "ROUTER_CANONICAL_HOSTNAME", Value: "router-" + ci.Name + "." + ci.Status.Domain})
 	}
 
 	if proxyNeeded {

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -377,7 +377,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_H1_CASE_ADJUST", true, "Host,Cache-Control")
 
-	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CANONICAL_HOSTNAME", true, ci.Status.Domain)
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CANONICAL_HOSTNAME", true, "router-"+ci.Name+"."+ci.Status.Domain)
 
 	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOG_FACILITY", false, "")


### PR DESCRIPTION
BZ https://bugzilla.redhat.com/1901648

The following use case is fixed now by this fix:

1. Create Ingress with a custom domain
2. Ingress status gets updated by OpenShift Ingress controller with router canonical hostname
3. Use external-dns to sync with Route 53

The problem was the canonical router hostname didn't exist in the DNS. It is not created by OpenShift. OpenShift creates this *.apps.<cluster_name>.<base_domain> DNS record and not this one apps.<cluster_name>.<base_domain>. So canonical router hostname was not right. Now this fix sets it to router-default.apps.<cluster_name>.<base_domain>