### PR TITLE
NE-472:Add tlsv1.3 support

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -569,8 +569,7 @@ func validateTLSSecurityProfile(ic *operatorv1.IngressController) error {
 		if len(invalidCiphers) != 0 {
 			errs = append(errs, fmt.Errorf("security profile has invalid ciphers: %s", strings.Join(invalidCiphers, ", ")))
 		}
-		filteredCiphers := filterTLS13Ciphers(spec.Ciphers)
-		if len(filteredCiphers) == 0 {
+		if tlsVersion13Ciphers.HasAll(spec.Ciphers...) {
 			errs = append(errs, fmt.Errorf("security profile contains only tls v1.3 cipher suites"))
 		}
 	}
@@ -580,22 +579,6 @@ func validateTLSSecurityProfile(ic *operatorv1.IngressController) error {
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-// filterTLS13Ciphers filters any TLS v1.3 cipher suites from ciphers returning
-// a filtered list of cipher suites.
-func filterTLS13Ciphers(ciphers []string) []string {
-	filteredCiphers := []string{}
-	for i := 0; i < len(ciphers); i++ {
-		exist := false
-		if tlsVersion13Ciphers.Has(ciphers[i]) {
-			exist = true
-		}
-		if !exist {
-			filteredCiphers = append(filteredCiphers, ciphers[i])
-		}
-	}
-	return filteredCiphers
 }
 
 // validateHTTPHeaderBufferValues validates the given ingresscontroller's header buffer

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -51,15 +51,13 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 			valid:        true,
 			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
 		},
-		// TODO: Update test case to use Modern cipher suites when haproxy is
-		//  built with an openssl version that supports tls v1.3.
 		{
 			description: "modern",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileModernType,
 			},
 			valid:        true,
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
 		},
 		{
 			description: "custom, nil profile",
@@ -274,29 +272,27 @@ func TestTLSProfileSpecForIngressController(t *testing.T) {
 			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
 			expectedSpec: &configv1.TLSProfileSpec{},
 		},
-		// TODO: Update test cases to use Modern cipher suites when haproxy is
-		//  built with an openssl version that supports tls v1.3.
 		{
-			description:  "modern, nil -> intermediate",
+			description:  "modern, nil -> modern",
 			icProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
 		},
 		{
 			description:  "nil, modern -> intermediate",
 			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
 		},
 		{
 			description:  "modern, empty -> intermediate",
 			icProfile:    &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
 			apiProfile:   &configv1.TLSSecurityProfile{},
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
 		},
 		{
 			description:  "empty, modern -> intermediate",
 			icProfile:    &configv1.TLSSecurityProfile{},
 			apiProfile:   &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
-			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+			expectedSpec: configv1.TLSProfiles[configv1.TLSProfileModernType],
 		},
 	}
 

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -606,8 +606,24 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 
 	tlsProfileSpec := tlsProfileSpecForIngressController(ci, apiConfig)
 
-	ciphers := strings.Join(tlsProfileSpec.Ciphers, ":")
-	env = append(env, corev1.EnvVar{Name: "ROUTER_CIPHERS", Value: ciphers})
+	var tls13Ciphers, otherCiphers []string
+	for _, cipher := range tlsProfileSpec.Ciphers {
+		if tlsVersion13Ciphers.Has(cipher) {
+			tls13Ciphers = append(tls13Ciphers, cipher)
+		} else {
+			otherCiphers = append(otherCiphers, cipher)
+		}
+	}
+	env = append(env, corev1.EnvVar{
+		Name:  "ROUTER_CIPHERS",
+		Value: strings.Join(otherCiphers, ":"),
+	})
+	if len(tls13Ciphers) != 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  "ROUTER_CIPHERSUITES",
+			Value: strings.Join(tls13Ciphers, ":"),
+		})
+	}
 
 	var minTLSVersion string
 	switch tlsProfileSpec.MinTLSVersion {
@@ -618,8 +634,8 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		minTLSVersion = "TLSv1.1"
 	case configv1.VersionTLS12:
 		minTLSVersion = "TLSv1.2"
-	// TODO: Add TLS 1.3 support when haproxy is built with an openssl
-	//  version that supports tls v1.3.
+	case configv1.VersionTLS13:
+		minTLSVersion = "TLSv1.3"
 	default:
 		minTLSVersion = "TLSv1.2"
 	}
@@ -819,12 +835,15 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 
 	var (
 		ciphersString       string
+		cipherSuitesString  string
 		minTLSVersionString string
 	)
 	for _, v := range env {
 		switch v.Name {
 		case "ROUTER_CIPHERS":
 			ciphersString = v.Value
+		case "ROUTER_CIPHERSUITES":
+			cipherSuitesString = v.Value
 		case "SSL_MIN_VERSION":
 			minTLSVersionString = v.Value
 		}
@@ -834,6 +853,9 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 	if len(ciphersString) > 0 {
 		ciphers = strings.Split(ciphersString, ":")
 	}
+	if len(cipherSuitesString) > 0 {
+		ciphers = append(ciphers, strings.Split(cipherSuitesString, ":")...)
+	}
 
 	var minTLSVersion configv1.TLSProtocolVersion
 	switch minTLSVersionString {
@@ -841,7 +863,8 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 		minTLSVersion = configv1.VersionTLS11
 	case "TLSv1.2":
 		minTLSVersion = configv1.VersionTLS12
-	// TODO: Add TLS 1.3 support when haproxy is built with openssl 1.1.1.
+	case "TLSv1.3":
+		minTLSVersion = configv1.VersionTLS13
 	default:
 		minTLSVersion = configv1.VersionTLS12
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -281,6 +281,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_REWRITE_SIZE", false, "")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "foo:bar:baz")
+	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_CIPHERSUITES")
 
 	checkDeploymentHasEnvVar(t, deployment, "SSL_MIN_VERSION", true, "TLSv1.1")
 
@@ -326,8 +327,12 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		Type: configv1.TLSProfileCustomType,
 		Custom: &configv1.CustomTLSProfile{
 			TLSProfileSpec: configv1.TLSProfileSpec{
-				Ciphers:       []string{"quux"},
-				MinTLSVersion: configv1.VersionTLS13,
+				Ciphers: []string{
+					"quux",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+				},
+				MinTLSVersion: configv1.VersionTLS12,
 			},
 		},
 	}
@@ -394,8 +399,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SET_FORWARDED_HEADERS", true, "append")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "quux")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERSUITES", true, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256")
 
-	// TODO: Update when haproxy is built with an openssl version that supports tls v1.3.
 	checkDeploymentHasEnvVar(t, deployment, "SSL_MIN_VERSION", true, "TLSv1.2")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_IP_V4_V6_MODE", true, "v4v6")
@@ -484,6 +489,19 @@ func TestDesiredRouterDeployment(t *testing.T) {
 			Format: "foo",
 		},
 	}
+	ci.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				Ciphers: []string{
+					"quux",
+					"TLS_AES_256_GCM_SHA384",
+					"TLS_CHACHA20_POLY1305_SHA256",
+				},
+				MinTLSVersion: configv1.VersionTLS13,
+			},
+		},
+	}
 	ci.Spec.NodePlacement = &operatorv1.NodePlacement{
 		NodeSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -565,6 +583,11 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_SET_FORWARDED_HEADERS", true, "never")
 
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERS", true, "quux")
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CIPHERSUITES", true, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256")
+
+	checkDeploymentHasEnvVar(t, deployment, "SSL_MIN_VERSION", true, "TLSv1.3")
+
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_IP_V4_V6_MODE", true, "v6")
 	checkDeploymentHasEnvVar(t, deployment, RouterDisableHTTP2EnvName, true, "true")
 
@@ -617,6 +640,56 @@ func TestInferTLSProfileSpecFromDeployment(t *testing.T) {
 			expected: &configv1.TLSProfileSpec{
 				Ciphers:       []string{"foo", "bar", "baz"},
 				MinTLSVersion: configv1.VersionTLS11,
+			},
+		},
+		{
+			description: "min TLS version 1.2",
+			containers: []corev1.Container{
+				{
+					Name: "router",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ROUTER_CIPHERS",
+							Value: "foo:bar:baz",
+						},
+						{
+							Name:  "SSL_MIN_VERSION",
+							Value: "TLSv1.2",
+						},
+					},
+				},
+				{
+					Name: "logs",
+				},
+			},
+			expected: &configv1.TLSProfileSpec{
+				Ciphers:       []string{"foo", "bar", "baz"},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+		{
+			description: "min TLS version 1.3",
+			containers: []corev1.Container{
+				{
+					Name: "router",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ROUTER_CIPHERS",
+							Value: "foo:bar:baz",
+						},
+						{
+							Name:  "SSL_MIN_VERSION",
+							Value: "TLSv1.3",
+						},
+					},
+				},
+				{
+					Name: "logs",
+				},
+			},
+			expected: &configv1.TLSProfileSpec{
+				Ciphers:       []string{"foo", "bar", "baz"},
+				MinTLSVersion: configv1.VersionTLS13,
 			},
 		},
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -926,7 +927,13 @@ func TestTLSSecurityProfile(t *testing.T) {
 		t.Fatalf("ingresscontroller status has no security profile")
 	}
 	intermediateProfileSpec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	if !reflect.DeepEqual(*ic.Status.TLSProfile, *intermediateProfileSpec) {
+
+	actualCiphers := ic.Status.TLSProfile.Ciphers
+	expectedCiphers := intermediateProfileSpec.Ciphers
+	sort.Strings(actualCiphers)
+	sort.Strings(expectedCiphers)
+
+	if !reflect.DeepEqual(actualCiphers, expectedCiphers) || !reflect.DeepEqual(intermediateProfileSpec.MinTLSVersion, ic.Status.TLSProfile.MinTLSVersion) {
 		expected, _ := yaml.Marshal(intermediateProfileSpec)
 		actual, _ := yaml.Marshal(*ic.Status.TLSProfile)
 		t.Fatalf("ingresscontroller status has unexpected security profile spec.\nexpected:\n%s\ngot:\n%s", expected, actual)


### PR DESCRIPTION
Delete filterTLS13Ciphers and simplify
Simplify the logic in validateTLSSecurityProfile so that filterTLS13Ciphers
is no longer needed, and delete the superfluous function definition.

* pkg/operator/controller/ingress/controller.go
(validateTLSSecurityProfile): Simplify TLSv1.3 ciphers check.
(filterTLS13Ciphers): Delete function.

Allow TLSv1.3 and the "Modern" TLS profile

OpenShift 4.6 is built using UBI 8, which has OpenSSL 1.1.1, which supports
TLSv1.3, so allow specifying spec.tlsSecurityProfile.type: Modern or
spec.tlsSecurityProfile.custom.minTLSVersion: VersionTLS13.

* pkg/operator/controller/ingress/controller.go
tlsProfileSpecForSecurityProfile): Allow use of the "Modern" profile.
(validTLSVersions): Add configv1.VersionTLS13.
(validateTLSSecurityProfile): Verify that some non-TLSv1.3 cipher is
specified if minTLSVersion is a version below TLSv1.3, and verify that some
TLSv1.3 cipher is specified if minTLSVersion is TLSv1.3.
* pkg/operator/controller/ingress/controller_test.go
(TestTLSProfileSpecForSecurityProfile)
(TestTLSProfileSpecForIngressController): Verify that the "Modern" profile
is used if it is specified.
* pkg/operator/controller/ingress/deployment.go (desiredRouterDeployment):
Allow TLSv1.3.  Set ROUTER_CIPHERS based on the non-TLSv1.3 ciphers in the
ingresscontroller's TLS profile, and set ROUTER_CIPHERSUITES based on the
TLSv1.3 ciphers.
(inferTLSProfileSpecFromDeployment): Allow TLSv1.3.
* pkg/operator/controller/ingress/deployment_test.go
(TestDesiredRouterDeployment): Verify that SSL_MIN_VERSION is set to
TLSv1.3 if TLSv1.3 was specified on the ingresscontroller.  Verify that
ROUTER_CIPHERSUITES is set if the TLS profile specifies any TLSv1.3
ciphers, and verify that ROUTER_CIPHERSUITES has TLSv1.3 ciphers and
ROUTER_CIPHERS has other ciphers.
(TestInferTLSProfileSpecFromDeployment): Add test cases for
SSL_MIN_VERSION=TLSv1.2 and for SSL_MIN_VERSION=TLSv1.3.