### PR TITLE
Add unsupported config override for reload interval

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -59,6 +59,8 @@ const (
 
 	RouterLoadBalancingAlgorithmEnvName = "ROUTER_LOAD_BALANCE_ALGORITHM"
 
+	RouterReloadIntervalEnvName = "RELOAD_INTERVAL"
+
 	RouterDisableHTTP2EnvName          = "ROUTER_DISABLE_HTTP2"
 	RouterDefaultEnableHTTP2Annotation = "ingress.operator.openshift.io/default-enable-http2"
 
@@ -443,6 +445,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	var unsupportedConfigOverrides struct {
 		LoadBalancingAlgorithm string `json:"loadBalancingAlgorithm"`
 		DynamicConfigManager   string `json:"dynamicConfigManager"`
+		ReloadInterval         int32  `json:"reloadInterval"`
 	}
 	if len(ci.Spec.UnsupportedConfigOverrides.Raw) > 0 {
 		if err := json.Unmarshal(ci.Spec.UnsupportedConfigOverrides.Raw, &unsupportedConfigOverrides); err != nil {
@@ -458,6 +461,14 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	env = append(env, corev1.EnvVar{
 		Name:  RouterLoadBalancingAlgorithmEnvName,
 		Value: loadBalancingAlgorithm,
+	})
+	reloadInterval := 5
+	if unsupportedConfigOverrides.ReloadInterval > 0 {
+		reloadInterval = int(unsupportedConfigOverrides.ReloadInterval)
+	}
+	env = append(env, corev1.EnvVar{
+		Name:  RouterReloadIntervalEnvName,
+		Value: strconv.Itoa(reloadInterval),
 	})
 
 	dynamicConfigOverride := unsupportedConfigOverrides.DynamicConfigManager

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -224,6 +224,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_503")
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_404")
 
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5")
+
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", false, "")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_CANONICAL_HOSTNAME", false, "")
@@ -356,7 +358,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	var expectedReplicas int32 = 8
 	ci.Spec.Replicas = &expectedReplicas
 	ci.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn","dynamicConfigManager":"false"}`),
+		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn","dynamicConfigManager":"false","reloadInterval":15}`),
 	}
 	ci.Spec.HttpErrorCodePages = configv1.ConfigMapNameReference{
 		Name: "my-custom-error-code-pages",
@@ -398,6 +400,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		//log.Info(fmt.Sprintf("deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name %v", deployment.Spec.Template.Spec.Containers[0]))
 		t.Error("router Deployment is missing error code pages volume mount")
 	}
+
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "15")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", true, "true")
 
@@ -469,6 +473,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_HAPROXY_CONFIG_MANAGER", true, "true")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOAD_BALANCE_ALGORITHM", true, "random")
+
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5")
 
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL")
 


### PR DESCRIPTION
* `pkg/operator/controller/ingress/deployment.go` (`RouterReloadIntervalEnvName`): New const.
(`desiredRouterDeployment`): Add unsupported config override for `RELOAD_INTERVAL`.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Verify the `desiredRouterDeployment` sets `RELOAD_INTERVAL` as expected.