### PR TITLE
Bug 1960284: Set the "local-with-fallback" service annotation

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -104,6 +105,12 @@ const (
 	// openstackInternalLBAnnotation is the annotation used on a service to specify an
 	// OpenStack load balancer as being internal.
 	openstackInternalLBAnnotation = "service.beta.kubernetes.io/openstack-internal-load-balancer"
+
+	// localWithFallbackAnnotation is the annotation used on a service that
+	// has "Local" external traffic policy to indicate that the service
+	// proxy should prefer using a local endpoint but forward traffic to any
+	// available endpoint if no local endpoint is available.
+	localWithFallbackAnnotation = "traffic-policy.network.alpha.openshift.io/local-with-fallback"
 )
 
 var (
@@ -298,6 +305,10 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 		}
 		// Azure load balancers are not customizable and are set to (2 fail @ 5s interval, 2 healthy)
 		// GCP load balancers are not customizable and are set to (3 fail @ 8s interval, 1 healthy)
+
+		if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+			service.Annotations[localWithFallbackAnnotation] = ""
+		}
 	}
 
 	service.SetOwnerReferences([]metav1.OwnerReference{deploymentRef})
@@ -394,14 +405,31 @@ func (r *reconciler) updateLoadBalancerService(current, desired *corev1.Service,
 	return true, nil
 }
 
+// managedLoadBalancerServiceAnnotations is a set of annotation keys for
+// annotations that the operator manages for LoadBalancer-type services.
+var managedLoadBalancerServiceAnnotations = sets.NewString(
+	awsLBHealthCheckIntervalAnnotation,
+	GCPGlobalAccessAnnotation,
+	localWithFallbackAnnotation,
+)
+
 // loadBalancerServiceChanged checks if the current load balancer service
 // matches the expected and if not returns an updated one.
 func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev1.Service) {
-	updated := current.DeepCopy()
-	changed := false
+	annotationCmpOpts := []cmp.Option{
+		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
+			return !managedLoadBalancerServiceAnnotations.Has(k)
+		}),
+	}
+	if cmp.Equal(current.Annotations, expected.Annotations, annotationCmpOpts...) {
+		return false, nil
+	}
 
-	// Preserve everything but the AWS LB health check interval annotation &
-	// GCP Global Access internal Load Balancer annotation.
+	updated := current.DeepCopy()
+
+	// Preserve everything but the AWS LB health check interval annotation,
+	// GCP Global Access internal Load Balancer annotation, and
+	// local-with-fallback annotation
 	// (see <https://bugzilla.redhat.com/show_bug.cgi?id=1908758>).
 	// Updating annotations and spec fields cannot be done unless the
 	// previous release blocks upgrades when the user has modified those
@@ -409,18 +437,15 @@ func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev
 	if updated.Annotations == nil {
 		updated.Annotations = map[string]string{}
 	}
-	if current.Annotations[awsLBHealthCheckIntervalAnnotation] != expected.Annotations[awsLBHealthCheckIntervalAnnotation] {
-		updated.Annotations[awsLBHealthCheckIntervalAnnotation] = expected.Annotations[awsLBHealthCheckIntervalAnnotation]
-		changed = true
-	}
 
-	if current.Annotations[GCPGlobalAccessAnnotation] != expected.Annotations[GCPGlobalAccessAnnotation] {
-		updated.Annotations[GCPGlobalAccessAnnotation] = expected.Annotations[GCPGlobalAccessAnnotation]
-		changed = true
-	}
-
-	if !changed {
-		return false, nil
+	for annotation := range managedLoadBalancerServiceAnnotations {
+		currentVal, have := current.Annotations[annotation]
+		expectedVal, want := expected.Annotations[annotation]
+		if want && (!have || currentVal != expectedVal) {
+			updated.Annotations[annotation] = expected.Annotations[annotation]
+		} else if have && !want {
+			delete(updated.Annotations, annotation)
+		}
 	}
 
 	return true, updated

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -132,8 +132,10 @@ func TestDesiredNodePortService(t *testing.T) {
 				},
 			},
 		}
-		want, svc := desiredNodePortService(ic, deploymentRef, tc.wantMetricsPort)
-		if want != tc.expect {
+		want, svc, err := desiredNodePortService(ic, deploymentRef, tc.wantMetricsPort)
+		if err != nil {
+			t.Errorf("unexpected error from desiredNodePortService: %w", err)
+		} else if want != tc.expect {
 			t.Errorf("expected desiredNodePortService to return %t for endpoint publishing strategy type %v, got %t, with service %#v", tc.expect, tc.strategyType, want, svc)
 		} else if tc.expect && !reflect.DeepEqual(svc, &tc.expectService) {
 			t.Errorf("expected desiredNodePortService to return %#v, got %#v", &tc.expectService, svc)

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -37,6 +37,9 @@ func TestDesiredNodePortService(t *testing.T) {
 			expect:       true,
 			expectService: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						localWithFallbackAnnotation: "",
+					},
 					Namespace: "openshift-ingress",
 					Name:      "router-nodeport-default",
 					Labels: map[string]string{
@@ -75,6 +78,9 @@ func TestDesiredNodePortService(t *testing.T) {
 			expect:          true,
 			expectService: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						localWithFallbackAnnotation: "",
+					},
 					Namespace: "openshift-ingress",
 					Name:      "router-nodeport-default",
 					Labels: map[string]string{
@@ -176,6 +182,20 @@ func TestNodePortServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the local-with-fallback annotation changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Annotations["traffic-policy.network.alpha.openshift.io/local-with-fallback"] = "x"
+			},
+			expect: true,
+		},
+		{
+			description: "if the local-with-fallback annotation is deleted",
+			mutate: func(svc *corev1.Service) {
+				delete(svc.Annotations, "traffic-policy.network.alpha.openshift.io/local-with-fallback")
+			},
+			expect: true,
+		},
+		{
 			description: "if .spec.healthCheckNodePort changes",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.HealthCheckNodePort = int32(34566)
@@ -236,6 +256,9 @@ func TestNodePortServiceChanged(t *testing.T) {
 	for _, tc := range testCases {
 		original := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"traffic-policy.network.alpha.openshift.io/local-with-fallback": "",
+				},
 				Namespace: "openshift-ingress",
 				Name:      "router-original",
 				UID:       "1",


### PR DESCRIPTION
#### Set the "local-with-fallback" service annotation

Set the `traffic-policy.network.alpha.openshift.io/local-with-fallback` annotation on LoadBalancer- and NodePort-type services that use the `Local` external traffic policy.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`localWithFallbackAnnotation`): New const.  Define the annotation key for the `local-with-fallback` service annotation.
(`desiredLoadBalancerService`): Set the `local-with-fallback` annotation when using the `Local` external traffic policy.
(`managedLoadBalancerServiceAnnotations`): New variable.  Define the keys for annotations that the operator manages on LoadBalancer-type services, which now include the `local-with-fallback` annotation.
(`loadBalancerServiceChanged`): Fix the update logic to properly handle annotations with empty values using go-cmp and `managedLoadBalancerServiceAnnotations`.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestDesiredLoadBalancerService`): Verify that the `local-with-fallback` annotation is set when appropriate.
(`TestLoadBalancerServiceChanged`): Verify that `loadBalancerServiceChanged` properly handles updates to the `local-with-fallback` annotation.
* `pkg/operator/controller/ingress/nodeport_service.go` (`desiredNodePortService`): Set the `local-with-fallback` annotation.
(`managedNodePortServiceAnnotations`): New variable.  Define the annotation keys that the operator manages on NodePort-type services.
(`nodePortServiceChanged`): Check if any of the annotations in `managedNodePortServiceAnnotations` have changed.  Update managed annotations if they have changed.
* `pkg/operator/controller/ingress/nodeport_service_test.go` (`TestDesiredNodePortService`): Verify that the expected annotations are set.
(`TestNodePortServiceChanged`): Add a test case to verify that `nodePortServiceChanged` properly handles updates to the `local-with-fallback` annotation.


#### Add local-with-fallback unsupported config override

* `pkg/operator/controller/ingress/load_balancer_service.go` (`desiredLoadBalancerService`): Use the new `shouldUseLocalWithFallback`function to determine whether to set the `local-with-fallback` annotation.
(`shouldUseLocalWithFallback`): New function.  Check the service's external traffic policy and the ingresscontroller's unsupported config overrides and return a Boolean value indicating whether `local-with-fallback` should be enabled, or an error if the override could not be parsed.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestShouldUseLocalWithFallback`): New test.  Verify that `shouldUseLocalWithFallback` behaves as expected.
* `pkg/operator/controller/ingress/nodeport_service.go` (`ensureNodePortService`): Check the error value from `desiredNodePortService`.
(`desiredNodePortService`): Add error return value.  Use the new `shouldUseLocalWithFallback` function (which can return an error) to determine whether to set the `local-with-fallback` annotation.
* `pkg/operator/controller/ingress/nodeport_service_test.go` (`TestDesiredNodePortService`): Check the error value from `desiredNodePortService`.
* test/e2e/operator_test.go (`TestLocalWithFallbackOverrideForLoadBalancerService`, `TestLocalWithFallbackOverrideForNodePortService`): New tests.  Verify that the operator does not set the `local-with-fallback` annotation on a LoadBalancer or NodePort service if the `localWithFallback` unsupported config override is set to "false".
