### PR TITLE
[release-4.7] Bug 1973983: Canary: Handle downgrades from 4.8 to 4.7 properly

### DIFF
--- a/pkg/operator/controller/canary/daemonset.go
+++ b/pkg/operator/controller/canary/daemonset.go
@@ -104,11 +104,20 @@ func canaryDaemonSetChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 	changed := false
 	updated := current.DeepCopy()
 
-	// Update the canary daemonset when the canary server image changes
-	if len(current.Spec.Template.Spec.Containers) > 0 && len(expected.Spec.Template.Spec.Containers) > 0 &&
-		current.Spec.Template.Spec.Containers[0].Image != expected.Spec.Template.Spec.Containers[0].Image {
-		updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
-		changed = true
+	// Update the canary daemonset when the canary server image, command, or container name changes
+	if len(current.Spec.Template.Spec.Containers) > 0 && len(expected.Spec.Template.Spec.Containers) > 0 {
+		if current.Spec.Template.Spec.Containers[0].Image != expected.Spec.Template.Spec.Containers[0].Image {
+			updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
+			changed = true
+		}
+		if !cmp.Equal(current.Spec.Template.Spec.Containers[0].Command, expected.Spec.Template.Spec.Containers[0].Command) {
+			updated.Spec.Template.Spec.Containers[0].Command = expected.Spec.Template.Spec.Containers[0].Command
+			changed = true
+		}
+		if current.Spec.Template.Spec.Containers[0].Name != expected.Spec.Template.Spec.Containers[0].Name {
+			updated.Spec.Template.Spec.Containers[0].Name = expected.Spec.Template.Spec.Containers[0].Name
+			changed = true
+		}
 	}
 
 	if !cmp.Equal(current.Spec.Template.Spec.NodeSelector, expected.Spec.Template.Spec.NodeSelector, cmpopts.EquateEmpty()) {

--- a/pkg/operator/controller/canary/daemonset_test.go
+++ b/pkg/operator/controller/canary/daemonset_test.go
@@ -123,6 +123,27 @@ func TestCanaryDaemonsetChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if canary command changes (removed)",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].Command = []string{}
+			},
+			expect: true,
+		},
+		{
+			description: "if canary command changes",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].Command = []string{"foo"}
+			},
+			expect: true,
+		},
+		{
+			description: "if canary server container name changes",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].Name = "bar"
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Commit 8332af2 changed the Canary daemonset image and command values
in OCP 4.8.

Prior to commit 8332af2, the Canary's daemonset logic did not trigger
updates to the Canary daemonset when the `command` field was modified.

When downgrading from OCP 4.8 to OCP 4.7, the 4.7 Canary container
is fed a startup command intended for the 4.8 Canary image, which
results in Canary endpoints that don't actually send back the
expected response body.

This commit is a partial backport of commit 8332af2 in order
to remove unwanted daemonset `command` values available in OCP 4.8
that should not exist on the daemonset in OCP 4.7.

pkg/operator/controller/canary/daemonset.go:

Update the canary daemonset when the canary server, image, or container
name changes (e.g. handle downgrades from OCP 4.8 to OCP 4.7).

pkg/operator/controller/canary/daemonset_test.go:

Add crucial unit test coverage.

/assign @Miciah @candita 