### PR TITLE
WIP: Enable config manager

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -555,7 +555,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	}
 
 	dynamicConfigOverride := unsupportedConfigOverrides.DynamicConfigManager
-	if v, err := strconv.ParseBool(dynamicConfigOverride); err == nil && v {
+	if v, err := strconv.ParseBool(dynamicConfigOverride); err != nil || v {
 		env = append(env, corev1.EnvVar{
 			Name:  RouterHAProxyConfigManager,
 			Value: "true",

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -437,7 +437,7 @@ func Test_desiredRouterDeployment(t *testing.T) {
 		{"ROUTER_DEFAULT_CONNECT_TIMEOUT", false, ""},
 		{"ROUTER_ERRORFILE_503", false, ""},
 		{"ROUTER_ERRORFILE_404", false, ""},
-		{"ROUTER_HAPROXY_CONFIG_MANAGER", false, ""},
+		{"ROUTER_HAPROXY_CONFIG_MANAGER", true, "true"},
 		{"ROUTER_H1_CASE_ADJUST", false, ""},
 		{"ROUTER_INSPECT_DELAY", false, ""},
 		{"ROUTER_IP_V4_V6_MODE", false, ""},

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3283,6 +3283,9 @@ func TestUnsupportedConfigOverride(t *testing.T) {
 			icName := types.NamespacedName{Namespace: operatorNamespace, Name: tt.name}
 			domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 			ic := newPrivateController(icName, domain)
+			ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(`{"%s":"false"}`, tt.unsupportedConfigOverride)),
+			}
 			if err := kclient.Create(context.TODO(), ic); err != nil {
 				t.Fatalf("failed to create ingresscontroller: %v", err)
 			}


### PR DESCRIPTION
Enable the dynamic config manager.  This PR is only for testing.

See also https://github.com/openshift/cluster-ingress-operator/pull/628, which adds an unsupported config override to enable the config manager (turned off by default).