### PR TITLE
Add unsupported config override for maxconn

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -475,7 +475,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	}
 	env = append(env, corev1.EnvVar{
 		Name:  RouterReloadIntervalEnvName,
-		Value: strconv.Itoa(reloadInterval),
+		Value: fmt.Sprintf("%ds", reloadInterval),
 	})
 
 	dynamicConfigOverride := unsupportedConfigOverrides.DynamicConfigManager

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -224,7 +224,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_503")
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_404")
 
-	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5")
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5s")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", false, "")
 
@@ -401,7 +401,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		t.Error("router Deployment is missing error code pages volume mount")
 	}
 
-	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "15")
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "15s")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", true, "true")
 
@@ -474,7 +474,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOAD_BALANCE_ALGORITHM", true, "random")
 
-	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5")
+	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5s")
 
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL")
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -224,6 +224,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_503")
 	checkDeploymentDoesNotHaveEnvVar(t, deployment, "ROUTER_ERRORFILE_404")
 
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_CONNECTIONS", false, "")
+
 	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5s")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", false, "")
@@ -358,7 +360,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	var expectedReplicas int32 = 8
 	ci.Spec.Replicas = &expectedReplicas
 	ci.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn","dynamicConfigManager":"false","reloadInterval":15}`),
+		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn","dynamicConfigManager":"false","maxConnections":-1,"reloadInterval":15}`),
 	}
 	ci.Spec.HttpErrorCodePages = configv1.ConfigMapNameReference{
 		Name: "my-custom-error-code-pages",
@@ -401,6 +403,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		t.Error("router Deployment is missing error code pages volume mount")
 	}
 
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_CONNECTIONS", true, "auto")
+
 	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "15s")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_USE_PROXY_PROTOCOL", true, "true")
@@ -436,7 +440,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	// Any value for loadBalancingAlgorithm other than "leastconn" should be
 	// ignored.
 	ci.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"loadBalancingAlgorithm":"source","dynamicConfigManager":"true"}`),
+		Raw: []byte(`{"loadBalancingAlgorithm":"source","dynamicConfigManager":"true","maxConnections":40000}`),
 	}
 	ci.Status.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
 		Scope: operatorv1.ExternalLoadBalancer,
@@ -473,6 +477,8 @@ func TestDesiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_HAPROXY_CONFIG_MANAGER", true, "true")
 
 	checkDeploymentHasEnvVar(t, deployment, "ROUTER_LOAD_BALANCE_ALGORITHM", true, "random")
+
+	checkDeploymentHasEnvVar(t, deployment, "ROUTER_MAX_CONNECTIONS", true, "40000")
 
 	checkDeploymentHasEnvVar(t, deployment, "RELOAD_INTERVAL", true, "5s")
 

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -81,6 +82,9 @@ func TestCanaryRoute(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -27,6 +27,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -211,6 +212,9 @@ func TestClientTLS(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
 		}
 	}()

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -121,6 +122,9 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPodValidRequest); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
 		}
 	}()
@@ -250,6 +254,9 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPodInvalidRequest); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
 		}
 	}()

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -18,6 +18,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -108,6 +109,9 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2170,8 +2170,8 @@ func TestReloadIntervalUnsupportedConfigOverride(t *testing.T) {
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "RELOAD_INTERVAL", "5"); err != nil {
-		t.Fatalf("expected initial deployment to set RELOAD_INTERVAL=5: %v", err)
+	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "RELOAD_INTERVAL", "5s"); err != nil {
+		t.Fatalf("expected initial deployment to set RELOAD_INTERVAL=5s: %v", err)
 	}
 
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
@@ -2180,8 +2180,8 @@ func TestReloadIntervalUnsupportedConfigOverride(t *testing.T) {
 	if err := kclient.Update(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "RELOAD_INTERVAL", "60"); err != nil {
-		t.Fatalf("expected updated deployment to set RELOAD_INTERVAL=60: %v", err)
+	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "RELOAD_INTERVAL", "60s"); err != nil {
+		t.Fatalf("expected updated deployment to set RELOAD_INTERVAL=60s: %v", err)
 	}
 }
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -369,9 +369,6 @@ func TestProxyProtocolAPI(t *testing.T) {
 		t.Errorf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
 	deployment := &appsv1.Deployment{}
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
@@ -380,6 +377,9 @@ func TestProxyProtocolAPI(t *testing.T) {
 		t.Fatalf("expected initial deployment not to enable PROXY protocol: %v", err)
 	}
 
+	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller: %v", err)
+	}
 	ic.Spec.EndpointPublishingStrategy.NodePort = &operatorv1.NodePortStrategy{
 		Protocol: operatorv1.ProxyProtocol,
 	}
@@ -1961,9 +1961,6 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 		t.Errorf("failed to observe expected conditions: %w", err)
 	}
 
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
 	deployment := &appsv1.Deployment{}
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
@@ -1973,6 +1970,9 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("expected initial deployment to use the %q algorithm: %v", expectedAlgorithm, err)
 	}
 
+	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller: %v", err)
+	}
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
 		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn"}`),
 	}
@@ -2001,9 +2001,6 @@ func TestDynamicConfigManagerUnsupportedConfigOverride(t *testing.T) {
 		t.Errorf("failed to observe expected conditions: %w", err)
 	}
 
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
 	deployment := &appsv1.Deployment{}
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
@@ -2012,6 +2009,9 @@ func TestDynamicConfigManagerUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("expected initial deployment not to set ROUTER_HAPROXY_CONFIG_MANAGER=true: %v", err)
 	}
 
+	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller: %v", err)
+	}
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
 		Raw: []byte(`{"dynamicConfigManager":"true"}`),
 	}
@@ -2214,10 +2214,6 @@ func TestReloadIntervalUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
-
 	deployment := &appsv1.Deployment{}
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
@@ -2226,6 +2222,9 @@ func TestReloadIntervalUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("expected initial deployment to set RELOAD_INTERVAL=5s: %v", err)
 	}
 
+	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller: %v", err)
+	}
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
 		Raw: []byte(`{"reloadInterval":60}`),
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2422,7 +2422,7 @@ func waitForDeploymentComplete(t *testing.T, cl client.Client, deployment *appsv
 func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.Deployment, timeout time.Duration, name, value string) error {
 	t.Helper()
 	deploymentName := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}
-	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		deployment := &appsv1.Deployment{}
 		if err := kclient.Get(context.TODO(), deploymentName, deployment); err != nil {
 			t.Logf("error getting deployment %s/%s: %v", deploymentName.Namespace, deploymentName.Name, err)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1599,6 +1599,9 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
@@ -1736,6 +1739,9 @@ func TestHTTPCookieCapture(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if errors.IsNotFound(err) {
+				return
+			}
 			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
@@ -1901,6 +1907,9 @@ func TestUniqueIdHeader(t *testing.T) {
 		}
 		defer func() {
 			if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+				if errors.IsNotFound(err) {
+					return
+				}
 				t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 			}
 		}()


### PR DESCRIPTION
This PR bundles (in logically separate commits) a fix to the reload interval override, a small fix to the E2E tests, and a new unsupported config override for `ROUTER_MAX_CONNECTIONS`.

#### `waitForDeploymentComplete`: Actually use timeout arg

* `test/e2e/operator_test.go` (`waitForDeploymentEnvVar`): Use the provided timeout parameter instead of a hard-coded value of 1 minute.


#### Specify a time unit in `RELOAD_INTERVAL`

Specify a time unit suffix "s" for seconds in the value of the `RELOAD_INTERVAL` environment variable in router deployments.  Omitting the time unit causes the following warning:

    router "msg"="invalid interval, using default"  "default"=5 "interval"="5" "name"="RELOAD_INTERVAL"

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Add "s" time unit suffix to the reload interval.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`):
* `test/e2e/operator_test.go` (`TestReloadIntervalUnsupportedConfigOverride`): Expect the time unit suffix.


#### Add unsupported config override for `maxconn`

Add an unsupported config override for setting HAProxy's global `maxconn` setting.  If the config override is unspecified, the current default of 20000 is used.  If the config override has the value "-1", the `maxconn` setting is omitted so that HAProxy automatically detects a reasonable value based on the value of `ulimit -n`.

* `pkg/operator/controller/ingress/deployment.go` (`RouterMaxConnectionsEnvName`): New const.
(`desiredRouterDeployment`): Add unsupported config override for `ROUTER_MAX_CONNECTIONS`.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Verify that `desiredRouterDeployment` sets `ROUTER_MAX_CONNECTIONS` as expected.
* `test/e2e/operator_test.go` (`TestMaxConnectionsUnsupportedConfigOverride`): Verify that the operator sets `ROUTER_MAX_CONNECTIONS` to the appropriate value based on the value specified in the unsupported configuration override if an override is specified.


#### `test/e2e`: Get ingresscontroller before update

When updating an ingresscontroller, do a get immediately before doing the update.

This is a cleanup and should have no significant functional effect.

* `test/e2e/operator_test.go` (`TestProxyProtocolAPI`, `TestLoadBalancingAlgorithmUnsupportedConfigOverride`, `TestDynamicConfigManagerUnsupportedConfigOverride`, `TestReloadIntervalUnsupportedConfigOverride`): Get ingresscontroller immediately before updating it.


#### `test/e2e`: Ignore some not-found errors on delete

Ignore not-found errors when deleting client pods.  These pods run and then exit, and it is possible that they get garbage collected before the test code deletes them, in which case it is expected that they be not found.

* `test/e2e/canary_test.go` (`TestCanaryRoute`):
* `test/e2e/client_tls_test.go` (`TestClientTLS`):
* `test/e2e/http_header_buffer_test.go` (`TestHTTPHeaderBufferSize`):
* `test/e2e/http_header_name_case_adjustment_test.go` (`TestHeaderNameCaseAdjustment`):
* `test/e2e/operator_test.go` (`TestHTTPHeaderCapture`, `TestHTTPCookieCapture`, `TestUniqueIdHeader`): Ignore not-found errors when deleting client pods.


---

Setting a config override of `maxConnections: -1` requires https://github.com/openshift/router/pull/304 to work properly.