### PR TITLE
IBM Cloud bug fixes

### DIFF
--- a/pkg/dns/ibm/dns.go
+++ b/pkg/dns/ibm/dns.go
@@ -41,11 +41,12 @@ func NewProvider(config Config) (*Provider, error) {
 		ApiKey: config.APIKey,
 	}
 	provider := &Provider{}
+	provider.dnsServices = make(map[string]dnsclient.DnsClient)
 
 	for _, zone := range config.Zones {
 		options := &dnsrecordsv1.DnsRecordsV1Options{
 			Authenticator:  authenticator,
-			URL:            "https://api.private.cis.cloud.ibm.com/v1",
+			URL:            "https://api.cis.cloud.ibm.com/",
 			Crn:            &config.CISCRN,
 			ZoneIdentifier: &zone,
 		}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -744,7 +744,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to ensure load balancer service for %s: %v", ci.Name, err))
 	} else {
 		lbService = lb
-		if _, record, err := r.ensureWildcardDNSRecord(ci, lbService, haveLB); err != nil {
+		if _, record, err := r.ensureWildcardDNSRecord(ci, lbService, haveLB, infraConfig); err != nil {
 			errs = append(errs, fmt.Errorf("failed to ensure wildcard dnsrecord for %s: %v", ci.Name, err))
 		} else {
 			wildcardRecord = record

--- a/pkg/operator/controller/ingress/dns.go
+++ b/pkg/operator/controller/ingress/dns.go
@@ -197,11 +197,11 @@ func dnsRecordChanged(current, expected *iov1.DNSRecord) (bool, *iov1.DNSRecord)
 }
 
 // getTTLForCloudProvider returns the cloud provider specific ttl value for dns record
-func getTTLForCloudProvider(infraConfig *configv1.Infrastructure) int64{
+func getTTLForCloudProvider(infraConfig *configv1.Infrastructure) int64 {
 	var platform configv1.PlatformType
 	if infraConfig != nil && infraConfig.Status.PlatformStatus != nil {
 		platform = infraConfig.Status.PlatformStatus.Type
-	}else{
+	} else {
 		return defaultRecordTTL
 	}
 


### PR DESCRIPTION
This PR contains following 3 bug fixes.

**1.  Assignment to entry in nil map panic in ibm cloud dns**

Ingress operator Panic trace:

```
2021-08-24T15:07:54.568+0530	INFO	operator.ingressclass_controller	controller/controller.go:298	reconciling	{"request": "openshift-ingress-operator/karthik"}
panic: 	

goroutine 1565 [running]:
github.com/openshift/cluster-ingress-operator/pkg/dns/ibm.NewProvider(0x31a3d4a, 0x2c, 0x32120ec, 0x74, 0xc004f7e910, 0x46, 0xc0006a2ae0, 0x1, 0x1, 0x3521100, ...)
	/Users/karthikkn/workspace/cluster-ingress-operator/pkg/dns/ibm/dns.go:61 +0x2b4
github.com/openshift/cluster-ingress-operator/pkg/operator/controller/dns.(*reconciler).createDNSProvider(0xc000273ea0, 0xc0035e0780, 0xc0031fc720, 0xc00044b398, 0xc003c42a00, 0x0, 0x0, 0x0, 0x0)
	/Users/karthikkn/workspace/cluster-ingress-operator/pkg/operator/controller/dns/controller.go:612 +0x172d
github.com/openshift/cluster-ingress-operator/pkg/operator/controller/dns.(*reconciler).createDNSProviderIfNeeded(0xc000273ea0, 0xc0035e0780, 0xc002a1b080, 0x0)
	/Users/karthikkn/workspace/cluster-ingress-operator/pkg/operator/controller/dns/controller.go:260 +0x376
github.com/openshift/cluster-ingress-operator/pkg/operator/controller/dns.(*reconciler).Reconcile(0xc000273ea0, 0x3559bf8, 0xc002a1b080, 0xc004056380, 0x1a, 0xc004005510, 0x10, 0xc002a1b080, 0xc00003a000, 0x2f4dcc0, ...)
	/Users/karthikkn/workspace/cluster-ingress-operator/pkg/operator/controller/dns/controller.go:133 +0x285
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0008b1a40, 0x3559b50, 0xc000a3a740, 0x2edf5a0, 0xc00403d760)
	/Users/karthikkn/workspace/cluster-ingress-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0008b1a40, 0x3559b50, 0xc000a3a740, 0xc002cd5700)
	/Users/karthikkn/workspace/cluster-ingress-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc002d1e010, 0xc0008b1a40, 0x3559b50, 0xc000a3a740)
	/Users/karthikkn/workspace/cluster-ingress-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:214 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	/Users/karthikkn/workspace/cluster-ingress-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:210 +0x425
```

**2. Invalid IBM Cloud Internet Service Endpoint URL**

Ingress operator error messages when try to create a new dns record

```
2021-08-24T14:40:12.495+0530	ERROR	operator.init.controller-runtime.manager.controller.dns_controller	controller/controller.go:253	Reconciler error	{"name": "karthik-wildcard", "namespace": "openshift-ingress-operator", "error": "failed to create DNS provider: failed to create IBM DNS manager: failed to validate ibm dns services: failed to get dns records: Get \"https://api.private.cis.cloud.ibm.com/v1/v1/crn:v1:bluemix:public:internet-svcs:global:a%2F65b64c1f1c29460e8c2e4bbfbd893c2c:453c4cff-2ee0-4309-95f1-2e9384d9bb96::/zones/3e4c8a33b7373f077a1e50677d277b1f/dns_records?per_page=1\": dial tcp: lookup api.private.cis.cloud.ibm.com on 218.248.112.1:53: no such host"}
2021-08-24T14:40:12.495+0530	INFO	operator.dns_controller	controller/controller.go:298	reconciling	{"request": "openshift-ingress-operator/karthik-wildcard"}
```

3. Invalid TTL value for dns record for IBM Cloud

Ingress operator error messages when try to create a new dns record

`2021-08-24T10:23:49.677+0530	ERROR	operator.dns_controller	dns/controller.go:203	failed to publish DNS record to zone	{"record": {"dnsName":"*.kak.apps.rdr-kn27.scnl-ibm.com.","targets":["ea448a75-eu-gb.lb.appdomain.cloud"],"recordType":"CNAME","recordTTL":30}, "dnszone": {"id":"3e4c8a33b7373f077a1e50677d277b1f"}, "error": "createOrUpdateDNSRecord: failed to create the dns record: DNS Validation Error"}`

Response from IBM Cloud CIS service upon trying to create CIS entry with default value of 30 seconds

`2021-08-24T10:23:48.362+0530     INFO  {"StatusCode":400,"Headers":{"Cf-Cache-Status":["DYNAMIC"],"Cf-Ray":["6839f9d7bb0b7351-BOM"],"Connection":["keep-alive"],"Content-Length":["231"],"Content-Type":["application/json; charset=UTF-8"],"Date":["Tue, 24 Aug 2021 04:53:17 GMT"],"Expect-Ct":["max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""],"Server":["cloudflare"],"X-Correlation-Id":["b3754e9f-efff-4c8a-95e3-c7e29f9ea44a"]},"Result":{"errors":[{"code":1004,"error_chain":[{"code":9021,"message":"TTL must be between 120 and 2,147,483,647 seconds, or 1 for Automatic."}],"message":"DNS Validation Error"}],"messages":[],"result":null,"success":false},"RawResult":null}`



