### PR TITLE
tlsVersion13Ciphers: Delete duplicates

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -60,9 +60,13 @@ var (
 	log = logf.Logger.WithName(controllerName)
 	// tlsVersion13Ciphers is a list of TLS v1.3 cipher suites as specified by
 	// https://www.openssl.org/docs/man1.1.1/man1/ciphers.html
-	tlsVersion13Ciphers = sets.NewString("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
-		"TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256", "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
-		"TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256")
+	tlsVersion13Ciphers = sets.NewString(
+		"TLS_AES_128_GCM_SHA256",
+		"TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256",
+		"TLS_AES_128_CCM_SHA256",
+		"TLS_AES_128_CCM_8_SHA256",
+	)
 )
 
 // New creates the ingress controller from configuration. This is the controller


### PR DESCRIPTION
Delete duplicate entries in `tlsVersion13Ciphers`.

The entries in `tlsVersion13Ciphers` were copied from a table in <https://www.openssl.org/docs/man1.1.1/man1/ciphers.html>, which lists each cipher suite twice: once by its name in the relevant specification and once by its name in OpenSSL, and these names happen to be identical in the case of TLSv1.3 cipher suites.  Logically, only the OpenSSL names should be included in `tlsVersion13Ciphers`.

Follow-up to <https://github.com/openshift/cluster-ingress-operator/pull/315/commits/92914d9200dfb604fcb2f315c701b1406b7c3bc3>.

* `pkg/operator/controller/ingress/controller.go` (`tlsVersion13Ciphers`):
Reformat and delete duplicate entries.