### PR TITLE
Bug 2001479: Fix IBM Cloud DNS bugs

### DIFF
--- a/pkg/dns/ibm/client/client.go
+++ b/pkg/dns/ibm/client/client.go
@@ -12,7 +12,6 @@ type DnsClient interface {
 	UpdateDnsRecord(updateDnsRecordOptions *dnsrecordsv1.UpdateDnsRecordOptions) (result *dnsrecordsv1.DnsrecordResp, response *core.DetailedResponse, err error)
 	NewCreateDnsRecordOptions() *dnsrecordsv1.CreateDnsRecordOptions
 	NewDeleteDnsRecordOptions(dnsrecordIdentifier string) *dnsrecordsv1.DeleteDnsRecordOptions
-	NewGetDnsRecordOptions(dnsrecordIdentifier string) *dnsrecordsv1.GetDnsRecordOptions
 	NewListAllDnsRecordsOptions() *dnsrecordsv1.ListAllDnsRecordsOptions
 	NewUpdateDnsRecordOptions(dnsrecordIdentifier string) *dnsrecordsv1.UpdateDnsRecordOptions
 }

--- a/pkg/dns/ibm/client/fake_client.go
+++ b/pkg/dns/ibm/client/fake_client.go
@@ -99,10 +99,6 @@ func (FakeDnsClient) NewDeleteDnsRecordOptions(dnsrecordIdentifier string) *dnsr
 	return &dnsrecordsv1.DeleteDnsRecordOptions{DnsrecordIdentifier: &dnsrecordIdentifier}
 }
 
-func (FakeDnsClient) NewGetDnsRecordOptions(dnsrecordIdentifier string) *dnsrecordsv1.GetDnsRecordOptions {
-	return &dnsrecordsv1.GetDnsRecordOptions{}
-}
-
 func (FakeDnsClient) NewListAllDnsRecordsOptions() *dnsrecordsv1.ListAllDnsRecordsOptions {
 	return &dnsrecordsv1.ListAllDnsRecordsOptions{}
 }


### PR DESCRIPTION
Related bugzilla report: https://bugzilla.redhat.com/show_bug.cgi?id=2001479

This PR fixes bugs in IBM Cloud DNS Provider:
- initialize provider map
- fix cis url
- set valid TTL for dns records
- trim dot from the end of dns record name before listing records (issue during wildcard record operations)
- remove unused NewGetDnsRecordOptions from interface