### PR TITLE
Bug 2014710: Fix for Azure dns privateZone degrade e2e test

### DIFF
--- a/test/e2e/dns_ingressdegrade_test.go
+++ b/test/e2e/dns_ingressdegrade_test.go
@@ -80,19 +80,22 @@ func TestIngressStatus(t *testing.T) {
 
 // updateDNSConfig - utility to set/unset PrivateZone Tags/ID
 func updateDNSConfig(set bool, dnsConfig *configv1.DNS) {
+	// Azure privateZone uses "/" notation the original error- prefix did not cause the privateZone to fail
+	// Tested on AWS and GCP
+	injectError := "/error"
 	if dnsConfig.Spec.PrivateZone.ID != "" {
 		if set {
-			dnsConfig.Spec.PrivateZone.ID = "error-" + dnsConfig.Spec.PrivateZone.ID
+			dnsConfig.Spec.PrivateZone.ID = injectError + dnsConfig.Spec.PrivateZone.ID
 		} else {
-			// remove 'error-' from prefix
+			// remove injectError from prefix
 			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[6:]
 		}
 	}
 	if dnsConfig.Spec.PrivateZone.Tags["Name"] != "" {
 		if set {
-			dnsConfig.Spec.PrivateZone.Tags["Name"] = "error-" + dnsConfig.Spec.PrivateZone.Tags["Name"]
+			dnsConfig.Spec.PrivateZone.Tags["Name"] = injectError + dnsConfig.Spec.PrivateZone.Tags["Name"]
 		} else {
-			// remove 'error-' from prefix
+			// remove injectError from prefix
 			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][6:]
 		}
 	}


### PR DESCRIPTION
This fix ensures the e2e test for dns privateZone works for Azure , GCP and AWS.

The fix is really simple. Azure uses a "/" naming notation for privateZones, the original "error-" prefix did not cause a failure, the updated prefix injected is simply "/error" which causes the operator status to degrade to TRUE

The change was verified on Azure & AWS via cluster-bot

For Azure 

```
GO111MODULE=on GOFLAGS=-mod=vendor go test -timeout 1h -count 1 -v -tags e2e -run "TestIngressStatus" ./test/e2e/                                                                                                       
I1015 12:27:32.540041 1235696 request.go:668] Waited for 1.046809151s due to client-side throttling, not priority and fairness, request: GET:https://api.ci-ln-zjdbpyt-002ac.ci.azure.devcluster.openshift.com:6443/apis/controlplane.operator.openshift.io/v1alpha1?timeout=32s
=== RUN   TestIngressStatus
--- PASS: TestIngressStatus (33.69s)
PASS
ok  	github.com/openshift/cluster-ingress-operator/test/e2e	37.117s
```

For AWS

```
GO111MODULE=on GOFLAGS=-mod=vendor go test -timeout 1h -count 1 -v -tags e2e -run "TestIngressStatus" ./test/e2e                                                                                       
I1015 14:04:16.269989    9695 request.go:668] Waited for 1.045602401s due to client-side throttling, not priority and fairness, request: GET:https://api.ci-ln-53wq70b-d5d6b.origin-ci-int-aws.dev.rhcloud.com:6443/apis/apiserver.openshift.io/v1?timeout=32s
=== RUN   TestIngressStatus
--- PASS: TestIngressStatus (35.77s)
PASS
ok  	github.com/openshift/cluster-ingress-operator/test/e2e	39.560s
```
 