### PR TITLE
Bug 2014710: test/e2e: updateDNSConfig: Replace integer literals

### DIFF
--- a/test/e2e/dns_ingressdegrade_test.go
+++ b/test/e2e/dns_ingressdegrade_test.go
@@ -78,25 +78,27 @@ func TestIngressStatus(t *testing.T) {
 	}
 }
 
-// updateDNSConfig - utility to set/unset PrivateZone Tags/ID
+// updateDNSConfig sets an invalid Tag or ID for the cluster DNS config's
+// PrivateZone if the set argument is true and reverts the DNS config back to
+// its original setting if the set argument is false.
 func updateDNSConfig(set bool, dnsConfig *configv1.DNS) {
-	// Azure privateZone uses "/" notation the original error- prefix did not cause the privateZone to fail
-	// Tested on AWS and GCP
-	injectError := "/error"
+	// Tested on Azure, AWS, and GCP.  Azure privateZone uses "/" notation,
+	// so prepending "error-" without "/" does not cause a failure on Azure.
+	const injectError = "/error"
 	if dnsConfig.Spec.PrivateZone.ID != "" {
 		if set {
 			dnsConfig.Spec.PrivateZone.ID = injectError + dnsConfig.Spec.PrivateZone.ID
 		} else {
-			// remove injectError from prefix
-			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[6:]
+			// Remove injectError from prefix.
+			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[len(injectError):]
 		}
 	}
 	if dnsConfig.Spec.PrivateZone.Tags["Name"] != "" {
 		if set {
 			dnsConfig.Spec.PrivateZone.Tags["Name"] = injectError + dnsConfig.Spec.PrivateZone.Tags["Name"]
 		} else {
-			// remove injectError from prefix
-			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][6:]
+			// Remove injectError from prefix.
+			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][len(injectError):]
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/openshift/cluster-ingress-operator/pull/662/commits/fe8c1ee814a5d1c361461ab39b49543ba61666f1 based on review comments on the release-4.9 backport: https://github.com/openshift/cluster-ingress-operator/pull/664#pullrequestreview-793432926

* `test/e2e/dns_ingressdegrade_test.go` (`updateDNSConfig`): Replace integer literals with `len(injectError)`.  Change `injectError` to a const.