### PR TITLE
[release-4.9] Bug 2014711: Fix for Azure dns privateZone degrade e2e test

### DIFF
--- a/test/e2e/dns_ingressdegrade_test.go
+++ b/test/e2e/dns_ingressdegrade_test.go
@@ -78,25 +78,27 @@ func TestIngressStatus(t *testing.T) {
 	}
 }
 
-// updateDNSConfig - utility to set/unset PrivateZone Tags/ID
+// updateDNSConfig sets an invalid Tag or ID for the cluster DNS config's
+// PrivateZone if the set argument is true and reverts the DNS config back to
+// its original setting if the set argument is false.
 func updateDNSConfig(set bool, dnsConfig *configv1.DNS) {
-	// Azure privateZone uses "/" notation the original error- prefix did not cause the privateZone to fail
-	// Tested on AWS and GCP
-	injectError := "/error"
+	// Tested on Azure, AWS, and GCP.  Azure privateZone uses "/" notation,
+	// so prepending "error-" without "/" does not cause a failure on Azure.
+	const injectError = "/error"
 	if dnsConfig.Spec.PrivateZone.ID != "" {
 		if set {
 			dnsConfig.Spec.PrivateZone.ID = injectError + dnsConfig.Spec.PrivateZone.ID
 		} else {
-			// remove injectError from prefix
-			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[6:]
+			// Remove injectError from prefix.
+			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[len(injectError):]
 		}
 	}
 	if dnsConfig.Spec.PrivateZone.Tags["Name"] != "" {
 		if set {
 			dnsConfig.Spec.PrivateZone.Tags["Name"] = injectError + dnsConfig.Spec.PrivateZone.Tags["Name"]
 		} else {
-			// remove injectError from prefix
-			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][6:]
+			// Remove injectError from prefix.
+			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][len(injectError):]
 		}
 	}
 }

--- a/test/e2e/dns_ingressdegrade_test.go
+++ b/test/e2e/dns_ingressdegrade_test.go
@@ -80,19 +80,22 @@ func TestIngressStatus(t *testing.T) {
 
 // updateDNSConfig - utility to set/unset PrivateZone Tags/ID
 func updateDNSConfig(set bool, dnsConfig *configv1.DNS) {
+	// Azure privateZone uses "/" notation the original error- prefix did not cause the privateZone to fail
+	// Tested on AWS and GCP
+	injectError := "/error"
 	if dnsConfig.Spec.PrivateZone.ID != "" {
 		if set {
-			dnsConfig.Spec.PrivateZone.ID = "error-" + dnsConfig.Spec.PrivateZone.ID
+			dnsConfig.Spec.PrivateZone.ID = injectError + dnsConfig.Spec.PrivateZone.ID
 		} else {
-			// remove 'error-' from prefix
+			// remove injectError from prefix
 			dnsConfig.Spec.PrivateZone.ID = dnsConfig.Spec.PrivateZone.ID[6:]
 		}
 	}
 	if dnsConfig.Spec.PrivateZone.Tags["Name"] != "" {
 		if set {
-			dnsConfig.Spec.PrivateZone.Tags["Name"] = "error-" + dnsConfig.Spec.PrivateZone.Tags["Name"]
+			dnsConfig.Spec.PrivateZone.Tags["Name"] = injectError + dnsConfig.Spec.PrivateZone.Tags["Name"]
 		} else {
-			// remove 'error-' from prefix
+			// remove injectError from prefix
 			dnsConfig.Spec.PrivateZone.Tags["Name"] = dnsConfig.Spec.PrivateZone.Tags["Name"][6:]
 		}
 	}


### PR DESCRIPTION
This is a manual cherry-pick of #662 and #672.

---

The recently added `TestIngressStatus` test fails on Azure, causing the e2e-azure-operator CI jobs in the cluster-ingress-operator repository to fail consistently.  This backport fixes the test so that it passes on Azure.  This is needed so that we can verify cluster-ingress-operator PRs to the release-4.9 branch on Azure.  This change has no direct impact on users.  
