### PR TITLE
NE-882: Set `ROUTER_DOMAIN` to enable route subdomain field

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -527,7 +527,11 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	}
 
 	if len(ci.Status.Domain) > 0 {
-		env = append(env, corev1.EnvVar{Name: "ROUTER_CANONICAL_HOSTNAME", Value: "router-" + ci.Name + "." + ci.Status.Domain})
+		cName := "router-" + ci.Name + "." + ci.Status.Domain
+		env = append(env,
+			corev1.EnvVar{Name: "ROUTER_DOMAIN", Value: ci.Status.Domain},
+			corev1.EnvVar{Name: "ROUTER_CANONICAL_HOSTNAME", Value: cName},
+		)
 	}
 
 	if proxyNeeded {

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -312,6 +312,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		{"STATS_PASSWORD_FILE", true, "/var/lib/haproxy/conf/metrics-auth/statsPassword"},
 		{"SSL_MIN_VERSION", true, "TLSv1.1"},
 		{WildcardRouteAdmissionPolicy, true, "false"},
+		{"ROUTER_DOMAIN", false, ""},
 	}
 	if err := checkDeploymentEnvironment(t, deployment, tests); err != nil {
 		t.Error(err)
@@ -510,6 +511,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		{"ROUTER_IP_V4_V6_MODE", true, "v4v6"},
 		{RouterEnableCompression, true, "true"},
 		{RouterCompressionMIMETypes, true, "text/html application/*"},
+		{"ROUTER_DOMAIN", true, ic.Status.Domain},
 	}
 	if err := checkDeploymentEnvironment(t, deployment, tests); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Set `ROUTER_DOMAIN` to the IngressController's domain in the router deployment so that the router can use the domain to construct a default host for routes that specify an empty value for `spec.host` and a nonempty value for `spec.subdomain`.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Set `ROUTER_DOMAIN`.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeployment`): Verify that `ROUTER_DOMAIN` is set as expected.