### PR TITLE
Bug 1918651: ingress operator doesn't report any error when one of router pods is not ready

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -48,6 +48,7 @@ const (
 	IngressControllerAdmittedConditionType                       = "Admitted"
 	IngressControllerPodsScheduledConditionType                  = "PodsScheduled"
 	IngressControllerDeploymentAvailableConditionType            = "DeploymentAvailable"
+	IngressControllerDeploymentProgressingConditionType          = "DeploymentProgressing"
 	IngressControllerDeploymentReplicasMinAvailableConditionType = "DeploymentReplicasMinAvailable"
 	IngressControllerDeploymentReplicasAllAvailableConditionType = "DeploymentReplicasAllAvailable"
 	IngressControllerCanaryCheckSuccessConditionType             = "CanaryChecksSucceeding"

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -19,6 +19,7 @@ func TestComputeOperatorProgressingCondition(t *testing.T) {
 		description           string
 		noNamespace           bool
 		allIngressesAvailable bool
+		ingressesProgressing  bool
 		reportedVersions      versions
 		oldVersions           versions
 		curVersions           versions
@@ -27,6 +28,18 @@ func TestComputeOperatorProgressingCondition(t *testing.T) {
 		{
 			description:           "all ingress controllers are available",
 			allIngressesAvailable: true,
+			expectProgressing:     configv1.ConditionFalse,
+		},
+		{
+			description:           "ingress controllers are progressing",
+			allIngressesAvailable: true,
+			ingressesProgressing:  true,
+			expectProgressing:     configv1.ConditionTrue,
+		},
+		{
+			description:           "ingress controllers are not progressing",
+			allIngressesAvailable: true,
+			ingressesProgressing:  false,
 			expectProgressing:     configv1.ConditionFalse,
 		},
 		{
@@ -134,7 +147,7 @@ func TestComputeOperatorProgressingCondition(t *testing.T) {
 			Status: tc.expectProgressing,
 		}
 
-		actual := computeOperatorProgressingCondition(tc.allIngressesAvailable, oldVersions, reportedVersions, tc.curVersions.operator, tc.curVersions.operand1, tc.curVersions.operand2)
+		actual := computeOperatorProgressingCondition(tc.allIngressesAvailable, oldVersions, reportedVersions, tc.curVersions.operator, tc.curVersions.operand1, tc.curVersions.operand2, tc.ingressesProgressing)
 		conditionsCmpOpts := []cmp.Option{
 			cmpopts.IgnoreFields(configv1.ClusterOperatorStatusCondition{}, "LastTransitionTime", "Reason", "Message"),
 		}


### PR DESCRIPTION
**Issue 1**: The cluster-ingress-operator reports Available: true and Progressing: false even when the number of defined in ingresscontroller/default.spec.replicas are not all available (e.g. 1/2 replicas available).

**Issue 2**: The cluster-ingress-operator reports Available: true and Progressing: false even when the ingresscontroller deployment reports Progressing: true.