### PR TITLE
WIP: Add send-canary-probe command to ingress operator for diagnostics

### DIFF
--- a/cmd/ingress-operator/main.go
+++ b/cmd/ingress-operator/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	"github.com/openshift/cluster-ingress-operator/test/canaryProbe"
 	grpctestserver "github.com/openshift/cluster-ingress-operator/test/grpc"
 	h2specclient "github.com/openshift/cluster-ingress-operator/test/h2spec"
 	httphealthcheck "github.com/openshift/cluster-ingress-operator/test/http"
@@ -36,6 +37,7 @@ func main() {
 		},
 	})
 	rootCmd.AddCommand(h2specclient.NewClientCommand())
+	rootCmd.AddCommand(canaryProbe.NewClientCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Error(err, "error")

--- a/pkg/operator/controller/canary/controller.go
+++ b/pkg/operator/controller/canary/controller.go
@@ -268,7 +268,7 @@ func (r *reconciler) startCanaryRoutePolling(stop <-chan struct{}) error {
 			return
 		}
 
-		err = probeRouteEndpoint(route)
+		err = ProbeRouteEndpoint(route, true, false)
 		if err != nil {
 			log.Error(err, "error performing canary route check")
 			SetCanaryRouteReachableMetric(route.Spec.Host, false)

--- a/test/canaryProbe/client.go
+++ b/test/canaryProbe/client.go
@@ -1,0 +1,97 @@
+package canaryProbe
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var kclient client.Client
+
+func NewClientCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "send-canary-probe [--report-stats=true]",
+		Short: "Operational testing tool for canary healthcheck debugging",
+		Long:  "Operational testing tool for canary healthcheck debugging.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args)
+		},
+	}
+
+	cmd.SilenceErrors = true
+
+	flags := cmd.Flags()
+	flags.Bool("report-stats", false, "Use the httpstats wrapper")
+	flags.Bool("help", false, "Display this help and exit")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	flags := cmd.Flags()
+
+	getStats, err := flags.GetBool("report-stats")
+	if err != nil {
+		return err
+	}
+
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kube config: %s\n", err)
+	}
+	kubeClient, err := operatorclient.NewClient(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %s\n", err)
+	}
+	kclient = kubeClient
+
+	// Get the current canary route
+	haveRoute, route, err := currentCanaryRoute()
+	if err != nil {
+		log.Fatalf("failed to get current canary route for canary check: %v", err)
+		return err
+	} else if !haveRoute {
+		return fmt.Errorf("error performing canary route check: route does not exist")
+	}
+
+	err = canary.ProbeRouteEndpoint(route, getStats, true)
+	if err != nil {
+		return fmt.Errorf("error performing canary route check: %v", err)
+	}
+
+	return err
+}
+
+// currentCanaryRoute gets the current canary route resource
+func currentCanaryRoute() (bool, *routev1.Route, error) {
+	canaryRoute := &routev1.Route{}
+	name := controller.CanaryRouteName()
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), name, canaryRoute); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			log.Printf("failed to get canary route %s: %v", name, err)
+			return false, err
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get canary route %s: %v", name, err)
+	}
+	return true, canaryRoute, nil
+}


### PR DESCRIPTION
Add send-canary-probe command to ingress operator for diagnostics. 
Usage ./ingress-operator send-canary-probe --report-stats=[true|false]
