### PR TITLE
Code improvements and unit tests for Alibaba DNS

### DIFF
--- a/pkg/dns/alibaba/dns.go
+++ b/pkg/dns/alibaba/dns.go
@@ -3,9 +3,6 @@ package alibaba
 import (
 	"fmt"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/pvtz"
 	configv1 "github.com/openshift/api/config/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/dns"
@@ -13,13 +10,19 @@ import (
 	"strings"
 )
 
-const (
-	zoneTypeDNS         = "public"
-	zoneTypePrivateZone = "private"
+// zoneType is a type of DNS zone: public or private.
+type zoneType string
 
-	actionEnsure  = "ensure"
-	actionReplace = "replace"
-	actionDelete  = "delete"
+// action is an action that can be performed on a DNS record by this DNS provider.
+type action string
+
+const (
+	zoneTypePublicZone  zoneType = "public"
+	zoneTypePrivateZone zoneType = "private"
+
+	actionEnsure  action = "ensure"
+	actionReplace action = "replace"
+	actionDelete  action = "delete"
 )
 
 var (
@@ -30,109 +33,57 @@ type Config struct {
 	Region       string
 	AccessKeyID  string
 	AccessSecret string
-	// PrivateZones is array of private zone names.
-	PrivateZones []string
 }
 
 type ZoneInfo struct {
-	// Type is the type of zone,
-	// should be 'dns' or 'pvtz'
-	Type string
-	// ID is the value used in OpenAPI to leverage dns records.
-	// In DNS(public zone), it should be domain name. And in private zone, it should be ZoneID
+	// Type is type of the zone.
+	Type zoneType
+	// ID is the value used in OpenAPI to leverage dns records via Service.
+	// In public zone, it should be domain name. In private zone, it should be zone name.
 	ID string
-	// DomainName is domain of the zone
+	// Domain is domain name of the zone
 	Domain string
 }
 
 type provider struct {
 	config   Config
-	services map[string]Service
-	pvtzIDs  map[string]string
+	services map[zoneType]Service
 }
 
 func NewProvider(config Config) (dns.Provider, error) {
-	client, err := sdk.NewClientWithAccessKey(config.Region, config.AccessKeyID, config.AccessSecret)
+	sdkClient, err := sdk.NewClientWithAccessKey(config.Region, config.AccessKeyID, config.AccessSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create alibaba cloud api service: %w", err)
+		return nil, fmt.Errorf("failed to create alibabacloud api service: %w", err)
 	}
 
-	pvtzIDs := make(map[string]string)
-	for _, zoneName := range config.PrivateZones {
-		request := pvtz.CreateDescribeZonesRequest()
-		request.Scheme = "https"
-		request.QueryRegionId = config.Region
-		request.Keyword = zoneName
-		request.SearchMode = "EXACT"
-		request.PageSize = requests.NewInteger(100)
-		response := pvtz.CreateDescribeZonesResponse()
-
-		// resolve endpoint
-		endpoint, err := endpoints.Resolve(&endpoints.ResolveParam{
-			Product:  strings.ToLower(request.GetProduct()),
-			RegionId: strings.ToLower(config.Region),
-		})
-
-		if err != nil {
-			endpoint = defaultEndpoints[strings.ToLower(request.GetProduct())]
-		}
-		request.SetDomain(endpoint)
-
-		err = client.DoAction(request, response)
-		if err != nil {
-			return nil, fmt.Errorf("failed on describe private zones: %w", err)
-		}
-
-		for _, zones := range response.Zones.Zone {
-			if zoneName == zones.ZoneName {
-				pvtzIDs[zoneName] = zones.ZoneId
-				break
-			}
-		}
-
-		if _, ok := pvtzIDs[zoneName]; !ok {
-			return nil, fmt.Errorf("zone id for name '%s' not found", zoneName)
-		}
-	}
-
+	client := NewClient(sdkClient, config.Region)
 	return &provider{
 		config: config,
-		services: map[string]Service{
-			zoneTypeDNS:         NewDNSService(client, config.Region),
-			zoneTypePrivateZone: NewPvtzService(client, config.Region),
+		services: map[zoneType]Service{
+			zoneTypePublicZone:  NewPublicZoneService(client),
+			zoneTypePrivateZone: NewPrivateZoneService(client),
 		},
-		pvtzIDs: pvtzIDs,
 	}, nil
 }
 
-// parseZone parses the zone id to ZoneInfo
+// parseZone parses the zone id to ZoneInfo.
 func (p *provider) parseZone(zone configv1.DNSZone) (ZoneInfo, error) {
-	zoneType, ok := zone.Tags["type"]
+	typeString, ok := zone.Tags["type"]
 	if !ok {
-		return ZoneInfo{}, fmt.Errorf("can not find tag 'type' in DNSZone")
-	}
-
-	zoneID := zone.ID
-	if zoneType == zoneTypePrivateZone {
-		// lookup private zone id in pvtzIDs
-		id, ok := p.pvtzIDs[zoneID]
-		if !ok {
-			return ZoneInfo{}, fmt.Errorf("can not get private zone id for name '%s'", zoneID)
-		}
-
-		zoneID = id
+		return ZoneInfo{}, fmt.Errorf("cannot find tag \"type\" in DNSZone")
 	}
 
 	return ZoneInfo{
-		Type:   zoneType,
-		ID:     zoneID,
+		Type: zoneType(typeString),
+		ID:   zone.ID,
+		// For now, Domain is equal to zone ID,
 		Domain: zone.ID,
 	}, nil
 }
 
-// getRR should get record name from a full qualified domain name
-// if dnsName is not a subdomain of domainName,
-// it will return the dnsName instead (without the trailing dot)
+// getRR should get record name from a full qualified domain name.
+// If dnsName is not a subdomain of domainName,
+// it will return the dnsName instead (without the trailing dot).
 func getRR(dnsName, domainName string) string {
 	dnsName = strings.TrimSuffix(dnsName, ".")
 	return strings.TrimSuffix(dnsName, "."+domainName)
@@ -150,7 +101,7 @@ func (p *provider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error 
 	return p.doRequest(zone, record, actionReplace)
 }
 
-func (p *provider) doRequest(zone configv1.DNSZone, record *iov1.DNSRecord, action string) (err error) {
+func (p *provider) doRequest(zone configv1.DNSZone, record *iov1.DNSRecord, action action) error {
 	zoneInfo, err := p.parseZone(zone)
 	if err != nil {
 		return err
@@ -170,7 +121,9 @@ func (p *provider) doRequest(zone configv1.DNSZone, record *iov1.DNSRecord, acti
 		err = service.Update(zoneInfo.ID, rr, string(record.Spec.RecordType), record.Spec.Targets[0], record.Spec.RecordTTL)
 	case actionDelete:
 		err = service.Delete(zoneInfo.ID, rr, record.Spec.Targets[0])
+	default:
+		err = fmt.Errorf("unknown action %q", action)
 	}
 
-	return
+	return err
 }

--- a/pkg/dns/alibaba/dns_test.go
+++ b/pkg/dns/alibaba/dns_test.go
@@ -1,1 +1,202 @@
 package alibaba
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/dns"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type fakeService struct {
+	// records for id+rr to target
+	records map[string]string
+	// lastAction records the last action performed
+	// can be "add", "update" or "delete"
+	lastAction string
+}
+
+func (p *fakeService) Add(id, rr, recordType, target string, ttl int64) error {
+	p.records[id+rr] = target
+	p.lastAction = "add"
+	return nil
+}
+
+func (p *fakeService) Update(id, rr, recordType, target string, ttl int64) error {
+	p.records[id+rr] = target
+	p.lastAction = "update"
+	return nil
+}
+
+func (p *fakeService) Delete(id, rr, target string) error {
+	delete(p.records, id+rr)
+	p.lastAction = "delete"
+	return nil
+}
+
+// getLastAction returns lastAction and sets it to empty
+func (p *fakeService) getLastAction() string {
+	action := p.lastAction
+	p.lastAction = ""
+	return action
+}
+
+func newFakeService() *fakeService {
+	return &fakeService{
+		records: make(map[string]string),
+	}
+}
+
+func newFakeProvider(public, private Service) dns.Provider {
+	return &provider{
+		services: map[zoneType]Service{
+			zoneTypePublicZone:  public,
+			zoneTypePrivateZone: private,
+		},
+	}
+}
+
+func TestGetRR(t *testing.T) {
+	cases := []struct {
+		dnsName    string
+		domainName string
+		excepted   string
+	}{
+		{
+			dnsName:    "test.example.com.",
+			domainName: "example.com",
+			excepted:   "test",
+		},
+		{
+			dnsName:    "test.subdomain.example.com.",
+			domainName: "example.com",
+			excepted:   "test.subdomain",
+		},
+		{
+			dnsName:    "test.subdomain.example.com.",
+			domainName: "subdomain.example.com",
+			excepted:   "test",
+		},
+		{
+			dnsName:    "without.domain.",
+			domainName: "example.com",
+			excepted:   "without.domain",
+		},
+	}
+
+	for _, c := range cases {
+		rr := getRR(c.dnsName, c.domainName)
+		assert.Equal(t, c.excepted, rr)
+	}
+}
+
+func TestParseZone(t *testing.T) {
+	cases := []struct {
+		id       string
+		tags     map[string]string
+		zoneType zoneType
+		error    bool
+	}{
+		{
+			id: "public.example.com",
+			tags: map[string]string{
+				"type": "public",
+			},
+			error:    false,
+			zoneType: zoneTypePublicZone,
+		},
+		{
+			id: "private.example.com",
+			tags: map[string]string{
+				"type": "private",
+			},
+			error:    false,
+			zoneType: zoneTypePrivateZone,
+		},
+		{
+			id:    "error.example.com",
+			tags:  map[string]string{},
+			error: true,
+		},
+	}
+
+	p := &provider{}
+	for _, c := range cases {
+		info, err := p.parseZone(configv1.DNSZone{
+			ID:   c.id,
+			Tags: c.tags,
+		})
+
+		if c.error {
+			assert.Error(t, err)
+			continue
+		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, c.id, info.ID)
+		assert.Equal(t, c.zoneType, info.Type)
+	}
+}
+
+func TestProvider(t *testing.T) {
+	servicePublic := newFakeService()
+	servicePrivate := newFakeService()
+	provider := newFakeProvider(servicePublic, servicePrivate)
+
+	record := &iov1.DNSRecord{
+		Spec: iov1.DNSRecordSpec{
+			DNSName:    "test.example.com.",
+			Targets:    []string{"123.123.123.123"},
+			RecordType: "A",
+			RecordTTL:  60,
+		},
+	}
+
+	dnsZonePublic := configv1.DNSZone{
+		ID: "example.com",
+		Tags: map[string]string{
+			"type": "public",
+		},
+	}
+
+	dnsZonePrivate := configv1.DNSZone{
+		ID: "example.com",
+		Tags: map[string]string{
+			"type": "private",
+		},
+	}
+
+	assert.Equal(t, "", servicePublic.getLastAction())
+	assert.Equal(t, "", servicePublic.getLastAction())
+
+	// test public zone ensure
+	assert.NoError(t, provider.Ensure(record, dnsZonePublic))
+	assert.Equal(t, "add", servicePublic.getLastAction())
+	assert.Equal(t, "", servicePrivate.getLastAction())
+
+	// test private zone replace
+	assert.NoError(t, provider.Replace(record, dnsZonePrivate))
+	assert.Equal(t, "", servicePublic.getLastAction())
+	assert.Equal(t, "update", servicePrivate.getLastAction())
+
+	// test public zone delete
+	assert.NoError(t, provider.Delete(record, dnsZonePublic))
+	assert.Equal(t, "delete", servicePublic.getLastAction())
+	assert.Equal(t, "", servicePrivate.getLastAction())
+
+	// test zone type unknown, should return error
+	dnsZoneUnknown := configv1.DNSZone{
+		ID: "example.com",
+		Tags: map[string]string{
+			"type": "unknown",
+		},
+	}
+	assert.Error(t, provider.Ensure(record, dnsZoneUnknown))
+
+	// test zone without type, should return error
+	dnsZoneNoType := configv1.DNSZone{
+		ID:   "example.com",
+		Tags: map[string]string{},
+	}
+	assert.Error(t, provider.Ensure(record, dnsZoneNoType))
+}

--- a/pkg/dns/alibaba/dns_test.go
+++ b/pkg/dns/alibaba/dns_test.go
@@ -1,0 +1,1 @@
+package alibaba

--- a/pkg/dns/alibaba/service.go
+++ b/pkg/dns/alibaba/service.go
@@ -52,7 +52,7 @@ func (d *publicZoneService) Add(id, rr, recordType, target string, ttl int64) er
 	if clampedTTL != ttl {
 		log.Info(fmt.Sprintf("record's TTL for public zone must be in the range of 600 to 86400, set it to %d", clampedTTL), "record", rr)
 	}
-	request.TTL = requests.NewInteger64(ttl)
+	request.TTL = requests.NewInteger64(clampedTTL)
 
 	response := alidns.CreateAddDomainRecordResponse()
 	return d.client.DoActionWithSetDomain(request, response)
@@ -76,7 +76,7 @@ func (d *publicZoneService) Update(id, rr, recordType, target string, ttl int64)
 	if clampedTTL != ttl {
 		log.Info(fmt.Sprintf("record's TTL for public zone must be in the range of 600 to 86400, set it to %d", clampedTTL), "record", rr)
 	}
-	request.TTL = requests.NewInteger64(ttl)
+	request.TTL = requests.NewInteger64(clampedTTL)
 
 	response := alidns.CreateUpdateDomainRecordResponse()
 	return d.client.DoActionWithSetDomain(request, response)
@@ -147,7 +147,7 @@ func (p *privateZoneService) Add(zoneName, rr, recordType, target string, ttl in
 	if clampedTTL != ttl {
 		log.Info(fmt.Sprintf("record's TTL for private zone must be in the range of 600 to 86400, set it to %d", clampedTTL), "record", rr)
 	}
-	request.Ttl = requests.NewInteger64(ttl)
+	request.Ttl = requests.NewInteger64(clampedTTL)
 
 	response := pvtz.CreateAddZoneRecordResponse()
 	return p.client.DoActionWithSetDomain(request, response)
@@ -176,7 +176,7 @@ func (p *privateZoneService) Update(zoneName, rr, recordType, target string, ttl
 	if clampedTTL != ttl {
 		log.Info(fmt.Sprintf("record's TTL for private zone must be in the range of 600 to 86400, set it to %d", clampedTTL), "record", rr)
 	}
-	request.Ttl = requests.NewInteger64(ttl)
+	request.Ttl = requests.NewInteger64(clampedTTL)
 
 	response := pvtz.CreateUpdateZoneRecordResponse()
 	return p.client.DoActionWithSetDomain(request, response)

--- a/pkg/dns/alibaba/util/credentials.go
+++ b/pkg/dns/alibaba/util/credentials.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/provider"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	"os"
+	"sync"
+)
+
+var (
+	mutex sync.Mutex
+)
+
+// Credentials contains AccessKeyID and AccessKeySecret to grant access to AlibabaCloud OpenAPI
+type Credentials struct {
+	AccessKeyID     string
+	AccessKeySecret string
+}
+
+// FetchAlibabaCredentialsIniFromSecret fetches secret from cloud credentials and returns Credentials
+// which provides access key & secret key.
+func FetchAlibabaCredentialsIniFromSecret(secret *corev1.Secret) (*Credentials, error) {
+	creds, ok := secret.Data["credentials"]
+	if !ok {
+		return nil, fmt.Errorf("failed to fetch key 'credentials' in secret data")
+	}
+	f, err := ioutil.TempFile("", "alibaba-creds-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	_, err = f.Write(creds)
+	if err != nil {
+		return nil, err
+	}
+	// This lock is used to prevent the environment variable from being updated while we
+	// are using the environment variable to call the Alibaba credential provider chain.
+	mutex.Lock()
+	defer mutex.Unlock()
+	os.Setenv(provider.ENVCredentialFile, f.Name())
+	defer os.Unsetenv(provider.ENVCredentialFile)
+	// use Alibaba provider initialization
+	p := provider.NewProfileProvider("default")
+	// get a valid auth credential
+	authCred, err := p.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alibabacloud auth credentials: %w", err)
+	}
+
+	c, ok := authCred.(*credentials.AccessKeyCredential)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert the credential to an AccessKeyCredential")
+	}
+
+	return &Credentials{
+		AccessKeyID:     c.AccessKeyId,
+		AccessKeySecret: c.AccessKeySecret,
+	}, nil
+}

--- a/pkg/dns/alibaba/util/numbers.go
+++ b/pkg/dns/alibaba/util/numbers.go
@@ -1,0 +1,13 @@
+package util
+
+// Clamp return the clamped value of val.
+func Clamp(val, min, max int64) int64 {
+	if val < min {
+		return min
+	}
+	if val > max {
+		return max
+	}
+
+	return val
+}

--- a/pkg/dns/alibaba/util/numbers_test.go
+++ b/pkg/dns/alibaba/util/numbers_test.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClamp(t *testing.T) {
+	cases := []struct {
+		val      int64
+		min      int64
+		max      int64
+		excepted int64
+	}{
+		{30, 5, 60, 30},
+		{30, 60, 300, 60},
+		{300, 30, 60, 60},
+		{30, 30, 60, 30},
+		{60, 30, 60, 60},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.excepted, Clamp(c.val, c.min, c.max))
+	}
+}


### PR DESCRIPTION
Here's a follow-up PR for #636 to get some code improvements based on the code review, and unit test for Alibaba DNS part.

This PR changes the logic of retrieving private zone ID by moving it to before every request, and caches it in local (dns.go:226).

And unit test is still work in progress, it should be pushed in a few days.

Signed-off-by: xiayu.lyt <xiayu.lyt@alibaba-inc.com>