### PR TITLE
CFE-72: make infrastructure resource tags updatable

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -105,6 +105,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	if err := c.Watch(&source.Kind{Type: &configv1.Ingress{}}, handler.EnqueueRequestsFromMapFunc(reconciler.ingressConfigToIngressController)); err != nil {
 		return nil, err
 	}
+	if err := c.Watch(&source.Kind{Type: &configv1.Infrastructure{}}, handler.EnqueueRequestsFromMapFunc(reconciler.ingressConfigToIngressController)); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -221,6 +221,7 @@ var (
 			// local-with-fallback annotation for kube-proxy (see
 			// <https://bugzilla.redhat.com/show_bug.cgi?id=1960284>).
 			localWithFallbackAnnotation,
+			awsLBAdditionalResourceTags,
 		)
 
 		// Azure and GCP support switching between internal and external

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -677,6 +677,13 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Annotations[awsLBAdditionalResourceTags] = "key=value"
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR adds a watch for Infrastructure type to update AWS tags when changed