### PR TITLE
Bug 2039339: Upgradeable Condition in Operator and IC status

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	iov1 "github.com/openshift/api/operatoringress/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -23,6 +22,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -827,7 +827,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
 	}
 
-	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig))
+	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, deploymentRef, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig))
 
 	SetIngressControllerNLBMetric(ci)
 
@@ -842,7 +842,7 @@ func IsStatusDomainSet(ingress *operatorv1.IngressController) bool {
 	return true
 }
 
-// IsPRoxyProtocolNeeded checks whether proxy protocol is needed based
+// IsProxyProtocolNeeded checks whether proxy protocol is needed based
 // upon the given ic and platform.
 func IsProxyProtocolNeeded(ic *operatorv1.IngressController, platform *configv1.PlatformStatus) (bool, error) {
 	if platform == nil {

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	oputil "github.com/openshift/cluster-ingress-operator/pkg/util"
@@ -19,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -251,11 +251,7 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ci.Namespace, ci.Name, err)
 	}
-	proxyNeeded, err := IsProxyProtocolNeeded(ci, platform)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to determine if proxy protocol is proxyNeeded for ingresscontroller %q: %v", ci.Name, err)
-	}
-	wantLBS, desiredLBService, err := desiredLoadBalancerService(ci, deploymentRef, platform, proxyNeeded)
+	wantLBS, desiredLBService, err := desiredLoadBalancerService(ci, deploymentRef, platform)
 	if err != nil {
 		return false, nil, err
 	}
@@ -312,7 +308,7 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 // ingresscontroller, or nil if an LB service isn't desired. An LB service is
 // desired if the high availability type is Cloud. An LB service will declare an
 // owner reference to the given deployment.
-func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef metav1.OwnerReference, platform *configv1.PlatformStatus, proxyNeeded bool) (bool, *corev1.Service, error) {
+func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef metav1.OwnerReference, platform *configv1.PlatformStatus) (bool, *corev1.Service, error) {
 	if ci.Status.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
 		return false, nil, nil
 	}
@@ -336,8 +332,9 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 	if service.Annotations == nil {
 		service.Annotations = map[string]string{}
 	}
-
-	if proxyNeeded {
+	if proxyNeeded, err := IsProxyProtocolNeeded(ci, platform); err != nil {
+		return false, nil, fmt.Errorf("failed to determine if proxy protocol is proxyNeeded for ingresscontroller %q: %v", ci.Name, err)
+	} else if proxyNeeded {
 		service.Annotations[awsLBProxyProtocolAnnotation] = "*"
 	}
 
@@ -589,9 +586,15 @@ func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev
 	// avoid problems, make sure the previous release blocks upgrades when
 	// the user has modified an annotation or spec field that the new
 	// release manages.
+	return loadBalancerServiceAnnotationsChanged(current, expected, managedLoadBalancerServiceAnnotations)
+}
+
+// loadBalancerServiceAnnotationsChanged checks if the annotations on the expected Service
+// match the ones on the current Service.
+func loadBalancerServiceAnnotationsChanged(current, expected *corev1.Service, annotations sets.String) (bool, *corev1.Service) {
 	annotationCmpOpts := []cmp.Option{
 		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
-			return !managedLoadBalancerServiceAnnotations.Has(k)
+			return !annotations.Has(k)
 		}),
 	}
 	if cmp.Equal(current.Annotations, expected.Annotations, annotationCmpOpts...) {
@@ -630,4 +633,35 @@ func IsServiceInternal(service *corev1.Service) bool {
 		}
 	}
 	return false
+}
+
+// loadBalancerServiceTagsModified verifies that none of the managedAnnotations have been changed and also the AWS tags annotation
+func loadBalancerServiceTagsModified(current, expected *corev1.Service) (bool, *corev1.Service) {
+	ignoredAnnotations := managedLoadBalancerServiceAnnotations.Union(sets.NewString(awsLBAdditionalResourceTags))
+	return loadBalancerServiceAnnotationsChanged(current, expected, ignoredAnnotations)
+}
+
+// loadBalancerServiceIsUpgradeable returns an error value indicating if the
+// load balancer service is safe to upgrade.  In particular, if the current
+// service matches the desired service, then the service is upgradeable, and the
+// return value is nil.  Otherwise, if something or someone else has modified
+// the service, then the return value is a non-nil error indicating that the
+// modification must be reverted before upgrading is allowed.
+func loadBalancerServiceIsUpgradeable(ic *operatorv1.IngressController, deploymentRef metav1.OwnerReference, current *corev1.Service, platform *configv1.PlatformStatus) error {
+	want, desired, err := desiredLoadBalancerService(ic, deploymentRef, platform)
+	if err != nil {
+		return err
+	}
+
+	if !want {
+		return nil
+	}
+
+	changed, updated := loadBalancerServiceTagsModified(current, desired)
+	if changed {
+		diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+		return fmt.Errorf("load balancer service has been modified; changes must be reverted before upgrading: %s", diff)
+	}
+
+	return nil
 }

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -327,7 +327,7 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 			t.Errorf("test %q failed; expected IsProxyProtocolNeeded to return %v, got %v", tc.description, tc.proxyNeeded, proxyNeeded)
 		}
 
-		haveSvc, svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig.Status.PlatformStatus, proxyNeeded)
+		haveSvc, svc, err := desiredLoadBalancerService(ic, deploymentRef, infraConfig.Status.PlatformStatus)
 		switch {
 		case err != nil:
 			t.Errorf("test %q failed; unexpected error from desiredLoadBalancerService for endpoint publishing strategy type %v: %v", tc.description, tc.strategyType, err)
@@ -677,52 +677,62 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags annotation changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"] = "Key3=Value3,Key4=Value4"
+			},
+			expect: false,
+		},
 	}
 
 	for _, tc := range testCases {
-		original := corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval": "5",
-				},
-				Namespace: "openshift-ingress",
-				Name:      "router-original",
-				UID:       "1",
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP:             "1.2.3.4",
-				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
-				HealthCheckNodePort:   int32(33333),
-				Ports: []corev1.ServicePort{
-					{
-						Name:       "http",
-						NodePort:   int32(33334),
-						Port:       int32(80),
-						Protocol:   corev1.ProtocolTCP,
-						TargetPort: intstr.FromString("http"),
+		t.Run(tc.description, func(t *testing.T) {
+			original := corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":     "5",
+						"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "Key1=Value1,Key2=Value2",
 					},
-					{
-						Name:       "https",
-						NodePort:   int32(33335),
-						Port:       int32(443),
-						Protocol:   corev1.ProtocolTCP,
-						TargetPort: intstr.FromString("https"),
+					Namespace: "openshift-ingress",
+					Name:      "router-original",
+					UID:       "1",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP:             "1.2.3.4",
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					HealthCheckNodePort:   int32(33333),
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							NodePort:   int32(33334),
+							Port:       int32(80),
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("http"),
+						},
+						{
+							Name:       "https",
+							NodePort:   int32(33335),
+							Port:       int32(443),
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("https"),
+						},
 					},
+					Selector: map[string]string{
+						"foo": "bar",
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
 				},
-				Selector: map[string]string{
-					"foo": "bar",
-				},
-				Type: corev1.ServiceTypeLoadBalancer,
-			},
-		}
-		mutated := original.DeepCopy()
-		tc.mutate(mutated)
-		if changed, updated := loadBalancerServiceChanged(&original, mutated); changed != tc.expect {
-			t.Errorf("%s, expect loadBalancerServiceChanged to be %t, got %t", tc.description, tc.expect, changed)
-		} else if changed {
-			if changedAgain, _ := loadBalancerServiceChanged(mutated, updated); changedAgain {
-				t.Errorf("%s, loadBalancerServiceChanged does not behave as a fixed point function", tc.description)
 			}
-		}
+			mutated := original.DeepCopy()
+			tc.mutate(mutated)
+			if changed, updated := loadBalancerServiceChanged(&original, mutated); changed != tc.expect {
+				t.Errorf("expected loadBalancerServiceChanged to be %t, got %t", tc.expect, changed)
+			} else if changed {
+				if changedAgain, _ := loadBalancerServiceChanged(mutated, updated); changedAgain {
+					t.Error("loadBalancerServiceChanged does not behave as a fixed point function")
+				}
+			}
+		})
 	}
 }

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1358,3 +1358,80 @@ func TestZoneInConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeIngressUpgradeableCondition(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*corev1.Service)
+		expect      bool
+	}{
+		{
+			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tag stays the same",
+			mutate: func(svc *corev1.Service) {
+				svc.Annotations[awsLBAdditionalResourceTags] = "Key1=Value1"
+			},
+			expect: true,
+		},
+		{
+			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tag annotation changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Annotations[awsLBAdditionalResourceTags] = "Key2=Value2"
+			},
+			expect: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ic := &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+					},
+				},
+			}
+			trueVar := true
+			deploymentRef := metav1.OwnerReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "router-default",
+				UID:        "1",
+				Controller: &trueVar,
+			}
+			platformStatus := &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+				AWS: &configv1.AWSPlatformStatus{
+					ResourceTags: []configv1.AWSResourceTag{
+						{
+							Key:   "Key1",
+							Value: "Value1",
+						},
+					},
+				},
+			}
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus)
+			if err != nil {
+				t.Errorf("%q: unexpected error from desiredLoadBalancerService: %v", tc.description, err)
+				return
+			}
+			if !wantSvc {
+				t.Errorf("%q: unexpected false value from desiredLoadBalancerService", tc.description)
+				return
+			}
+			tc.mutate(service)
+
+			expectedStatus := operatorv1.ConditionFalse
+			if tc.expect {
+				expectedStatus = operatorv1.ConditionTrue
+			}
+
+			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus)
+			if actual.Status != expectedStatus {
+				t.Errorf("%q: expected Upgradeable to be %q, got %q", tc.description, expectedStatus, actual.Status)
+			}
+
+		})
+	}
+}

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,11 +11,12 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-
 	iov1 "github.com/openshift/api/operatoringress/v1"
+
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	oputil "github.com/openshift/cluster-ingress-operator/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -160,6 +162,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			r.config.CanaryImage,
 		),
 		computeOperatorDegradedCondition(state.IngressControllers),
+		computeOperatorUpgradeableCondition(state.IngressControllers),
 	)
 
 	if !operatorStatusesEqual(*oldStatus, co.Status) {
@@ -331,6 +334,45 @@ func computeOperatorDegradedCondition(ingresses []operatorv1.IngressController) 
 	}
 
 	return degradedCondition
+}
+
+// computeOperatorUpgradeableCondition computes the operator's Upgradeable
+// status condition.
+func computeOperatorUpgradeableCondition(ingresses []operatorv1.IngressController) configv1.ClusterOperatorStatusCondition {
+	nonUpgradeableIngresses := make(map[*operatorv1.IngressController]operatorv1.OperatorCondition)
+	for i, ingress := range ingresses {
+		for j, cond := range ingress.Status.Conditions {
+			if cond.Type == operatorv1.OperatorStatusTypeUpgradeable && cond.Status == operatorv1.ConditionFalse {
+				nonUpgradeableIngresses[&ingresses[i]] = ingress.Status.Conditions[j]
+			}
+		}
+	}
+	if len(nonUpgradeableIngresses) == 0 {
+		return configv1.ClusterOperatorStatusCondition{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+			Reason: "IngressControllersUpgradeable",
+		}
+	}
+	message := "Some ingresscontrollers are not upgradeable:"
+	// Sort keys so that the result is deterministic.
+	keys := make([]*operatorv1.IngressController, 0, len(nonUpgradeableIngresses))
+	for ingress := range nonUpgradeableIngresses {
+		keys = append(keys, ingress)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return oputil.ObjectLess(&keys[i].ObjectMeta, &keys[j].ObjectMeta)
+	})
+	for _, ingress := range keys {
+		cond := nonUpgradeableIngresses[ingress]
+		message = fmt.Sprintf("%s ingresscontroller %q is not upgradeable: %s: %s", message, ingress.Name, cond.Reason, cond.Message)
+	}
+	return configv1.ClusterOperatorStatusCondition{
+		Type:    configv1.OperatorUpgradeable,
+		Status:  configv1.ConditionFalse,
+		Reason:  "IngressControllersNotUpgradeable",
+		Message: message,
+	}
 }
 
 // computeOperatorProgressingCondition computes the operator's current Progressing status state.


### PR DESCRIPTION
This change sets the `Upgradeable` condition for the IngressController. If the corresponding load balancer _Service_ has been modified, particularly the AWS resource tags fields then the IngressController is marked as `Upgradable=False`. This in turn marks the operator as `Upgradeable=False`.