### PR TITLE
no CredentialsRequests in ibm-cloud-managed

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-ingress
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
@@ -35,7 +34,6 @@ metadata:
   name: openshift-ingress-azure
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
@@ -56,7 +54,6 @@ metadata:
   name: openshift-ingress-gcp
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/ibm-cloud-managed-cleanup.yaml
+++ b/manifests/ibm-cloud-managed-cleanup.yaml
@@ -1,0 +1,26 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-ingress
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-ingress-azure
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-ingress-gcp
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
The ibm-cloud-managed profile doesn't use the cloud-credential-operator.
The CredentialsRequest CRs should not be installed in that environment.

Unmark the existing CredentialsRequests so they are no longer installed
in ibm-cloud-managed.

Create a list of previously-installed CredentialsRequests so that they
are cleaned up by the CVO only on the ibm-cloud-managed profile.

xref: https://issues.redhat.com/browse/CCO-177