### PR TITLE
BUG 2037447: Disable keepalive for canary probe

### DIFF
--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -59,8 +59,9 @@ func probeRouteEndpoint(route *routev1.Route) error {
 		Transport: &http.Transport{
 			// Use the cluster-wide proxy if it is available in the
 			// pod's environment.
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:             http.ProxyFromEnvironment,
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: true, // BZ#2037447
 		},
 	}
 	response, err := client.Do(request)


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2037447

If keepalives are enabled then we see an accumulation of established
canary connections that remain in ESTABLISHED state. Given that we
only probe once per minute it's not clear we gain anything from
keepalives so let's just disable them when probing the canary host.

This helps prevent resource exhaustion.