### PR TITLE
Properly reconcile and react to changes in cluster operator resource

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -65,6 +65,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := c.Watch(&source.Kind{Type: &configv1.ClusterOperator{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return nil, err
+	}
 	if err := c.Watch(&source.Kind{Type: &operatorv1.IngressController{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When an external actor modifies the clusteroperators/ingress resource, it takes 10h[1] for the ingress operator to react and reconcile.
This fix (hopefully) makes the ingress operator reconcile the status when clusteroperator resource change, so it should react to any modification immediately. 

[1] https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#example-New