### PR TITLE
Bug 2055470: Normalize the AWS internal LB annotation value

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -291,6 +291,14 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 				return haveLBS, currentLBService, err
 			}
 		}
+		if updated, err := r.normalizeLoadBalancerServiceAnnotations(currentLBService); err != nil {
+			return true, currentLBService, fmt.Errorf("failed to normalize annotations for load balancer service: %w", err)
+		} else if updated {
+			haveLBS, currentLBService, err = r.currentLoadBalancerService(ci)
+			if err != nil {
+				return haveLBS, currentLBService, err
+			}
+		}
 		deleteIfScopeChanged := false
 		if _, ok := ci.Annotations[autoDeleteLoadBalancerAnnotation]; ok {
 			deleteIfScopeChanged = true
@@ -482,6 +490,34 @@ func (r *reconciler) deleteLoadBalancerServiceFinalizer(service *corev1.Service)
 	log.Info("removed finalizer from load balancer service", "namespace", service.Namespace, "name", service.Name)
 
 	return true, nil
+}
+
+// normalizeLoadBalancerServiceAnnotations normalizes annotations for the
+// provided LoadBalancer-type service.
+func (r *reconciler) normalizeLoadBalancerServiceAnnotations(service *corev1.Service) (bool, error) {
+	// On AWS, the service.beta.kubernetes.io/aws-load-balancer-internal
+	// annotation can have either the value "0.0.0.0/0" or the value "true"
+	// to indicate that the service load-balancer should be internal.
+	// OpenShift 4.7 and earlier use the value "0.0.0.0/0", and OpenShift
+	// 4.8 and later use the value "true".  A service that was created on an
+	// older cluster might have the value "0.0.0.0/0".  Normalize the value
+	// to ensure that comparisons that use "true" behave as expected.  See
+	// <https://bugzilla.redhat.com/show_bug.cgi?id=2055470>.
+	if v, ok := service.Annotations[awsInternalLBAnnotation]; ok && v == "0.0.0.0/0" {
+		// Mutate a copy to avoid assuming we know where the current one came from
+		// (i.e. it could have been from a cache).
+		updated := service.DeepCopy()
+		updated.Annotations[awsInternalLBAnnotation] = "true"
+		if err := r.client.Update(context.TODO(), updated); err != nil {
+			return false, fmt.Errorf("failed to normalize %s annotation on service %s/%s: %w", awsInternalLBAnnotation, service.Namespace, service.Name, err)
+		}
+
+		log.Info("normalized annotation", "namespace", service.Namespace, "name", service.Name, "annotation", awsInternalLBAnnotation, "old", v, "new", updated.Annotations[awsInternalLBAnnotation])
+
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // finalizeLoadBalancerService removes the "ingress.openshift.io/operator" finalizer

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -804,6 +804,43 @@ func TestInternalLoadBalancer(t *testing.T) {
 			t.Fatalf("expected %s=%s, found %s=%s", name, expected, name, actual)
 		}
 	}
+
+	// On AWS, verify that the operator normalizes the
+	// service.beta.kubernetes.io/aws-load-balancer-internal=0.0.0.0/0
+	// annotation to replace "0.0.0.0/0" with "true".  See
+	// <https://bugzilla.redhat.com/show_bug.cgi?id=2055470>.
+	if platform == configv1.AWSPlatformType {
+		const annotation = "service.beta.kubernetes.io/aws-load-balancer-internal"
+
+		// Set the annotation value to "0.0.0.0/0".
+		if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+			t.Fatalf("failed to get LoadBalancer service: %v", err)
+		}
+		lbService.Annotations[annotation] = "0.0.0.0/0"
+		if err := kclient.Update(context.TODO(), lbService); err != nil {
+			t.Errorf("failed to update LoadBalancer service: %w", err)
+		}
+
+		// Verify that the operator reverts the annotation value to
+		// "true".
+		err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+			if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+				t.Logf("failed to get LoadBalancer service: %v", err)
+				return false, nil
+			}
+			if v, ok := lbService.Annotations[annotation]; !ok {
+				t.Logf("load balancer has no %q annotation: %v", annotation, lbService.Annotations)
+				return false, nil
+			} else if v != "true" {
+				t.Logf("expected %s=%s, found %s=%s", annotation, "true", annotation, v)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Errorf("failed to observe expected annotation on load balancer service %s: %w", controller.LoadBalancerServiceName(ic), err)
+		}
+	}
 }
 
 // TestInternalLoadBalancerGlobalAccessGCP creates an ingresscontroller


### PR DESCRIPTION
The AWS cloud-provider implementation checks the `service.beta.kubernetes.io/aws-load-balancer-internal` service annotation to determine whether a service load-balancer (SLB) should be internal.  The cloud-provider implementation recognizes both the value "0.0.0.0/0" and the value "true" as indicating that the SLB should be internal.  OpenShift 4.7 and earlier use the value "0.0.0.0/0", and OpenShift 4.8 and later use the value "true".  A service that was created on an older cluster might have the value "0.0.0.0/0", which can cause comparisons that check for the "true" value to return the wrong result.  This PR adds logic to normalize the annotation value to "true".

Follow-up to <https://github.com/openshift/cluster-ingress-operator/pull/543> and to <https://github.com/openshift/cluster-ingress-operator/pull/582>.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`ensureLoadBalancerService`): Call the new `normalizeLoadBalancerServiceAnnotations` method to normalize the AWS internal LB annotation.
(`normalizeLoadBalancerServiceAnnotations`): New method.  Normalize the `service.beta.kubernetes.io/aws-load-balancer-internal` service annotation by replacing the value "0.0.0.0/0" with the value "true".
* `test/e2e/operator_test.go` (`TestInternalLoadBalancer`): Verify that the operator updates the old "0.0.0.0/0" annotation value to "true".
