### PR TITLE
Bug 2058699: Upgradeable Condition in Operator and IC status

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	iov1 "github.com/openshift/api/operatoringress/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -23,6 +22,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -799,7 +799,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
 	}
 
-	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig))
+	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, deploymentRef, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig))
 
 	return retryable.NewMaybeRetryableAggregate(errs)
 }
@@ -812,7 +812,7 @@ func IsStatusDomainSet(ingress *operatorv1.IngressController) bool {
 	return true
 }
 
-// IsPRoxyProtocolNeeded checks whether proxy protocol is needed based
+// IsProxyProtocolNeeded checks whether proxy protocol is needed based
 // upon the given ic and platform.
 func IsProxyProtocolNeeded(ic *operatorv1.IngressController, platform *configv1.PlatformStatus) (bool, error) {
 	if platform == nil {

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -11,12 +11,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	iov1 "github.com/openshift/api/operatoringress/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/retryableerror"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
+
 	oputil "github.com/openshift/cluster-ingress-operator/pkg/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -44,7 +46,7 @@ type expectedCondition struct {
 
 // syncIngressControllerStatus computes the current status of ic and
 // updates status upon any changes since last sync.
-func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS) error {
+func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, deploymentRef metav1.OwnerReference, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS, infraConfig *configv1.Infrastructure) error {
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
 		return fmt.Errorf("deployment has invalid spec.selector: %v", err)
@@ -66,6 +68,7 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, degradedCondition)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressUpgradeableCondition(ic, deploymentRef, service, infraConfig.Status.PlatformStatus))
 	updated.Status.Conditions = PruneConditions(updated.Status.Conditions)
 
 	if !IngressStatusesEqual(updated.Status, ic.Status) {
@@ -526,6 +529,31 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition, 
 		err = retryableerror.New(errors.New("IngressController may become degraded soon: "+grace), requeueAfter)
 	}
 	return condition, err
+}
+
+// computeIngressUpgradeableCondition computes the IngressController's "Upgradeable" status condition.
+func computeIngressUpgradeableCondition(ic *operatorv1.IngressController, deploymentRef metav1.OwnerReference, service *corev1.Service, platform *configv1.PlatformStatus) operatorv1.OperatorCondition {
+	var errs []error
+
+	if service != nil {
+		errs = append(errs, loadBalancerServiceIsUpgradeable(ic, deploymentRef, service, platform))
+	}
+
+	if err := kerrors.NewAggregate(errs); err != nil {
+		return operatorv1.OperatorCondition{
+			Type:    operatorv1.OperatorStatusTypeUpgradeable,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "OperandsNotUpgradeable",
+			Message: fmt.Sprintf("One or more managed resources are not upgradeable: %s", err),
+		}
+	}
+
+	return operatorv1.OperatorCondition{
+		Type:    operatorv1.OperatorStatusTypeUpgradeable,
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "Upgradeable",
+		Message: "IngressController is upgradeable.",
+	}
 }
 
 func formatConditions(conditions []*operatorv1.OperatorCondition) string {

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -500,6 +501,70 @@ func TestComputeOperatorStatusVersions(t *testing.T) {
 		}
 		if !cmp.Equal(versions, expectedVersions, versionsCmpOpts...) {
 			t.Fatalf("%q: expected %v, got %v", tc.description, expectedVersions, versions)
+		}
+	}
+}
+
+func TestComputeOperatorUpgradeableCondition(t *testing.T) {
+	testCases := []struct {
+		description                   string
+		ingresscontrollersUpgradeable []bool
+		expectUpgradeable             bool
+	}{
+		{
+			description:                   "no ingresscontrollers exist",
+			ingresscontrollersUpgradeable: []bool{},
+			expectUpgradeable:             true,
+		},
+		{
+			description:                   "no ingresscontrollers are upgradeable",
+			ingresscontrollersUpgradeable: []bool{false, false},
+			expectUpgradeable:             false,
+		},
+		{
+			description:                   "some ingresscontrollers are upgradeable",
+			ingresscontrollersUpgradeable: []bool{false, true},
+			expectUpgradeable:             false,
+		},
+		{
+			description:                   "all ingresscontrollers are upgradeable",
+			ingresscontrollersUpgradeable: []bool{true, true},
+			expectUpgradeable:             true,
+		},
+	}
+
+	for _, tc := range testCases {
+		ingresscontrollers := []operatorv1.IngressController{}
+		for _, upgradeable := range tc.ingresscontrollersUpgradeable {
+			upgradeableStatus := operatorv1.ConditionFalse
+			if upgradeable {
+				upgradeableStatus = operatorv1.ConditionTrue
+			}
+			ic := operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Conditions: []operatorv1.OperatorCondition{{
+						Type:   "Upgradeable",
+						Status: upgradeableStatus,
+					}},
+				},
+			}
+			ingresscontrollers = append(ingresscontrollers, ic)
+		}
+
+		expected := configv1.ClusterOperatorStatusCondition{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionFalse,
+		}
+		if tc.expectUpgradeable {
+			expected.Status = configv1.ConditionTrue
+		}
+
+		actual := computeOperatorUpgradeableCondition(ingresscontrollers)
+		conditionsCmpOpts := []cmp.Option{
+			cmpopts.IgnoreFields(configv1.ClusterOperatorStatusCondition{}, "LastTransitionTime", "Reason", "Message"),
+		}
+		if !cmp.Equal(actual, expected, conditionsCmpOpts...) {
+			t.Fatalf("%q: expected %#v, got %#v", tc.description, expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
This change sets the `Upgradeable` condition for the IngressController. If the corresponding load balancer _Service_ has been modified, particularly the AWS resource tags fields then the IngressController is marked as `Upgradable=False`. This in turn marks the operator as `Upgradeable=False`.