### PR TITLE
Bug 2079517: Use externalTrafficPolicy: Cluster with OVN

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -760,7 +760,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 
 	var lbService *corev1.Service
 	var wildcardRecord *iov1.DNSRecord
-	if haveLB, lb, err := r.ensureLoadBalancerService(ci, deploymentRef, infraConfig); err != nil {
+	if haveLB, lb, err := r.ensureLoadBalancerService(ci, deploymentRef, infraConfig, networkConfig); err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure load balancer service for %s: %v", ci.Name, err))
 	} else {
 		lbService = lb
@@ -799,7 +799,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		errs = append(errs, fmt.Errorf("failed to list pods in namespace %q: %v", operatorcontroller.DefaultOperatorNamespace, err))
 	}
 
-	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, deploymentRef, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig))
+	errs = append(errs, r.syncIngressControllerStatus(ci, deployment, deploymentRef, pods.Items, lbService, operandEvents.Items, wildcardRecord, dnsConfig, infraConfig, networkConfig))
 
 	return retryable.NewMaybeRetryableAggregate(errs)
 }

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1312,7 +1312,12 @@ func TestComputeIngressUpgradeableCondition(t *testing.T) {
 					},
 				},
 			}
-			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus)
+			networkConfig := &configv1.Network{
+				Spec: configv1.NetworkSpec{
+					NetworkType: "OpenShiftSDN",
+				},
+			}
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, networkConfig.Spec.NetworkType)
 			if err != nil {
 				t.Errorf("%q: unexpected error from desiredLoadBalancerService: %v", tc.description, err)
 				return
@@ -1334,7 +1339,7 @@ func TestComputeIngressUpgradeableCondition(t *testing.T) {
 				expectedStatus = operatorv1.ConditionTrue
 			}
 
-			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret)
+			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, networkConfig, secret)
 			if actual.Status != expectedStatus {
 				t.Errorf("%q: expected Upgradeable to be %q, got %q", tc.description, expectedStatus, actual.Status)
 			}


### PR DESCRIPTION
OVN-Kubernetes in OpenShift 4.9 and earlier does not support `externalTrafficPolicy: Local`, and specifying it is reported to result in imbalanced traffic for some users.  This change checks the cluster network type and sets `externalTrafficPolicy: Cluster` on the LoadBalancer-type service that the operator creates for ingress if the network type is "OVN-Kubernetes".

* `pkg/operator/controller/ingress/controller.go` (`ensureIngressController`): Pass the network config to `ensureLoadBalancerService` and `syncIngressControllerStatus`.
* `pkg/operator/controller/ingress/load_balancer_service.go` (`ensureLoadBalancerService`, `loadBalancerServiceIsUpgradeable`): Add a parameter for the network config.  Pass the network type from the network config to `desiredLoadBalancerService`.
(`desiredLoadBalancerService`): Add a parameter for the network type.  Set `externalTrafficPolicy: Cluster` if the network type is "OVN-Kubernetes".
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestDesiredLoadBalancerService`): Add a test case for OVN-Kubernetes.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Add a parameter for the network config.  Pass the config to `computeIngressUpgradeableCondition`.
(`computeIngressUpgradeableCondition`): Add a parameter for the network config.  Pass the network config to `loadBalancerServiceIsUpgradeable`.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputeIngressUpgradeableCondition`): Pass the network type to `desiredLoadBalancerService` and the network config to `computeIngressUpgradeableCondition`.

---

This PR includes commits from #711 because we want #711 to merge first, and it includes conflicting changes.  The first two commits in this PR can be ignored by reviewers.  

/hold

---

Surya, can you verify that this change is correct?  In particular, I want to be sure we're checking the right API field for the right value and that the logic behind this PR is sound at a high level.  

/assign @tssurya 