### PR TITLE
Fix incorrect related object references in ClusterOperator status.

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -122,12 +122,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		},
 		{
 			Group:     operatorv1.GroupName,
-			Resource:  "IngressController",
+			Resource:  "ingresscontrollers",
 			Namespace: r.config.Namespace,
 		},
 		{
 			Group:     iov1.GroupVersion.Group,
-			Resource:  "DNSRecord",
+			Resource:  "dnsrecords",
 			Namespace: r.config.Namespace,
 		},
 	}


### PR DESCRIPTION
origin will be adding tests shortly to fail on this, so we want to get
this fixed before those go in.
