### PR TITLE
NE-825: Update router to use random balancing algorithm once again

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -312,7 +312,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		{"ROUTER_H1_CASE_ADJUST", false, ""},
 		{"ROUTER_INSPECT_DELAY", false, ""},
 		{"ROUTER_IP_V4_V6_MODE", false, ""},
-		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "leastconn"},
+		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "random"},
 		{"ROUTER_LOG_FACILITY", false, ""},
 		{"ROUTER_LOG_LEVEL", false, ""},
 		{"ROUTER_LOG_MAX_LENGTH", false, ""},
@@ -455,7 +455,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	var expectedReplicas int32 = 8
 	ic.Spec.Replicas = &expectedReplicas
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"loadBalancingAlgorithm":"random","dynamicConfigManager":"false","reloadInterval":15}`),
+		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn","dynamicConfigManager":"false","reloadInterval":15}`),
 	}
 	ic.Spec.HttpErrorCodePages = configv1.ConfigMapNameReference{
 		Name: "my-custom-error-code-pages",
@@ -501,7 +501,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
 	tests := []envData{
 		{"ROUTER_HAPROXY_CONFIG_MANAGER", false, ""},
-		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "random"},
+		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "leastconn"},
 		{"ROUTER_TCP_BALANCE_SCHEME", true, "source"},
 		{"ROUTER_MAX_CONNECTIONS", true, "auto"},
 		{"RELOAD_INTERVAL", true, "15s"},
@@ -536,7 +536,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 
 	checkDeploymentHasEnvSorted(t, deployment)
 
-	// Any value for loadBalancingAlgorithm other than "random" should be
+	// Any value for loadBalancingAlgorithm other than "leastconn" should be
 	// ignored.
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
 		Raw: []byte(`{"loadBalancingAlgorithm":"source","dynamicConfigManager":"true"}`),
@@ -576,7 +576,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 
 	tests = []envData{
 		{"ROUTER_HAPROXY_CONFIG_MANAGER", true, "true"},
-		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "leastconn"},
+		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "random"},
 		{"ROUTER_TCP_BALANCE_SCHEME", true, "source"},
 		{"ROUTER_MAX_CONNECTIONS", true, "40000"},
 		{"RELOAD_INTERVAL", true, "5s"},

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2286,7 +2286,7 @@ func TestUniqueIdHeader(t *testing.T) {
 }
 
 // TestLoadBalancingAlgorithmUnsupportedConfigOverride verifies that the
-// operator configures router pod replicas to use the "random" load-balancing
+// operator configures router pod replicas to use the "leastconn" load-balancing
 // algorithm for non-passthrough routes if the ingresscontroller is so
 // configured using an unsupported config override.  The test also verifies that
 // the operator always configures router pod replicas to use the "source"
@@ -2308,7 +2308,7 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
-	expectedAlgorithm := "leastconn"
+	expectedAlgorithm := "random"
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
 		t.Fatalf("expected initial deployment to have ROUTER_LOAD_BALANCE_ALGORITHM=%s: %v", expectedAlgorithm, err)
 	}
@@ -2320,12 +2320,12 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("failed to get ingresscontroller: %v", err)
 	}
 	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"loadBalancingAlgorithm":"random"}`),
+		Raw: []byte(`{"loadBalancingAlgorithm":"leastconn"}`),
 	}
 	if err := kclient.Update(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
-	expectedAlgorithm = "random"
+	expectedAlgorithm = "leastconn"
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_LOAD_BALANCE_ALGORITHM=%s: %v", expectedAlgorithm, err)
 	}


### PR DESCRIPTION
After attempting to use random as the default algorithm and subsequently
reverting, we discovered that reducing haproxy's weight to 1 for backends
with a single service significantly reduces the memory overhead of
the random balance algorithm and provides the same exactly functionality.

We are now turning back on random again since we have mitigated the memory
overhead issue.