### PR TITLE
MGMT-9797: Determine number of replicas according to `DefaultPlacement`

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -450,7 +450,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
+	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -644,7 +644,7 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}

--- a/pkg/operator/controller/ingress/replicas.go
+++ b/pkg/operator/controller/ingress/replicas.go
@@ -1,0 +1,25 @@
+package ingress
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// DetermineReplicas implements the replicas choice algorithm as described in
+// the documentation for the IngressController replicas parameter. Used both in
+// determining the number of replicas for the default IngressController and in
+// determining the number of replicas in the Deployments corresponding to
+// IngressController resources in which the number of replicas is unset
+func DetermineReplicas(ingressConfig *configv1.Ingress, infraConfig *configv1.Infrastructure) int32 {
+	// DefaultPlacement affects which topology field we're interested in
+	topology := infraConfig.Status.InfrastructureTopology
+	if ingressConfig.Status.DefaultPlacement == configv1.DefaultPlacementControlPlane {
+		topology = infraConfig.Status.ControlPlaneTopology
+	}
+
+	if topology == configv1.SingleReplicaTopologyMode {
+		return 1
+	}
+
+	// TODO: Set the replicas value to the number of workers.
+	return 2
+}


### PR DESCRIPTION
Implementation of the https://github.com/openshift/enhancements/blob/master/enhancements/single-node/single-node-openshift-with-workers.md
enhancement.

The installation process now sets the new `DefaultPlacement`
API field in the Ingress Config CR's status (https://github.com/openshift/installer/pull/5746
still unmerged at the time of writing this message).

This PR introduces two new changes -

- While creating the default `IngressController`, or while creating
deployments corresponding to `IngressController` resources which
don't have their number of replicas set, we determine the number
of replicas according to the value of the new `DefaultPlacement`
parameter.

- When creating Deployments out of `IngressController` resources
which don't have their nodeSelector set, we determine the default
nodeSelector according to the new `DefaultPlacement` API field.

See the enhancement, new API documentation, implementation and code
comments in the diff for the exact details on how, why and when we
set the fields and to which values.