### PR TITLE
Bug 2072106: Fix test `Errorf` limitation in go 1.18

### DIFF
--- a/pkg/dns/ibm/dns_test.go
+++ b/pkg/dns/ibm/dns_test.go
@@ -139,7 +139,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			if !tc.expectedErr && err != nil {
-				t.Errorf("expected nil err, got %w", err)
+				t.Errorf("expected nil err, got %v", err)
 			}
 
 			recordedCall, _ := dnsService.RecordedCall(record.Spec.DNSName)
@@ -259,7 +259,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 
 			if !tc.expectedErr && err != nil {
-				t.Errorf("expected nil err, got %w", err)
+				t.Errorf("expected nil err, got %v", err)
 			}
 
 			recordedCall, _ := dnsService.RecordedCall(record.Spec.DNSName)

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -545,7 +545,7 @@ func TestShouldUseLocalWithFallback(t *testing.T) {
 		actual, err := shouldUseLocalWithFallback(ic, &service)
 		switch {
 		case !tc.expectError && err != nil:
-			t.Errorf("%q: unexpected error: %w", tc.description, err)
+			t.Errorf("%q: unexpected error: %v", tc.description, err)
 		case tc.expectError && err == nil:
 			t.Errorf("%q: expected error, got nil", tc.description)
 		case tc.expect != actual:

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -134,7 +134,7 @@ func TestDesiredNodePortService(t *testing.T) {
 		}
 		want, svc, err := desiredNodePortService(ic, deploymentRef, tc.wantMetricsPort)
 		if err != nil {
-			t.Errorf("unexpected error from desiredNodePortService: %w", err)
+			t.Errorf("unexpected error from desiredNodePortService: %v", err)
 		} else if want != tc.expect {
 			t.Errorf("expected desiredNodePortService to return %t for endpoint publishing strategy type %v, got %t, with service %#v", tc.expect, tc.strategyType, want, svc)
 		} else if tc.expect && !reflect.DeepEqual(svc, &tc.expectService) {


### PR DESCRIPTION
Running `go test ./...` using go 1.18 results in errors along the lines
of:

```
...
pkg/operator/controller/ingress/load_balancer_service_test.go:548:4: (*testing.common).Errorf does not support error-wrapping directive %w
pkg/operator/controller/ingress/nodeport_service_test.go:137:4: (*testing.common).Errorf does not support error-wrapping directive %w
...
```

This PR should fix that