### PR TITLE
NE-781: Allow users to tune kubelet probe timeouts

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -222,3 +222,34 @@ func podExec(t *testing.T, pod corev1.Pod, stdout, stderr *bytes.Buffer, cmd []s
 		Stderr: stderr,
 	})
 }
+
+// cmpProbes compares two probes on their timeoutSeconds, periodSeconds,
+// successThreshold, and failureThreshold parameters.
+func cmpProbes(a, b *corev1.Probe) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.TimeoutSeconds != b.TimeoutSeconds {
+		return false
+	}
+	if a.PeriodSeconds != b.PeriodSeconds {
+		return false
+	}
+	if a.SuccessThreshold != b.SuccessThreshold {
+		return false
+	}
+	if a.FailureThreshold != b.FailureThreshold {
+		return false
+	}
+	return true
+}
+
+// probe returns a Probe with the specified parameters.
+func probe(timeout, period, success, failure int) *corev1.Probe {
+	return &corev1.Probe{
+		TimeoutSeconds:   int32(timeout),
+		PeriodSeconds:    int32(period),
+		SuccessThreshold: int32(success),
+		FailureThreshold: int32(failure),
+	}
+}


### PR DESCRIPTION
Allow users to set the `timeoutSeconds` parameter on the liveness, readiness, and startup probes for router deployments other than that of the default ingresscontroller.

* `pkg/operator/controller/ingress/deployment.go` (`ensureRouterDeployment`): Check the ingresscontroller's name to determine whether it is the default ingresscontroller and pass a Boolean value indicating the same to `desiredRouterDeployment` and `updateRouterDeployment`.
(`desiredRouterDeployment`): Add a `defaultIngressController` parameter and pass its argument to `deploymentTemplateHash`.
(`deploymentHash`, `deploymentTemplateHash`): Add a `defaultIngressController` parameter and pass the argument to `hashableDeployment`.
(`hashableDeployment`): Add a `defaultIngressController` parameter and pass its argument to `hashableProbe`.
(`hashableProbe`): Add a `defaultIngressController` parameter.  If its argument is false, don't include the probe's `timeoutSeconds` parameter in the hashable probe.
(`updateRouterDeployment`): Add a `defaultIngressController` parameter and pass its argument to `deploymentHash`.
(`deploymentConfigChanged`): Add a `defaultIngressController` parameter and use it along with the new `copyProbe` function to set the updated deployment's probe parameters.
(`copyProbe`): New function.  Copy one probe to another, preserving `timeoutSeconds` if the `defaultIngressController` parameter is false so as to allow users to modify the `timeoutSeconds` parameter.
* `pkg/operator/controller/ingress/deployment_test.go` (`checkDeploymentHasContainer`, `TestDesiredRouterDeployment`, `TestDeploymentHash`): Pass a false `defaultIngressController` argument to functions that need it.
(`TestDeploymentConfigChanged`): Add test cases to verify that `deploymentConfigChanged` detects changes to `timeoutSeconds` and other probe parameters for the default ingresscontroller and ignores changes to `timeoutSeconds` for other ingresscontrollers.
* `test/e2e/operator_test.go` (`TestTunableRouterKubeletProbesForDefaultIngressController`, `TestTunableRouterKubeletProbesForCustomIngressController`): New tests.
* `test/e2e/util.go` (`cmpProbes`, `probe`): New helpers that are used by the new tests.

---

This PR implements https://github.com/openshift/enhancements/pull/1039.