### PR TITLE
Bug 2055601: Add cluster tag to *.apps domain record

### DIFF
--- a/pkg/dns/azure/client/client.go
+++ b/pkg/dns/azure/client/client.go
@@ -32,6 +32,9 @@ type ARecord struct {
 
 	//TTL is the Time To Live property of the A record
 	TTL int64
+
+	//Label is the metadata label that needs to be added with the A record.
+	Label string
 }
 
 type dnsClient struct {
@@ -99,6 +102,10 @@ func (c *recordSetClient) Put(ctx context.Context, zone Zone, arec ARecord) erro
 				{Ipv4Address: &arec.Address},
 			},
 		},
+	}
+	if arec.Label != "" {
+		ownedValue := "owned"
+		rs.RecordSetProperties.Metadata = map[string]*string{arec.Label: &ownedValue}
 	}
 	_, err := c.client.CreateOrUpdate(ctx, zone.ResourceGroup, zone.Name, arec.Name, dns.A, rs, "", "")
 	if err != nil {

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -552,6 +552,7 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 			TenantID:       string(creds.Data["azure_tenant_id"]),
 			SubscriptionID: string(creds.Data["azure_subscription_id"]),
 			ARMEndpoint:    platformStatus.Azure.ARMEndpoint,
+			InfraID:        infraStatus.InfrastructureName,
 		}, r.config.OperatorReleaseVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Azure DNS manager: %v", err)


### PR DESCRIPTION
The installer adds a cluster tag to the api.* and the api-int.*
records during creation and uses that tag to identify the dns
records that belong to the cluster and delete them. Adding the
cluster tag to the *.apps domain record to be able to identify
it during destroy.