### PR TITLE
Bug 2075671: Fix k8s client cache object global inclusion and duplication.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -77,9 +77,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 			operatorcontroller.DefaultOperandNamespace,
 			operatorcontroller.DefaultCanaryNamespace,
 			operatorcontroller.GlobalMachineSpecifiedConfigNamespace,
-			"",
 			operatorcontroller.SourceConfigMapNamespace,
-			operatorcontroller.GlobalUserSpecifiedConfigNamespace,
 		}),
 		// Use a non-caching client everywhere. The default split client does not
 		// promise to invalidate the cache during writes (nor does it promise


### PR DESCRIPTION
  An empty string was included in MultiNamespacedCacheBuilder which was intended to capture
  Cluster Scoped Resources, but it erroneously included ALL objects in ANY namespace.
  It also duplicated other objects that had already been selected by a namespace. It is not
  needed since cluster scoped resources are already included in the cache by default.
  This may fix many inefficiencies such as double reconcilations and cache overloading.