### PR TITLE
BUG 2076984: test/e2e: add resilience to RBAC test teardown

### DIFF
--- a/test/e2e/configurable_route_test.go
+++ b/test/e2e/configurable_route_test.go
@@ -39,11 +39,11 @@ func TestConfigurableRouteRBAC(t *testing.T) {
 			t.Fatalf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
-		if err := kclient.Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
 			t.Errorf("failed to restore cluster ingress.spec resource to original state: %v", err)
 		}
 		ingress.Status.ComponentRoutes = nil
-		if err := kclient.Status().Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
 	}()
@@ -198,11 +198,11 @@ func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 			t.Fatalf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
-		if err := kclient.Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
 		ingress.Status.ComponentRoutes = nil
-		if err := kclient.Status().Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
 	}()
@@ -297,11 +297,11 @@ func TestConfigurableRouteNoConsumingUserNoRBAC(t *testing.T) {
 			t.Fatalf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
-		if err := kclient.Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
 		ingress.Status.ComponentRoutes = nil
-		if err := kclient.Status().Update(context.TODO(), ingress); err != nil {
+		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
 	}()


### PR DESCRIPTION
RBAC tests fail in teardown with:

    configurable_route_test.go:301: failed to restore cluster ingress resource to original state: Operation cannot be fulfilled on ingresses.config.openshift.io "cluster": the object has been modified; please apply your changes to the latest version and try again
    configurable_route_test.go:305: failed to restore cluster ingress resource to original state: Operation cannot be fulfilled on ingresses.config.openshift.io "cluster": the object has been modified; please apply your changes to the latest version and try again

Change the defer logic for all the RBAC e2e tests to make multiple
attempts to restore both the spec and status when the test completes.
