### PR TITLE
Bug 2081447: `desiredRouterDeployment`: Fix for port defaulting

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1099,14 +1099,17 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		corev1.ContainerPort{
 			Name:          HTTPPortName,
 			ContainerPort: httpPort,
+			Protocol:      corev1.ProtocolTCP,
 		},
 		corev1.ContainerPort{
 			Name:          HTTPSPortName,
 			ContainerPort: httpsPort,
+			Protocol:      corev1.ProtocolTCP,
 		},
 		corev1.ContainerPort{
 			Name:          StatsPortName,
 			ContainerPort: statsPort,
+			Protocol:      corev1.ProtocolTCP,
 		},
 	)
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1342,14 +1342,14 @@ func TestDeploymentConfigChanged(t *testing.T) {
 		{
 			description: "if container HTTPS port is changed",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 8443
+				deployment.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort = 8443
 			},
 			expect: true,
 		},
 		{
 			description: "if container Stats port is changed",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = 8936
+				deployment.Spec.Template.Spec.Containers[0].Ports[2].ContainerPort = 8936
 			},
 			expect: true,
 		},

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1353,6 +1353,24 @@ func TestDeploymentConfigChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if the protocol for container ports is set to the default value",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Ports[0].Protocol = corev1.ProtocolTCP
+				deployment.Spec.Template.Spec.Containers[0].Ports[1].Protocol = corev1.ProtocolTCP
+				deployment.Spec.Template.Spec.Containers[0].Ports[2].Protocol = corev1.ProtocolTCP
+			},
+			expect: false,
+		},
+		{
+			description: "if the protocol for container ports is set to a non-default value",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Ports[0].Protocol = corev1.ProtocolUDP
+				deployment.Spec.Template.Spec.Containers[0].Ports[1].Protocol = corev1.ProtocolUDP
+				deployment.Spec.Template.Spec.Containers[0].Ports[2].Protocol = corev1.ProtocolUDP
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1466,14 +1484,17 @@ func TestDeploymentConfigChanged(t *testing.T) {
 									{
 										Name:          "http",
 										ContainerPort: int32(80),
+										Protocol:      corev1.ProtocolTCP,
 									},
 									{
 										Name:          "https",
 										ContainerPort: 443,
+										Protocol:      corev1.ProtocolTCP,
 									},
 									{
 										Name:          "metrics",
 										ContainerPort: 1936,
+										Protocol:      corev1.ProtocolTCP,
 									},
 								},
 							},


### PR DESCRIPTION
#### `TestDeploymentConfigChanged`: Fix tests for ports

Follow-up to #694.

* `pkg/operator/controller/ingress/deployment_test.go` (`TestDeploymentConfigChanged`): Update the correct ports in the test cases for mutating the "https" and "metrics" ports.


#### `desiredRouterDeployment`: Fix for port defaulting

Specify `deployment.spec.template.spec.containers[0].ports[*].protocol` in router deployments.

Before this change, the operator left the protocol field unspecified, and as a consequence, the update logic would keep trying to revert the default value that the API set for this field.  The default value for this field is "TCP", so specifying "TCP" has the result that the API does not need to update the deployment to fill in the default value, and so the operator's update logic is no longer triggered by the API's defaulting of this field.

Follow-up to #694.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Specify the protocol field on container ports.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDeploymentConfigChanged`): Add test cases to verify that updates that set container ports' protocol to the default value are ignore and that updates that change the protocol to a non-default value are not ignored.