### PR TITLE
[release-4.8] Bug 2084337: Fix enabling PROXY protocol on an upgraded cluster

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -415,17 +415,23 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 		}
 	case operatorv1.NodePortServiceStrategyType:
 		// Update if PROXY protocol is turned on or off.
+		if ic.Status.EndpointPublishingStrategy.NodePort == nil {
+			ic.Status.EndpointPublishingStrategy.NodePort = &operatorv1.NodePortStrategy{}
+		}
 		statusNP := ic.Status.EndpointPublishingStrategy.NodePort
 		specNP := effectiveStrategy.NodePort
-		if specNP != nil && statusNP != nil && specNP.Protocol != statusNP.Protocol {
+		if specNP != nil && specNP.Protocol != statusNP.Protocol {
 			statusNP.Protocol = specNP.Protocol
 			return true
 		}
 	case operatorv1.HostNetworkStrategyType:
 		// Update if PROXY protocol is turned on or off.
+		if ic.Status.EndpointPublishingStrategy.HostNetwork == nil {
+			ic.Status.EndpointPublishingStrategy.HostNetwork = &operatorv1.HostNetworkStrategy{}
+		}
 		statusHN := ic.Status.EndpointPublishingStrategy.HostNetwork
 		specHN := effectiveStrategy.HostNetwork
-		if specHN != nil && statusHN != nil && specHN.Protocol != statusHN.Protocol {
+		if specHN != nil && specHN.Protocol != statusHN.Protocol {
 			statusHN.Protocol = specHN.Protocol
 			return true
 		}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -342,7 +342,7 @@ func setDefaultDomain(ic *operatorv1.IngressController, ingressConfig *configv1.
 }
 
 func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig *configv1.Infrastructure) bool {
-	effectiveStrategy := ic.Spec.EndpointPublishingStrategy
+	effectiveStrategy := ic.Spec.EndpointPublishingStrategy.DeepCopy()
 	if effectiveStrategy == nil {
 		var strategyType operatorv1.EndpointPublishingStrategyType
 		switch infraConfig.Status.Platform {

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -386,38 +386,49 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 		return true
 	}
 
-	// Detect changes to GCP LB provider parameters, which is something we can safely roll out.
-	statusLB := ic.Status.EndpointPublishingStrategy.LoadBalancer
-	specLB := effectiveStrategy.LoadBalancer
-	if specLB != nil && statusLB != nil {
-		// If the ProviderParameters field does not exist for spec or status,
-		// just propagate (or remove) ProviderParameters in it's entirety
-		// (as long as GCP parameters are specified one way or the other).
-		if specLB.ProviderParameters == nil && statusLB.ProviderParameters != nil && statusLB.ProviderParameters.GCP != nil ||
-			specLB.ProviderParameters != nil && specLB.ProviderParameters.GCP != nil && statusLB.ProviderParameters == nil {
-			ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters = specLB.ProviderParameters
+	// Detect changes to endpoint publishing strategy parameters that the
+	// operator can safely update.
+	switch effectiveStrategy.Type {
+	case operatorv1.LoadBalancerServiceStrategyType:
+		// Update if GCP LB provider parameters changed.
+		statusLB := ic.Status.EndpointPublishingStrategy.LoadBalancer
+		specLB := effectiveStrategy.LoadBalancer
+		if specLB != nil && statusLB != nil {
+			changed := false
+
+			// If the ProviderParameters field does not exist for spec or status,
+			// just propagate (or remove) ProviderParameters in its entirety
+			// (as long as GCP parameters are specified one way or the other).
+			if specLB.ProviderParameters == nil && statusLB.ProviderParameters != nil && statusLB.ProviderParameters.GCP != nil ||
+				specLB.ProviderParameters != nil && specLB.ProviderParameters.GCP != nil && statusLB.ProviderParameters == nil {
+				ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters = specLB.ProviderParameters
+				changed = true
+			}
+
+			if specLB.ProviderParameters != nil && statusLB.ProviderParameters != nil &&
+				specLB.ProviderParameters.GCP != statusLB.ProviderParameters.GCP {
+				ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.GCP = specLB.ProviderParameters.GCP
+				changed = true
+			}
+
+			return changed
+		}
+	case operatorv1.NodePortServiceStrategyType:
+		// Update if PROXY protocol is turned on or off.
+		statusNP := ic.Status.EndpointPublishingStrategy.NodePort
+		specNP := effectiveStrategy.NodePort
+		if specNP != nil && statusNP != nil && specNP.Protocol != statusNP.Protocol {
+			statusNP.Protocol = specNP.Protocol
 			return true
 		}
-
-		if specLB.ProviderParameters != nil && statusLB.ProviderParameters != nil &&
-			specLB.ProviderParameters.GCP != statusLB.ProviderParameters.GCP {
-			ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.GCP = specLB.ProviderParameters.GCP
+	case operatorv1.HostNetworkStrategyType:
+		// Update if PROXY protocol is turned on or off.
+		statusHN := ic.Status.EndpointPublishingStrategy.HostNetwork
+		specHN := effectiveStrategy.HostNetwork
+		if specHN != nil && statusHN != nil && specHN.Protocol != statusHN.Protocol {
+			statusHN.Protocol = specHN.Protocol
 			return true
 		}
-	}
-
-	// Update if PROXY protocol is turned on or off.
-	statusNP := ic.Status.EndpointPublishingStrategy.NodePort
-	specNP := effectiveStrategy.NodePort
-	if specNP != nil && statusNP != nil && specNP.Protocol != statusNP.Protocol {
-		statusNP.Protocol = specNP.Protocol
-		return true
-	}
-	statusHN := ic.Status.EndpointPublishingStrategy.HostNetwork
-	specHN := effectiveStrategy.HostNetwork
-	if specHN != nil && statusHN != nil && specHN.Protocol != statusHN.Protocol {
-		statusHN.Protocol = specHN.Protocol
-		return true
 	}
 
 	return false


### PR DESCRIPTION
This is a manual cherry-pick of #681 and #691.  #582 introduced conflicts that required resolution.  

---

#### `setDefaultPublishingStrategy`: Reformat with `switch`

Refactor the update logic in `setDefaultPublishingStrategy`.  

* `pkg/operator/controller/ingress/controller.go` (`setDefaultPublishingStrategy`): Use a switch statement for the update logic so that the logic only looks at parameters related to the selected endpoint publishing strategy type.


#### `setDefaultPublishingStrategy`: Fix PROXY protocol

Fix the update logic in `setDefaultPublishingStrategy` so that updates are properly handled when `status.endpointPublishingStrategy.hostNetwork` or `status.endpointPublishingStrategy.nodePort` is null.

Before OpenShift 4.8, the IngressController API did not have any fields under the `status.endpointPublishingStrategy.hostNetwork` and `status.endpointPublishingStrategy.nodePort` fields.  As result, these fields could be null even if the `spec.endpointPublishingStrategy.type` field was set to "HostNetwork" or "NodePortService".

OpenShift 4.8 added `status.endpointPublishingStrategy.hostNetwork.protocol` and `status.endpointPublishingStrategy.nodePort.protocol` fields, and the operator now sets default values for these fields when the operator admits or re-admits an ingresscontroller that specifies the "HostNetwork" or "NodePortService" strategy type, respectively.

However, a cluster that was upgraded from a version of OpenShift before 4.8 could have an already admitted ingresscontroller with null values for `status.endpointPublishingStrategy.hostNetwork` and `status.endpointPublishingStrategy.nodePort` even when ingresscontroller specifies the "HostNetwork" or "NodePortService" strategy type.

In this case, the operator ignored updates to the `spec.endpointPublishingStrategy.hostNetwork.protocol` or `spec.endpointPublishingStrategy.nodePort.protocol` fields.

This PR fixes the update logic so that it correctly updates the `status.endpointPublishingStrategy.hostNetwork.protocol` or `status.endpointPublishingStrategy.nodePort.protocol` field when `status.endpointPublishingStrategy.hostNetwork` or `status.endpointPublishingStrategy.nodePort` is null, the `spec.endpointPublishingStrategy.hostNetwork.protocol` or `spec.endpointPublishingStrategy.nodePort.protocol` field is set, and the strategy type is "HostNetwork" or "NodePortService", respectively.

* `pkg/operator/controller/ingress/controller.go` (`setDefaultPublishingStrategy`): Fix logic to properly handle null values for `status.endpointPublishingStrategy.hostNetwork` or `status.endpointPublishingStrategy.nodePort`.


#### `setDefaultPublishingStrategy`: Deep copy, tests

Make a copy of `spec.endpointPublishingStrategy` to avoid mutating it, and add unit tests for `setDefaultDomain` and `setDefaultPublishingStrategy`.

* `pkg/operator/controller/ingress/controller.go` (`setDefaultPublishingStrategy`): Use a deep copy of `ic.Spec.EndpointPublishingStrategy`.
* `pkg/operator/controller/ingress/controller_test.go` (`TestSetDefaultDomain`, `TestSetDefaultPublishingStrategySetsPlatformDefaults`, `TestSetDefaultPublishingStrategyHandlesUpdates`): New tests.