### PR TITLE
Bug 2041616: Do not create DNS records for IngressControllers with domain not matching baseDomain

### DIFF
--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -135,96 +135,94 @@ func TestSetDefaultPublishingStrategySetsPlatformDefaults(t *testing.T) {
 				},
 			},
 		}
-		makeInfra = func(platform configv1.PlatformType) *configv1.Infrastructure {
-			return &configv1.Infrastructure{
-				Status: configv1.InfrastructureStatus{
-					Platform: platform,
-				},
+		makePlatformStatus = func(platform configv1.PlatformType) *configv1.PlatformStatus {
+			return &configv1.PlatformStatus{
+				Type: platform,
 			}
 		}
 	)
 
 	testCases := []struct {
-		name        string
-		infraConfig *configv1.Infrastructure
-		expectedIC  *operatorv1.IngressController
+		name           string
+		platformStatus *configv1.PlatformStatus
+		expectedIC     *operatorv1.IngressController
 	}{
 		{
-			name:        "Alibaba",
-			infraConfig: makeInfra(configv1.AlibabaCloudPlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "Alibaba",
+			platformStatus: makePlatformStatus(configv1.AlibabaCloudPlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "AWS",
-			infraConfig: makeInfra(configv1.AWSPlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "AWS",
+			platformStatus: makePlatformStatus(configv1.AWSPlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "Azure",
-			infraConfig: makeInfra(configv1.AzurePlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "Azure",
+			platformStatus: makePlatformStatus(configv1.AzurePlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "Bare metal",
-			infraConfig: makeInfra(configv1.BareMetalPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "Bare metal",
+			platformStatus: makePlatformStatus(configv1.BareMetalPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "Equinix Metal",
-			infraConfig: makeInfra(configv1.EquinixMetalPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "Equinix Metal",
+			platformStatus: makePlatformStatus(configv1.EquinixMetalPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "GCP",
-			infraConfig: makeInfra(configv1.GCPPlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "GCP",
+			platformStatus: makePlatformStatus(configv1.GCPPlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "IBM Cloud",
-			infraConfig: makeInfra(configv1.IBMCloudPlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "IBM Cloud",
+			platformStatus: makePlatformStatus(configv1.IBMCloudPlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "Libvirt",
-			infraConfig: makeInfra(configv1.LibvirtPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "Libvirt",
+			platformStatus: makePlatformStatus(configv1.LibvirtPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "No platform",
-			infraConfig: makeInfra(configv1.NonePlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "No platform",
+			platformStatus: makePlatformStatus(configv1.NonePlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "OpenStack",
-			infraConfig: makeInfra(configv1.OpenStackPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "OpenStack",
+			platformStatus: makePlatformStatus(configv1.OpenStackPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "Power VS",
-			infraConfig: makeInfra(configv1.PowerVSPlatformType),
-			expectedIC:  ingressControllerWithLoadBalancer,
+			name:           "Power VS",
+			platformStatus: makePlatformStatus(configv1.PowerVSPlatformType),
+			expectedIC:     ingressControllerWithLoadBalancer,
 		},
 		{
-			name:        "RHV",
-			infraConfig: makeInfra(configv1.OvirtPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "RHV",
+			platformStatus: makePlatformStatus(configv1.OvirtPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "vSphere",
-			infraConfig: makeInfra(configv1.VSpherePlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "vSphere",
+			platformStatus: makePlatformStatus(configv1.VSpherePlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 		{
-			name:        "Nutanix",
-			infraConfig: makeInfra(configv1.NutanixPlatformType),
-			expectedIC:  ingressControllerWithHostNetwork,
+			name:           "Nutanix",
+			platformStatus: makePlatformStatus(configv1.NutanixPlatformType),
+			expectedIC:     ingressControllerWithHostNetwork,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ic := &operatorv1.IngressController{}
-			infraConfig := tc.infraConfig.DeepCopy()
-			if actualResult := setDefaultPublishingStrategy(ic, infraConfig); actualResult != true {
+			platformStatus := tc.platformStatus.DeepCopy()
+			if actualResult := setDefaultPublishingStrategy(ic, platformStatus); actualResult != true {
 				t.Errorf("expected result %v, got %v", true, actualResult)
 			}
 			if diff := cmp.Diff(tc.expectedIC, ic); len(diff) != 0 {
@@ -506,12 +504,10 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ic := tc.ic.DeepCopy()
-			infraConfig := &configv1.Infrastructure{
-				Status: configv1.InfrastructureStatus{
-					Platform: configv1.NonePlatformType,
-				},
+			platformStatus := &configv1.PlatformStatus{
+				Type: configv1.NonePlatformType,
 			}
-			if actualResult := setDefaultPublishingStrategy(ic, infraConfig); actualResult != tc.expectedResult {
+			if actualResult := setDefaultPublishingStrategy(ic, platformStatus); actualResult != tc.expectedResult {
 				t.Errorf("expected result %v, got %v", tc.expectedResult, actualResult)
 			}
 			if diff := cmp.Diff(tc.expectedIC, ic); len(diff) != 0 {

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
-	oputil "github.com/openshift/cluster-ingress-operator/pkg/util"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -109,16 +107,12 @@ const (
 
 // ensureRouterDeployment ensures the router deployment exists for a given
 // ingresscontroller.
-func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap) (bool, *appsv1.Deployment, error) {
+func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, platformStatus *configv1.PlatformStatus) (bool, *appsv1.Deployment, error) {
 	haveDepl, current, err := r.currentRouterDeployment(ci)
 	if err != nil {
 		return false, nil, err
 	}
-	platform, err := oputil.GetPlatformStatus(r.client, infraConfig)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ci.Namespace, ci.Name, err)
-	}
-	proxyNeeded, err := IsProxyProtocolNeeded(ci, platform)
+	proxyNeeded, err := IsProxyProtocolNeeded(ci, platformStatus)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to determine if proxy protocol is needed for ingresscontroller %s/%s: %v", ci.Namespace, ci.Name, err)
 	}

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -27,6 +27,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestCreateSecretThenIngressController", TestCreateSecretThenIngressController)
 		t.Run("TestCustomErrorpages", TestCustomErrorpages)
 		t.Run("TestCustomIngressClass", TestCustomIngressClass)
+		t.Run("TestDomainNotMatchingBase", TestDomainNotMatchingBase)
 		t.Run("TestDynamicConfigManagerUnsupportedConfigOverride", TestDynamicConfigManagerUnsupportedConfigOverride)
 		t.Run("TestForwardedHeaderPolicyAppend", TestForwardedHeaderPolicyAppend)
 		t.Run("TestForwardedHeaderPolicyIfNone", TestForwardedHeaderPolicyIfNone)

--- a/test/e2e/domain_not_matching_base_test.go
+++ b/test/e2e/domain_not_matching_base_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+	"time"
+)
+
+func TestDomainNotMatchingBase(t *testing.T) {
+	t.Parallel()
+	if infraConfig.Status.Platform != configv1.AWSPlatformType {
+		t.Skip("test skipped on non-aws platform")
+		return
+	}
+
+	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "domain-not-matching"}
+	domain := icName.Name + ".local"
+	ic := newLoadBalancerController(icName, domain)
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	//Ensure the DNSManaged=False condition
+	t.Logf("waiting for ingresscontroller %v", icName)
+	conditions := []operatorv1.OperatorCondition{
+		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
+	}
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, conditions...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	ic, err := getIngressController(t, kclient, icName, 1*time.Minute)
+	if err != nil {
+		t.Fatalf("failed to get ingress controller: %v", err)
+	}
+
+	//Ensure there is no DNS record created
+	wildcardRecordName := controller.WildcardDNSRecordName(ic)
+	wildcardRecord := &iov1.DNSRecord{}
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err == nil {
+		t.Fatalf("Expected to find no wildcard dnsrecord, but found one %s", wildcardRecordName)
+	}
+	if err != nil && !errors.IsNotFound(err) {
+		t.Fatalf("Unexpected error while looking for a dnsrecord: %v", err)
+	}
+}


### PR DESCRIPTION
This change implements a check for ingresscontrollers with a spec.domain that does not match the spec.baseDomain of the cluster DNS config. As a result of this check, operator does not create DNS records and sets `DNSManaged` condition to `False` for the respective ingresscontroller. 
- `pkg/operator/controller/ingress/controller.go`: `platformStatus` was being calculated in many different functions before. With this change, it is only calculated once in controller.go and passed to the other functions as an argument. It also uses `manageDNSForDomain` function while admitting the ingresscontroller to emit a warning event.
- `pkg/operator/controller/ingress/controller_test.go`: This updates the tests to use `platformStatus` instead of `infraConfig`.
- `pkg/operator/controller/ingress/deployment.go`: `platformStatus` calculation moved to controller.go.
- `pkg/operator/controller/ingress/dns.go`: This implements and uses `manageDNSForDomain` function to skip creation of DNS records for ingresscontrollers having a domain not matching the baseDomain on AWS.
- `pkg/operator/controller/ingress/dns_test.go`: This introduces a unit test for `manageDNSForDomain` function.
- `pkg/operator/controller/ingress/load_balancer_service.go`: `platformStatus` calculation moved to controller.go.
- `pkg/operator/controller/ingress/status.go`: `platformStatus` calculation moved to controller.go. This also sets `DNSManaged-False` as a result of `manageDNSForDomain` function.
- `test/e2e/domain_not_matching_base_test.go`: This implements an e2e test to check if the operator skips creation of DNS records and sets `DNSManaged=False` for ingresscontrollers having a domain not matching the baseDomain on AWS.