### PR TITLE
Bug 2075671: Add a e2e test that verifies the ingress operator's cache doesn't include everything

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -61,6 +61,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestUniqueDomainRejection", TestUniqueDomainRejection)
 		t.Run("TestUniqueIdHeader", TestUniqueIdHeader)
 		t.Run("TestUserDefinedIngressController", TestUserDefinedIngressController)
+		t.Run("TestIngressOperatorCacheIsNotGlobal", TestIngressOperatorCacheIsNotGlobal)
 	})
 
 	t.Run("serial", func(t *testing.T) {


### PR DESCRIPTION
Adding a simple e2e for BZ2075671 (that was already closed) to validate that the ingress operator's cache isn't including all objects.