### PR TITLE
Bug 2066560: Make ingress clusteroperator progressing=true when router deployment is rolling out

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -54,6 +54,8 @@ const (
 	IngressControllerDeploymentAvailableConditionType            = "DeploymentAvailable"
 	IngressControllerDeploymentReplicasMinAvailableConditionType = "DeploymentReplicasMinAvailable"
 	IngressControllerDeploymentReplicasAllAvailableConditionType = "DeploymentReplicasAllAvailable"
+	IngressControllerDeploymentRollingOutConditionType           = "DeploymentRollingOut"
+	IngressControllerLoadBalancerProgressingConditionType        = "LoadBalancerProgressing"
 	IngressControllerCanaryCheckSuccessConditionType             = "CanaryChecksSucceeding"
 
 	routerDefaultHeaderBufferSize           = 32768


### PR DESCRIPTION
When a router deployment the ingress controller is rolling out, set progressing=true in the cluster operator status with a message.