### PR TITLE
Option to disable creation of default ingress controller

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -50,6 +50,9 @@ type StartOptions struct {
 	CanaryImage string
 	// ReleaseVersion is the cluster version which the operator will converge to.
 	ReleaseVersion string
+	// AutoCreateDefaultIngressController indicates if the controller should create the default
+	// controller if none exists
+	AutoCreateDefaultIngressController bool
 }
 
 func NewStartCommand() *cobra.Command {
@@ -73,6 +76,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.ReleaseVersion, "release-version", "", statuscontroller.UnknownVersionValue, "the release version the operator should converge to (required)")
 	cmd.Flags().StringVarP(&options.MetricsListenAddr, "metrics-listen-addr", "", "127.0.0.1:60000", "metrics endpoint listen address (required)")
 	cmd.Flags().StringVarP(&options.ShutdownFile, "shutdown-file", "s", defaultTrustedCABundle, "if provided, shut down the operator when this file changes")
+	cmd.Flags().BoolVarP(&options.AutoCreateDefaultIngressController, "auto-create-default-ingress-controller", "", true, "specifies if the ingress operator should automatically create a default ingresscontroller or not.")
 
 	if err := cmd.MarkFlagRequired("namespace"); err != nil {
 		panic(err)
@@ -117,10 +121,11 @@ func start(opts *StartOptions) error {
 	defer cancel()
 
 	operatorConfig := operatorconfig.Config{
-		OperatorReleaseVersion: opts.ReleaseVersion,
-		Namespace:              opts.OperatorNamespace,
-		IngressControllerImage: opts.IngressControllerImage,
-		CanaryImage:            opts.CanaryImage,
+		OperatorReleaseVersion:             opts.ReleaseVersion,
+		Namespace:                          opts.OperatorNamespace,
+		IngressControllerImage:             opts.IngressControllerImage,
+		CanaryImage:                        opts.CanaryImage,
+		AutoCreateDefaultIngressController: opts.AutoCreateDefaultIngressController,
 	}
 
 	// Start operator metrics.

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -15,5 +15,9 @@ type Config struct {
 	// CanaryImage is the ingress operator image, which runs a canary command.
 	CanaryImage string
 
+	// AutoCreateDefaultIngressController indicates if the controller should create the default
+	// controller if none exists
+	AutoCreateDefaultIngressController bool
+
 	Stop chan struct{}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -64,6 +64,8 @@ type Operator struct {
 	manager manager.Manager
 
 	namespace string
+
+	autoCreateDefaultIngressController bool
 }
 
 // New creates (but does not start) a new operator from configuration.
@@ -212,8 +214,9 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		manager: mgr,
 		// TODO: These are only needed for the default ingress controller stuff, which
 		// should be refactored away.
-		client:    mgr.GetClient(),
-		namespace: config.Namespace,
+		client:                             mgr.GetClient(),
+		namespace:                          config.Namespace,
+		autoCreateDefaultIngressController: config.AutoCreateDefaultIngressController,
 	}, nil
 }
 
@@ -221,17 +224,19 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 // synchronously until a message is received on the stop channel.
 // TODO: Move the default IngressController logic elsewhere.
 func (o *Operator) Start(ctx context.Context) error {
-	// Periodicaly ensure the default controller exists.
-	go wait.Until(func() {
-		if !o.manager.GetCache().WaitForCacheSync(ctx) {
-			log.Error(nil, "failed to sync cache before ensuring default ingresscontroller")
-			return
-		}
-		err := o.ensureDefaultIngressController()
-		if err != nil {
-			log.Error(err, "failed to ensure default ingresscontroller")
-		}
-	}, 1*time.Minute, ctx.Done())
+	if o.autoCreateDefaultIngressController {
+		// Periodicaly ensure the default controller exists.
+		go wait.Until(func() {
+			if !o.manager.GetCache().WaitForCacheSync(ctx) {
+				log.Error(nil, "failed to sync cache before ensuring default ingresscontroller")
+				return
+			}
+			err := o.ensureDefaultIngressController()
+			if err != nil {
+				log.Error(err, "failed to ensure default ingresscontroller")
+			}
+		}, 1*time.Minute, ctx.Done())
+	}
 
 	if err := o.handleSingleNode4Dot11Upgrade(); err != nil {
 		log.Error(err, "failed to handle single node 4.11 upgrade logic")


### PR DESCRIPTION
Due to the way Hypershift is designed, it needs the ability to start the ingress operator in the hosted cluster namespace, and then create the default ingresscontroller object later on which hypershift's controllers manage. Right now we have a race between the ingress operator attempting to autocreate the default ingresscontroller and hypershift's controllers attempting to do it. 

This PR adds a cli option to the operator to disable the autocreation of the default ingresscontroller which allows hypershift to manage the default ingresscontroller without conflict.