### PR TITLE
EnvVar to disable creation of default ingress controller

### DIFF
--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -15,5 +15,9 @@ type Config struct {
 	// CanaryImage is the ingress operator image, which runs a canary command.
 	CanaryImage string
 
+	// DisableDefaultIngressController indicates if the default ingress controller
+	// should be created automatically if it doesn't already exist
+	DisableDefaultIngressController bool
+
 	Stop chan struct{}
 }


### PR DESCRIPTION
Due to the way Hypershift is designed, it needs the ability to start the ingress operator in the hosted cluster namespace, and then create the default ingresscontroller object later on which hypershift's controllers manage. Right now we have a race between the ingress operator attempting to autocreate the default ingresscontroller and hypershift's controllers attempting to do it.

This PR adds an environment variable option to the operator to disable the autocreation of the default ingresscontroller which allows hypershift to manage the default ingresscontroller without conflict.
