### PR TITLE
Bug 2095229: desiredRouterDeployment: Check for nil hostNetwork

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -657,15 +657,16 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		deployment.Spec.Template.Spec.Containers[0].StartupProbe.ProbeHandler.HTTPGet.Host = "localhost"
 		deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 
-		config := ci.Status.EndpointPublishingStrategy.HostNetwork
-		if config.HTTPSPort == config.HTTPPort || config.HTTPPort == config.StatsPort || config.StatsPort == config.HTTPSPort {
-			return nil, fmt.Errorf("the specified HTTPS, HTTP and Stats ports %d, %d, %d are not unique", config.HTTPSPort, config.HTTPPort, config.StatsPort)
-		}
+		if config := ci.Status.EndpointPublishingStrategy.HostNetwork; config != nil {
+			if config.HTTPSPort == config.HTTPPort || config.HTTPPort == config.StatsPort || config.StatsPort == config.HTTPSPort {
+				return nil, fmt.Errorf("the specified HTTPS, HTTP and Stats ports %d, %d, %d are not unique", config.HTTPSPort, config.HTTPPort, config.StatsPort)
+			}
 
-		// Set the ports to the values from the host network configuration
-		httpPort = config.HTTPPort
-		httpsPort = config.HTTPSPort
-		statsPort = config.StatsPort
+			// Set the ports to the values from the host network configuration
+			httpPort = config.HTTPPort
+			httpsPort = config.HTTPSPort
+			statsPort = config.StatsPort
+		}
 
 		// Append the environment variables for the HTTP and HTTPS ports
 		env = append(env,


### PR DESCRIPTION
Check whether the ingresscontroller's `status.endpointPublishingStrategy.hostNetwork` field is nil before trying to dereference it.

Before this change, the operator would crash-loop with a nil pointer dereference if the cluster had been upgraded from an earlier version of OpenShift where the cluster had had an ingresscontroller with `status.endpointPublishingStrategy.type` set to "HostNetwork".

Follow-up to #694.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Check whether the ingresscontroller's `status.endpointPublishingStrategy.hostNetwork` field is nil before trying to dereference it.
* `pkg/operator/controller/ingress/deployment_test.go` (`TestDesiredRouterDeploymentHostNetworkNil`): New test.  Verify that `desiredRouterDeployment` behaves correctly when the ingresscontroller's `status.endpointPublishingStrategy.type` is "HostNetwork" but `status.endpointPublishingStrategy.hostNetwork` is nil.