### PR TITLE
NE-568: Add dnsManagementPolicy option to ingresscontrollers

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -25,7 +25,7 @@ import (
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
-	operatorutil "github.com/openshift/cluster-ingress-operator/pkg/util"
+	oputil "github.com/openshift/cluster-ingress-operator/pkg/util"
 	awsutil "github.com/openshift/cluster-ingress-operator/pkg/util/aws"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/slice"
 
@@ -39,7 +39,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatoringressv1 "github.com/openshift/api/operatoringress/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,10 +131,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get dns 'cluster': %v", err)
 	}
 
-	if err := r.createDNSProviderIfNeeded(dnsConfig); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	record := &iov1.DNSRecord{}
 	if err := r.client.Get(ctx, request.NamespacedName, record); err != nil {
 		if errors.IsNotFound(err) {
@@ -144,6 +139,16 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		log.Error(err, "failed to get dnsrecord; will retry", "dnsrecord", request.NamespacedName)
 		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
+	if updated, err := r.migrateRecordStatusConditions(record); err != nil {
+		return reconcile.Result{}, err
+	} else if updated {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	if err := r.createDNSProviderIfNeeded(dnsConfig, record); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// If the DNS record was deleted, clean up and return.
@@ -190,7 +195,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if dnsConfig.Spec.PublicZone != nil {
 		zones = append(zones, *dnsConfig.Spec.PublicZone)
 	}
-	statuses, result := r.publishRecordToZones(zones, record)
+	requeue, statuses := r.publishRecordToZones(zones, record)
+
+	// Requeue if publishing records failed.
+	result := reconcile.Result{}
+	if requeue {
+		result.RequeueAfter = 30 * time.Second
+	}
+
 	if !dnsZoneStatusSlicesEqual(statuses, record.Status.Zones) {
 		updated := record.DeepCopy()
 		updated.Status.Zones = statuses
@@ -202,6 +214,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			log.Info("updated dnsrecord", "dnsrecord", updated)
 		}
 	}
+
 	return result, nil
 }
 
@@ -210,8 +223,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 // changed since the current provider was created.  After creating a new
 // provider, createDNSProviderIfNeeded updates the reconciler state
 // with the new provider and current platform status and cloud credentials.
-func (r *reconciler) createDNSProviderIfNeeded(dnsConfig *configv1.DNS) error {
+func (r *reconciler) createDNSProviderIfNeeded(dnsConfig *configv1.DNS, record *iov1.DNSRecord) error {
 	var needUpdate bool
+
+	if record.Spec.DNSManagementPolicy == iov1.UnmanagedDNS {
+		return nil
+	}
 
 	infraConfig := &configv1.Infrastructure{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
@@ -256,61 +273,105 @@ func (r *reconciler) createDNSProviderIfNeeded(dnsConfig *configv1.DNS) error {
 	return nil
 }
 
-func (r *reconciler) publishRecordToZones(zones []configv1.DNSZone, record *iov1.DNSRecord) ([]iov1.DNSZoneStatus, reconcile.Result) {
-	result := reconcile.Result{}
+// replacePublishedRecord replaces a previously published record with the given record,
+// and the result is returned as a condition. Upon errors during publishing,
+// an error object is returned.
+func (r *reconciler) replacePublishedRecord(zone configv1.DNSZone, record *iov1.DNSRecord) (iov1.DNSZoneCondition, error) {
+	condition := iov1.DNSZoneCondition{
+		Status:             string(operatorv1.ConditionUnknown),
+		Type:               iov1.DNSRecordPublishedConditionType,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	err := r.dnsProvider.Replace(record, zone)
+	if err != nil {
+		log.Error(err, "failed to replace DNS record in zone", "record", record.Spec, "dnszone", zone)
+		condition.Status = string(operatorv1.ConditionFalse)
+		condition.Reason = "ProviderError"
+		condition.Message = fmt.Sprintf("The DNS provider failed to replace the record: %v", err)
+	} else {
+		log.Info("replaced DNS record in zone", "record", record.Spec, "dnszone", zone)
+		condition.Status = string(operatorv1.ConditionTrue)
+		condition.Reason = "ProviderSuccess"
+		condition.Message = "The DNS provider succeeded in replacing the record"
+	}
+
+	return condition, err
+}
+
+// publishRecord ensures the given record is published to the provided zone
+// and the result is returned as a condition. Upon errors during publishing
+// an error object is returned.
+func (r *reconciler) publishRecord(zone configv1.DNSZone, record *iov1.DNSRecord) (iov1.DNSZoneCondition, error) {
+	condition := iov1.DNSZoneCondition{
+		Status:             string(operatorv1.ConditionUnknown),
+		Type:               iov1.DNSRecordPublishedConditionType,
+		LastTransitionTime: metav1.Now(),
+	}
+
+	err := r.dnsProvider.Ensure(record, zone)
+	if err != nil {
+		log.Error(err, "failed to publish DNS record to zone", "record", record.Spec, "dnszone", zone)
+		condition.Status = string(operatorv1.ConditionFalse)
+		condition.Reason = "ProviderError"
+		condition.Message = fmt.Sprintf("The DNS provider failed to ensure the record: %v", err)
+	} else {
+		log.Info("published DNS record to zone", "record", record.Spec, "dnszone", zone)
+		condition.Status = string(operatorv1.ConditionTrue)
+		condition.Reason = "ProviderSuccess"
+		condition.Message = "The DNS provider succeeded in ensuring the record"
+	}
+
+	return condition, err
+}
+
+// publishRecordToZones attempts to publish records and returns a bool
+// indicating if we need to requeue due to errors and list of latest DNS Zone status.
+func (r *reconciler) publishRecordToZones(zones []configv1.DNSZone, record *iov1.DNSRecord) (bool, []iov1.DNSZoneStatus) {
 	var statuses []iov1.DNSZoneStatus
+	var requeue bool
+	dnsPolicy := record.Spec.DNSManagementPolicy
 	for i := range zones {
-		zone := zones[i]
+		isRecordPublished := recordIsAlreadyPublishedToZone(record, &zones[i])
 
 		// Only publish the record if the DNSRecord has been modified
 		// (which would mean the target could have changed) or its
 		// status does not indicate that it has already been published.
-		if record.Generation == record.Status.ObservedGeneration && recordIsAlreadyPublishedToZone(record, &zone) {
-			log.Info("skipping zone to which the DNS record is already published", "record", record.Spec, "dnszone", zone)
+		if record.Generation == record.Status.ObservedGeneration && isRecordPublished {
+			log.Info("skipping zone to which the DNS record is already published", "record", record.Spec, "dnszone", zones[i])
 			continue
 		}
 
-		condition := iov1.DNSZoneCondition{
-			Status:             string(operatorv1.ConditionUnknown),
-			Type:               iov1.DNSRecordFailedConditionType,
-			LastTransitionTime: metav1.Now(),
-		}
-
-		if recordIsAlreadyPublishedToZone(record, &zone) {
-			log.Info("replacing DNS record", "record", record.Spec, "dnszone", zone)
-
-			if err := r.dnsProvider.Replace(record, zone); err != nil {
-				log.Error(err, "failed to replace DNS record in zone", "record", record.Spec, "dnszone", zone)
-				condition.Status = string(operatorv1.ConditionTrue)
-				condition.Reason = "ProviderError"
-				condition.Message = fmt.Sprintf("The DNS provider failed to replace the record: %v", err)
-				result.RequeueAfter = 30 * time.Second
-			} else {
-				log.Info("replaced DNS record in zone", "record", record.Spec, "dnszone", zone)
-				condition.Status = string(operatorv1.ConditionFalse)
-				condition.Reason = "ProviderSuccess"
-				condition.Message = "The DNS provider succeeded in replacing the record"
+		var err error
+		var condition iov1.DNSZoneCondition
+		if dnsPolicy == iov1.UnmanagedDNS {
+			log.Info("DNS record not published", "record", record.Spec)
+			condition = iov1.DNSZoneCondition{
+				Message:            "DNS record is currently not being managed by the operator",
+				Reason:             "UnmanagedDNS",
+				Status:             string(operatorv1.ConditionUnknown),
+				Type:               iov1.DNSRecordPublishedConditionType,
+				LastTransitionTime: metav1.Now(),
 			}
+		} else if isRecordPublished {
+			condition, err = r.replacePublishedRecord(zones[i], record)
 		} else {
-			if err := r.dnsProvider.Ensure(record, zone); err != nil {
-				log.Error(err, "failed to publish DNS record to zone", "record", record.Spec, "dnszone", zone)
-				condition.Status = string(operatorv1.ConditionTrue)
-				condition.Reason = "ProviderError"
-				condition.Message = fmt.Sprintf("The DNS provider failed to ensure the record: %v", err)
-				result.RequeueAfter = 30 * time.Second
-			} else {
-				log.Info("published DNS record to zone", "record", record.Spec, "dnszone", zone)
-				condition.Status = string(operatorv1.ConditionFalse)
-				condition.Reason = "ProviderSuccess"
-				condition.Message = "The DNS provider succeeded in ensuring the record"
-			}
+			condition, err = r.publishRecord(zones[i], record)
 		}
+
+		// Check if replacing or publishing record resulted in an error.
+		// If it did, re-enqueue the request for processing.
+		if err != nil {
+			requeue = true
+		}
+
 		statuses = append(statuses, iov1.DNSZoneStatus{
-			DNSZone:    zone,
+			DNSZone:    zones[i],
 			Conditions: []iov1.DNSZoneCondition{condition},
 		})
 	}
-	return mergeStatuses(zones, record.Status.DeepCopy().Zones, statuses), result
+
+	return requeue, mergeStatuses(zones, record.Status.DeepCopy().Zones, statuses)
 }
 
 // recordIsAlreadyPublishedToZone returns a Boolean value indicating whether the
@@ -323,8 +384,8 @@ func recordIsAlreadyPublishedToZone(record *iov1.DNSRecord, zoneToPublish *confi
 		}
 
 		for _, condition := range zoneInStatus.Conditions {
-			if condition.Type == iov1.DNSRecordFailedConditionType {
-				return condition.Status == string(operatorv1.ConditionFalse)
+			if condition.Type == iov1.DNSRecordPublishedConditionType {
+				return condition.Status == string(operatorv1.ConditionTrue)
 			}
 		}
 	}
@@ -415,6 +476,75 @@ func conditionChanged(a, b iov1.DNSZoneCondition) bool {
 	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
+// migrateRecordStatusConditions purges deprecated fields from DNS Record
+// status. Removes "Failed" (DNSRecordFailedConditionType) and replaces with
+// "Published" (DNSRecordPublishedConditionType). If the status needs to be
+// updated, this function performs the update.  The function returns a Boolean
+// value indicating whether it has performed an update along with the error
+// value from any update it has performed.
+//
+// This function is at least required for 1 minor release and can be removed after
+// Openshift 4.13 is released.
+func (r *reconciler) migrateRecordStatusConditions(record *iov1.DNSRecord) (bool, error) {
+	var updateConditions bool
+	for i := range record.Status.Zones {
+		zone := record.Status.DeepCopy().Zones[i]
+		updateZone, cond := migrateRecordStatusCondition(zone.Conditions)
+		if updateZone {
+			updateConditions = true
+			record.Status.Zones[i].Conditions = cond
+		}
+	}
+	if updateConditions {
+		if err := r.client.Status().Update(context.TODO(), record); err != nil {
+			return false, fmt.Errorf("failed to update dnsrecord status: %w", err)
+		}
+		log.Info("dnsrecord status migrated", "dnsrecord", record)
+		return true, nil
+	}
+	return false, nil
+}
+
+func migrateRecordStatusCondition(conditions []iov1.DNSZoneCondition) (bool, []iov1.DNSZoneCondition) {
+	var result []iov1.DNSZoneCondition
+	var updatedCondition iov1.DNSZoneCondition
+	var updated bool
+	now := metav1.NewTime(clock.Now())
+	for _, cond := range conditions {
+		if cond.Type != iov1.DNSRecordFailedConditionType {
+			updatedCondition = cond
+		} else {
+			updated = true
+			switch cond.Status {
+			case string(operatorv1.ConditionTrue):
+				updatedCondition = iov1.DNSZoneCondition{
+					Type:               iov1.DNSRecordPublishedConditionType,
+					Status:             string(operatorv1.ConditionFalse),
+					LastTransitionTime: now,
+					Reason:             cond.Reason,
+					Message:            cond.Message,
+				}
+			case string(operatorv1.ConditionFalse):
+				updatedCondition = iov1.DNSZoneCondition{
+					Type:               iov1.DNSRecordPublishedConditionType,
+					Status:             string(operatorv1.ConditionTrue),
+					LastTransitionTime: now,
+					Reason:             cond.Reason,
+					Message:            cond.Message,
+				}
+			default:
+				// We don't need to map Failed=Unknown condition
+				// since the operator never set this condition to Unknown.
+				// Since no version of the operator had this condition, we
+				// don't need to migrate it.
+				continue
+			}
+		}
+		result = mergeConditions(result, []iov1.DNSZoneCondition{updatedCondition})
+	}
+	return updated, result
+}
+
 // dnsZoneStatusSlicesEqual compares two DNSZoneStatus slice values.  Returns
 // true if the provided values should be considered equal for the purpose of
 // determining whether an update is necessary, false otherwise.  The comparison
@@ -437,7 +567,7 @@ func dnsZoneStatusSlicesEqual(a, b []iov1.DNSZoneStatus) bool {
 // ToDNSRecords returns reconciliation requests for all DNSRecords.
 func (r *reconciler) ToDNSRecords(o client.Object) []reconcile.Request {
 	var requests []reconcile.Request
-	records := &operatoringressv1.DNSRecordList{}
+	records := &iov1.DNSRecordList{}
 	if err := r.cache.List(context.Background(), records, client.InNamespace(r.config.Namespace)); err != nil {
 		log.Error(err, "failed to list dnsrecords", "related", o.GetSelfLink())
 		return requests
@@ -499,32 +629,32 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 					break
 				case ep.Name == awsdns.Route53Service:
 					route53Found = true
-					scheme, err := operatorutil.URI(ep.URL)
+					scheme, err := oputil.URI(ep.URL)
 					if err != nil {
 						return nil, fmt.Errorf("failed to validate URI %s: %v", ep.URL, err)
 					}
-					if scheme != operatorutil.SchemeHTTPS {
-						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, operatorutil.SchemeHTTPS)
+					if scheme != oputil.SchemeHTTPS {
+						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, oputil.SchemeHTTPS)
 					}
 					cfg.ServiceEndpoints = append(cfg.ServiceEndpoints, awsdns.ServiceEndpoint{Name: ep.Name, URL: ep.URL})
 				case ep.Name == awsdns.ELBService:
 					elbFound = true
-					scheme, err := operatorutil.URI(ep.URL)
+					scheme, err := oputil.URI(ep.URL)
 					if err != nil {
 						return nil, fmt.Errorf("failed to validate URI %s: %v", ep.URL, err)
 					}
-					if scheme != operatorutil.SchemeHTTPS {
-						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, operatorutil.SchemeHTTPS)
+					if scheme != oputil.SchemeHTTPS {
+						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, oputil.SchemeHTTPS)
 					}
 					cfg.ServiceEndpoints = append(cfg.ServiceEndpoints, awsdns.ServiceEndpoint{Name: ep.Name, URL: ep.URL})
 				case ep.Name == awsdns.TaggingService:
 					tagFound = true
-					scheme, err := operatorutil.URI(ep.URL)
+					scheme, err := oputil.URI(ep.URL)
 					if err != nil {
 						return nil, fmt.Errorf("failed to validate URI %s: %v", ep.URL, err)
 					}
-					if scheme != operatorutil.SchemeHTTPS {
-						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, operatorutil.SchemeHTTPS)
+					if scheme != oputil.SchemeHTTPS {
+						return nil, fmt.Errorf("invalid scheme for URI %s; must be %s", ep.URL, oputil.SchemeHTTPS)
 					}
 					cfg.ServiceEndpoints = append(cfg.ServiceEndpoints, awsdns.ServiceEndpoint{Name: ep.Name, URL: ep.URL})
 				}
@@ -591,7 +721,7 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 			return &dns.FakeProvider{}, nil
 		}
 	case configv1.PowerVSPlatformType:
-		//Power VS platform will use the ibm dns implementation
+		// Power VS platform will use the ibm dns implementation
 		var err error
 		if platformStatus.PowerVS.CISInstanceCRN != "" {
 			dnsProvider, err = getIbmDNSProvider(dnsConfig, creds, platformStatus.PowerVS.CISInstanceCRN, userAgent, true)

--- a/pkg/operator/controller/dns/controller_test.go
+++ b/pkg/operator/controller/dns/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
@@ -15,17 +16,28 @@ import (
 )
 
 func TestPublishRecordToZones(t *testing.T) {
-	var tests = []struct {
-		name   string
-		zones  []configv1.DNSZone
-		expect []string
+	tests := []struct {
+		name         string
+		zones        []configv1.DNSZone
+		unManagedDNS bool
+		expect       []iov1.DNSZoneStatus
 	}{
 		{
 			name: "testing for a successful update of 1 record",
-			zones: []configv1.DNSZone{{
-				ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
+			zones: []configv1.DNSZone{
+				{ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
 			},
-			expect: []string{string(operatorv1.ConditionFalse)},
+			expect: []iov1.DNSZoneStatus{{
+				DNSZone: configv1.DNSZone{
+					ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io",
+				},
+				Conditions: []iov1.DNSZoneCondition{
+					{
+						Type:   "Published",
+						Status: "True",
+					},
+				},
+			}},
 		},
 		{
 			name:   "when no zones available",
@@ -36,32 +48,80 @@ func TestPublishRecordToZones(t *testing.T) {
 			name: "when one zone available and one not available",
 			zones: []configv1.DNSZone{
 				{ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
-				{ID: ""}},
-			expect: []string{string(operatorv1.ConditionFalse), string(operatorv1.ConditionFalse)},
+				{ID: ""},
+			},
+			expect: []iov1.DNSZoneStatus{
+				{
+					DNSZone: configv1.DNSZone{ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "True",
+						},
+					},
+				},
+				{
+					DNSZone: configv1.DNSZone{ID: ""},
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "True",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "when one zone available and one not available and unmanaged DNS policy",
+			zones: []configv1.DNSZone{
+				{ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
+				{ID: ""},
+			},
+			unManagedDNS: true,
+			expect: []iov1.DNSZoneStatus{
+				{
+					DNSZone: configv1.DNSZone{ID: "/subscriptions/E540B02D-5CCE-4D47-A13B-EB05A19D696E/resourceGroups/test-rg/providers/Microsoft.Network/dnszones/dnszone.io"},
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "Unknown",
+						},
+					},
+				},
+				{
+					DNSZone: configv1.DNSZone{ID: ""},
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "Unknown",
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for _, test := range tests {
 		record := &iov1.DNSRecord{
 			Spec: iov1.DNSRecordSpec{
-				DNSName:    "subdomain.dnszone.io.",
-				RecordType: iov1.ARecordType,
-				Targets:    []string{"55.11.22.33"},
+				DNSName:             "subdomain.dnszone.io.",
+				RecordType:          iov1.ARecordType,
+				DNSManagementPolicy: iov1.ManagedDNS,
+				Targets:             []string{"55.11.22.33"},
 			},
 		}
+		if test.unManagedDNS {
+			record.Spec.DNSManagementPolicy = iov1.UnmanagedDNS
+		}
 		r := &reconciler{
-			//TODO To write a fake provider that can return errors and add more test cases.
+			// TODO To write a fake provider that can return errors and add more test cases.
 			dnsProvider: &dns.FakeProvider{},
 		}
-		actual, _ := r.publishRecordToZones(test.zones, record)
-		var conditions []string
-		for _, dnsStatus := range actual {
-			for _, condition := range dnsStatus.Conditions {
-				conditions = append(conditions, condition.Status)
-			}
-		}
-		if !cmp.Equal(conditions, test.expect) {
-			t.Fatalf("%q: expected:\n%#v\ngot:\n%#v", test.name, test.expect, conditions)
+
+		_, actual := r.publishRecordToZones(test.zones, record)
+		opts := cmpopts.IgnoreFields(iov1.DNSZoneCondition{}, "Reason", "Message", "LastTransitionTime")
+		if !cmp.Equal(actual, test.expect, opts) {
+			t.Fatalf("%q: found diff between actual and expected:\n%s", test.name, cmp.Diff(actual, test.expect, opts))
 		}
 	}
 }
@@ -69,7 +129,7 @@ func TestPublishRecordToZones(t *testing.T) {
 // TestPublishRecordToZonesMergesStatus verifies that publishRecordToZones
 // correctly merges status updates.
 func TestPublishRecordToZonesMergesStatus(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		description     string
 		oldZoneStatuses []iov1.DNSZoneStatus
 		expectChange    bool
@@ -99,8 +159,8 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -116,8 +176,8 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 						},
 					},
 				},
@@ -133,8 +193,8 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:    "Failed",
-							Status:  "False",
+							Type:    "Published",
+							Status:  "True",
 							Reason:  "ProviderSuccess",
 							Message: "The DNS provider succeeded in ensuring the record",
 						},
@@ -147,17 +207,156 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		record := &iov1.DNSRecord{
+			Spec: iov1.DNSRecordSpec{
+				DNSManagementPolicy: iov1.ManagedDNS,
+			},
 			Status: iov1.DNSRecordStatus{Zones: tc.oldZoneStatuses},
 		}
 		r := &reconciler{dnsProvider: &dns.FakeProvider{}}
 		zone := []configv1.DNSZone{{ID: "zone2"}}
 		oldStatuses := record.Status.DeepCopy().Zones
-		newStatuses, _ := r.publishRecordToZones(zone, record)
+		_, newStatuses := r.publishRecordToZones(zone, record)
 		if !dnsZoneStatusSlicesEqual(oldStatuses, tc.oldZoneStatuses) {
 			t.Fatalf("%q: publishRecordToZones mutated the record's status conditions\nold: %#v\nnew: %#v", tc.description, oldStatuses, tc.oldZoneStatuses)
 		}
 		if equal := dnsZoneStatusSlicesEqual(oldStatuses, newStatuses); !equal != tc.expectChange {
 			t.Fatalf("%q: expected old and new status equal to be %v, got %v\nold: %#v\nnew: %#v", tc.description, tc.expectChange, equal, oldStatuses, newStatuses)
+		}
+	}
+}
+
+func TestMigrateDNSRecordStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []iov1.DNSZoneCondition
+		expected   []iov1.DNSZoneCondition
+		changed    bool
+	}{
+		{
+			name: "DNS record has previously failed records",
+			conditions: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordFailedConditionType,
+					Status: string(operatorv1.ConditionTrue),
+				},
+			},
+			expected: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordPublishedConditionType,
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			changed: true,
+		},
+		{
+			name: "DNS record has previously succeeded records",
+			conditions: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordFailedConditionType,
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			expected: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordPublishedConditionType,
+					Status: string(operatorv1.ConditionTrue),
+				},
+			},
+			changed: true,
+		},
+		{
+			name: "DNS record has unrelated status condition",
+			conditions: []iov1.DNSZoneCondition{
+				{
+					Type:   "UnrelatedType",
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			expected: []iov1.DNSZoneCondition{
+				{
+					Type:   "UnrelatedType",
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			changed: false,
+		},
+		{
+			name: "DNS record has unrelated status and Failed condition",
+			conditions: []iov1.DNSZoneCondition{
+				{
+					Type:   "UnrelatedType",
+					Status: string(operatorv1.ConditionFalse),
+				},
+				{
+					Type:   iov1.DNSRecordFailedConditionType,
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			expected: []iov1.DNSZoneCondition{
+				{
+					Type:   "UnrelatedType",
+					Status: string(operatorv1.ConditionFalse),
+				},
+				{
+					Type:   iov1.DNSRecordPublishedConditionType,
+					Status: string(operatorv1.ConditionTrue),
+				},
+			},
+			changed: true,
+		},
+		{
+			name: "DNS record has Published condition and Failed condition",
+			conditions: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordPublishedConditionType,
+					Status: string(operatorv1.ConditionFalse),
+				},
+				{
+					Type:   iov1.DNSRecordFailedConditionType,
+					Status: string(operatorv1.ConditionFalse),
+				},
+			},
+			expected: []iov1.DNSZoneCondition{
+				{
+					Type:   iov1.DNSRecordPublishedConditionType,
+					Status: string(operatorv1.ConditionTrue),
+				},
+			},
+			changed: true,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	iov1.AddToScheme(scheme)
+
+	testDNSRecord := &iov1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sample-dns-record",
+		},
+		Status: iov1.DNSRecordStatus{
+			Zones: []iov1.DNSZoneStatus{
+				{
+					DNSZone: configv1.DNSZone{ID: "sample-zone"},
+				},
+			},
+		},
+	}
+
+	client := fake.NewFakeClientWithScheme(scheme, testDNSRecord)
+	r := reconciler{client: client}
+	for _, tc := range tests {
+
+		testDNSRecord.Status.Zones[0].Conditions = tc.conditions
+		changed, _ := r.migrateRecordStatusConditions(testDNSRecord)
+		if changed != tc.changed {
+			t.Fatalf("DNS record status not updated, expected status condition to be updated")
+		}
+
+		t.Logf("\n%+v", testDNSRecord.Status)
+
+		opts := cmpopts.IgnoreFields(iov1.DNSZoneCondition{}, "Reason", "Message", "LastTransitionTime")
+		if !cmp.Equal(testDNSRecord.Status.Zones[0].Conditions, tc.expected, opts) {
+			t.Fatalf("%q: status condition found diff:\n%s", tc.name, cmp.Diff(testDNSRecord.Status.Zones[0].Conditions, tc.expected, opts))
 		}
 	}
 }
@@ -193,8 +392,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -206,8 +405,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -223,8 +422,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 						},
 					},
 				},
@@ -253,8 +452,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 						},
 					},
 				},
@@ -266,8 +465,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -283,8 +482,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:               "Failed",
-							Status:             "True",
+							Type:               "Published",
+							Status:             "False",
 							LastTransitionTime: metav1.Unix(0, 0),
 						},
 					},
@@ -297,8 +496,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:               "Failed",
-							Status:             "True",
+							Type:               "Published",
+							Status:             "False",
 							LastTransitionTime: metav1.Unix(1, 0),
 						},
 					},
@@ -315,8 +514,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 							Reason: "foo",
 						},
 					},
@@ -329,8 +528,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 							Reason: "bar",
 						},
 					},
@@ -347,8 +546,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 						{
 							Type:   "Ready",
@@ -368,8 +567,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 							Status: "True",
 						},
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -385,12 +584,12 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -402,8 +601,8 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 					},
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},
@@ -423,7 +622,7 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 		zoneWithId  = configv1.DNSZone{ID: "foo"}
 		zoneWithTag = configv1.DNSZone{Tags: map[string]string{"foo": "bar"}}
 	)
-	var testCases = []struct {
+	testCases := []struct {
 		description  string
 		zone         *configv1.DNSZone
 		zoneStatuses []iov1.DNSZoneStatus
@@ -436,14 +635,14 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 			expect:       false,
 		},
 		{
-			description: "status.zones has an entry with matching id but Failed=Unknown",
+			description: "status.zones has an entry with matching id but Published=Unknown",
 			zone:        &zoneWithId,
 			zoneStatuses: []iov1.DNSZoneStatus{
 				{
 					DNSZone: zoneWithId,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
+							Type:   "Published",
 							Status: "Unknown",
 						},
 					},
@@ -452,7 +651,7 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 					DNSZone: zoneWithTag,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
+							Type:   "Published",
 							Status: "Unknown",
 						},
 					},
@@ -461,64 +660,14 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 			expect: false,
 		},
 		{
-			description: "status.zones has an entry with matching id but Failed=True",
+			description: "status.zones has an entry with matching id but Published=False",
 			zone:        &zoneWithId,
 			zoneStatuses: []iov1.DNSZoneStatus{
 				{
 					DNSZone: zoneWithId,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
-						},
-					},
-				},
-				{
-					DNSZone: zoneWithTag,
-					Conditions: []iov1.DNSZoneCondition{
-						{
-							Type:   "Failed",
-							Status: "True",
-						},
-					},
-				},
-			},
-			expect: false,
-		},
-		{
-			description: "status.zones has an entry with matching tag but Failed=True",
-			zone:        &zoneWithTag,
-			zoneStatuses: []iov1.DNSZoneStatus{
-				{
-					DNSZone: zoneWithId,
-					Conditions: []iov1.DNSZoneCondition{
-						{
-							Type:   "Failed",
-							Status: "True",
-						},
-					},
-				},
-				{
-					DNSZone: zoneWithTag,
-					Conditions: []iov1.DNSZoneCondition{
-						{
-							Type:   "Failed",
-							Status: "True",
-						},
-					},
-				},
-			},
-			expect: false,
-		},
-		{
-			description: "status.zones has an entry with matching id and Failed=False",
-			zone:        &zoneWithId,
-			zoneStatuses: []iov1.DNSZoneStatus{
-				{
-					DNSZone: zoneWithId,
-					Conditions: []iov1.DNSZoneCondition{
-						{
-							Type:   "Failed",
+							Type:   "Published",
 							Status: "False",
 						},
 					},
@@ -527,7 +676,57 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 					DNSZone: zoneWithTag,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
+							Type:   "Published",
+							Status: "False",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			description: "status.zones has an entry with matching tag but Published=False",
+			zone:        &zoneWithTag,
+			zoneStatuses: []iov1.DNSZoneStatus{
+				{
+					DNSZone: zoneWithId,
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "False",
+						},
+					},
+				},
+				{
+					DNSZone: zoneWithTag,
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "False",
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			description: "status.zones has an entry with matching id and Published=True",
+			zone:        &zoneWithId,
+			zoneStatuses: []iov1.DNSZoneStatus{
+				{
+					DNSZone: zoneWithId,
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
+							Status: "True",
+						},
+					},
+				},
+				{
+					DNSZone: zoneWithTag,
+					Conditions: []iov1.DNSZoneCondition{
+						{
+							Type:   "Published",
 							Status: "True",
 						},
 					},
@@ -536,15 +735,15 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "status.zones has an entry with matching tag and Failed=False",
+			description: "status.zones has an entry with matching tag and Published=True",
 			zone:        &zoneWithTag,
 			zoneStatuses: []iov1.DNSZoneStatus{
 				{
 					DNSZone: zoneWithId,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "True",
+							Type:   "Published",
+							Status: "False",
 						},
 					},
 				},
@@ -552,8 +751,8 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 					DNSZone: zoneWithTag,
 					Conditions: []iov1.DNSZoneCondition{
 						{
-							Type:   "Failed",
-							Status: "False",
+							Type:   "Published",
+							Status: "True",
 						},
 					},
 				},

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -82,8 +82,8 @@ func TestSetDefaultDomain(t *testing.T) {
 		},
 		{
 			name:           "spec has custom domain, status has cluster ingress domain",
-			ic:             makeIC(ingressConfig.Spec.Domain, "otherdomain.com"),
-			expectedIC:     makeIC(ingressConfig.Spec.Domain, "otherdomain.com"),
+			ic:             makeIC("otherdomain.com", ingressConfig.Spec.Domain),
+			expectedIC:     makeIC("otherdomain.com", ingressConfig.Spec.Domain),
 			expectedResult: false,
 		},
 		{
@@ -117,7 +117,19 @@ func TestSetDefaultPublishingStrategySetsPlatformDefaults(t *testing.T) {
 				EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
 					Type: operatorv1.LoadBalancerServiceStrategyType,
 					LoadBalancer: &operatorv1.LoadBalancerStrategy{
-						Scope: operatorv1.ExternalLoadBalancer,
+						DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						Scope:               operatorv1.ExternalLoadBalancer,
+					},
+				},
+			},
+		}
+		ingressControllerWithLoadBalancerUnmanagedDNS = &operatorv1.IngressController{
+			Status: operatorv1.IngressControllerStatus{
+				EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+					Type: operatorv1.LoadBalancerServiceStrategyType,
+					LoadBalancer: &operatorv1.LoadBalancerStrategy{
+						DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
+						Scope:               operatorv1.ExternalLoadBalancer,
 					},
 				},
 			},
@@ -143,86 +155,107 @@ func TestSetDefaultPublishingStrategySetsPlatformDefaults(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name           string
-		platformStatus *configv1.PlatformStatus
-		expectedIC     *operatorv1.IngressController
+		name                    string
+		platformStatus          *configv1.PlatformStatus
+		expectedIC              *operatorv1.IngressController
+		domainMatchesBaseDomain bool
 	}{
 		{
-			name:           "Alibaba",
-			platformStatus: makePlatformStatus(configv1.AlibabaCloudPlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "Alibaba",
+			platformStatus:          makePlatformStatus(configv1.AlibabaCloudPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "AWS",
-			platformStatus: makePlatformStatus(configv1.AWSPlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "AWS",
+			platformStatus:          makePlatformStatus(configv1.AWSPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Azure",
-			platformStatus: makePlatformStatus(configv1.AzurePlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "Azure",
+			platformStatus:          makePlatformStatus(configv1.AzurePlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Bare metal",
-			platformStatus: makePlatformStatus(configv1.BareMetalPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "Bare metal",
+			platformStatus:          makePlatformStatus(configv1.BareMetalPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Equinix Metal",
-			platformStatus: makePlatformStatus(configv1.EquinixMetalPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "Equinix Metal",
+			platformStatus:          makePlatformStatus(configv1.EquinixMetalPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "GCP",
-			platformStatus: makePlatformStatus(configv1.GCPPlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "GCP",
+			platformStatus:          makePlatformStatus(configv1.GCPPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "IBM Cloud",
-			platformStatus: makePlatformStatus(configv1.IBMCloudPlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "IBM Cloud",
+			platformStatus:          makePlatformStatus(configv1.IBMCloudPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Libvirt",
-			platformStatus: makePlatformStatus(configv1.LibvirtPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "Libvirt",
+			platformStatus:          makePlatformStatus(configv1.LibvirtPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "No platform",
-			platformStatus: makePlatformStatus(configv1.NonePlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "No platform",
+			platformStatus:          makePlatformStatus(configv1.NonePlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "OpenStack",
-			platformStatus: makePlatformStatus(configv1.OpenStackPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "OpenStack",
+			platformStatus:          makePlatformStatus(configv1.OpenStackPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Power VS",
-			platformStatus: makePlatformStatus(configv1.PowerVSPlatformType),
-			expectedIC:     ingressControllerWithLoadBalancer,
+			name:                    "Power VS",
+			platformStatus:          makePlatformStatus(configv1.PowerVSPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancer,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "RHV",
-			platformStatus: makePlatformStatus(configv1.OvirtPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "RHV",
+			platformStatus:          makePlatformStatus(configv1.OvirtPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "vSphere",
-			platformStatus: makePlatformStatus(configv1.VSpherePlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "vSphere",
+			platformStatus:          makePlatformStatus(configv1.VSpherePlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "Nutanix",
-			platformStatus: makePlatformStatus(configv1.NutanixPlatformType),
-			expectedIC:     ingressControllerWithHostNetwork,
+			name:                    "Nutanix",
+			platformStatus:          makePlatformStatus(configv1.NutanixPlatformType),
+			expectedIC:              ingressControllerWithHostNetwork,
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "AWS Unmanaged DNS",
+			platformStatus:          makePlatformStatus(configv1.AWSPlatformType),
+			expectedIC:              ingressControllerWithLoadBalancerUnmanagedDNS,
+			domainMatchesBaseDomain: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ic := &operatorv1.IngressController{}
 			platformStatus := tc.platformStatus.DeepCopy()
-			if actualResult := setDefaultPublishingStrategy(ic, platformStatus); actualResult != true {
+			if actualResult := setDefaultPublishingStrategy(ic, platformStatus, tc.domainMatchesBaseDomain); actualResult != true {
 				t.Errorf("expected result %v, got %v", true, actualResult)
 			}
 			if diff := cmp.Diff(tc.expectedIC, ic); len(diff) != 0 {
@@ -237,7 +270,9 @@ func TestSetDefaultPublishingStrategySetsPlatformDefaults(t *testing.T) {
 // spec.endpointPublishingStrategy.
 func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 	var (
-		makeIC = func(spec operatorv1.IngressControllerSpec, status operatorv1.IngressControllerStatus) *operatorv1.IngressController {
+		managedDNS   = operatorv1.ManagedLoadBalancerDNS
+		unmanagedDNS = operatorv1.UnmanagedLoadBalancerDNS
+		makeIC       = func(spec operatorv1.IngressControllerSpec, status operatorv1.IngressControllerStatus) *operatorv1.IngressController {
 			return &operatorv1.IngressController{Spec: spec, Status: status}
 		}
 		spec = func(eps *operatorv1.EndpointPublishingStrategy) operatorv1.IngressControllerSpec {
@@ -250,16 +285,23 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 				EndpointPublishingStrategy: eps,
 			}
 		}
-		lb = func(scope operatorv1.LoadBalancerScope) *operatorv1.EndpointPublishingStrategy {
+		lbs = func(scope operatorv1.LoadBalancerScope, policy *operatorv1.LoadBalancerDNSManagementPolicy) *operatorv1.LoadBalancerStrategy {
+			lbs := &operatorv1.LoadBalancerStrategy{
+				Scope: scope,
+			}
+			if policy != nil {
+				lbs.DNSManagementPolicy = *policy
+			}
+			return lbs
+		}
+		eps = func(lbs *operatorv1.LoadBalancerStrategy) *operatorv1.EndpointPublishingStrategy {
 			return &operatorv1.EndpointPublishingStrategy{
-				Type: operatorv1.LoadBalancerServiceStrategyType,
-				LoadBalancer: &operatorv1.LoadBalancerStrategy{
-					Scope: scope,
-				},
+				Type:         operatorv1.LoadBalancerServiceStrategyType,
+				LoadBalancer: lbs,
 			}
 		}
 		elb = func() *operatorv1.EndpointPublishingStrategy {
-			eps := lb(operatorv1.ExternalLoadBalancer)
+			eps := eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))
 			eps.LoadBalancer.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
 				Type: operatorv1.AWSLoadBalancerProvider,
 				AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -269,7 +311,7 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 			return eps
 		}
 		elbWithNullParameters = func() *operatorv1.EndpointPublishingStrategy {
-			eps := lb(operatorv1.ExternalLoadBalancer)
+			eps := eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))
 			eps.LoadBalancer.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
 				Type: operatorv1.AWSLoadBalancerProvider,
 				AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -280,7 +322,7 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 			return eps
 		}
 		elbWithIdleTimeout = func(timeout metav1.Duration) *operatorv1.EndpointPublishingStrategy {
-			eps := lb(operatorv1.ExternalLoadBalancer)
+			eps := eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))
 			eps.LoadBalancer.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
 				Type: operatorv1.AWSLoadBalancerProvider,
 				AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -293,7 +335,7 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 			return eps
 		}
 		nlb = func() *operatorv1.EndpointPublishingStrategy {
-			eps := lb(operatorv1.ExternalLoadBalancer)
+			eps := eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))
 			eps.LoadBalancer.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
 				Type: operatorv1.AWSLoadBalancerProvider,
 				AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -303,7 +345,7 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 			return eps
 		}
 		gcpLB = func(clientAccess operatorv1.GCPClientAccess) *operatorv1.EndpointPublishingStrategy {
-			eps := lb(operatorv1.ExternalLoadBalancer)
+			eps := eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))
 			eps.LoadBalancer.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
 				Type: operatorv1.GCPLoadBalancerProvider,
 				GCP: &operatorv1.GCPLoadBalancerParameters{
@@ -368,201 +410,253 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name           string
-		ic             *operatorv1.IngressController
-		expectedIC     *operatorv1.IngressController
-		expectedResult bool
+		name                    string
+		ic                      *operatorv1.IngressController
+		expectedIC              *operatorv1.IngressController
+		expectedResult          bool
+		domainMatchesBaseDomain bool
 	}{
 		{
-			name:           "loadbalancer scope changed from external to internal",
-			ic:             makeIC(spec(lb(operatorv1.InternalLoadBalancer)), status(lb(operatorv1.ExternalLoadBalancer))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(lb(operatorv1.InternalLoadBalancer)), status(lb(operatorv1.InternalLoadBalancer))),
+			name:                    "loadbalancer scope changed from external to internal",
+			ic:                      makeIC(spec(eps(lbs(operatorv1.InternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS)))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(eps(lbs(operatorv1.InternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.InternalLoadBalancer, &managedDNS)))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer scope changed from internal to external",
-			ic:             makeIC(spec(lb(operatorv1.ExternalLoadBalancer)), status(lb(operatorv1.InternalLoadBalancer))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(lb(operatorv1.ExternalLoadBalancer)), status(lb(operatorv1.ExternalLoadBalancer))),
+			name:                    "loadbalancer scope changed from internal to external",
+			ic:                      makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.InternalLoadBalancer, &managedDNS)))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS)))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer type set to ELB",
-			ic:             makeIC(spec(elb()), status(elb())),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(elb()), status(elbWithNullParameters())),
+			name:                    "loadbalancer type set to ELB",
+			ic:                      makeIC(spec(elb()), status(elb())),
+			expectedResult:          false,
+			expectedIC:              makeIC(spec(elb()), status(elbWithNullParameters())),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer type set to NLB",
-			ic:             makeIC(spec(nlb()), status(nlb())),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(nlb()), status(nlb())),
+			name:                    "loadbalancer type set to NLB",
+			ic:                      makeIC(spec(nlb()), status(nlb())),
+			expectedResult:          false,
+			expectedIC:              makeIC(spec(nlb()), status(nlb())),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer type changed from ELB to NLB",
-			ic:             makeIC(spec(nlb()), status(elb())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(nlb()), status(nlb())),
+			name:                    "loadbalancer type changed from ELB to NLB",
+			ic:                      makeIC(spec(nlb()), status(elb())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nlb()), status(nlb())),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer type changed from NLB to ELB",
-			ic:             makeIC(spec(elb()), status(nlb())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(elb()), status(elbWithNullParameters())),
+			name:                    "loadbalancer type changed from NLB to ELB",
+			ic:                      makeIC(spec(elb()), status(nlb())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(elb()), status(elbWithNullParameters())),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer ELB connection idle timeout changed from unset with null provider parameters to 2m",
-			ic:             makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithNullParameters())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
+			name:                    "loadbalancer ELB connection idle timeout changed from unset with null provider parameters to 2m",
+			ic:                      makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithNullParameters())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer ELB connection idle timeout changed from unset with empty provider parameters to 2m",
-			ic:             makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{}))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
+			name:                    "loadbalancer ELB connection idle timeout changed from unset with empty provider parameters to 2m",
+			ic:                      makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{}))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute})), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer ELB connection idle timeout changed from unset to -1s",
-			ic:             makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: -1 * time.Second})), status(elb())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: -1 * time.Second})), status(elbWithIdleTimeout(metav1.Duration{}))),
+			name:                    "loadbalancer ELB connection idle timeout changed from unset to -1s",
+			ic:                      makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: -1 * time.Second})), status(elb())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(elbWithIdleTimeout(metav1.Duration{Duration: -1 * time.Second})), status(elbWithIdleTimeout(metav1.Duration{}))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer ELB connection idle timeout changed from 2m to unset",
-			ic:             makeIC(spec(elb()), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(elb()), status(elbWithIdleTimeout(metav1.Duration{}))),
+			name:                    "loadbalancer ELB connection idle timeout changed from 2m to unset",
+			ic:                      makeIC(spec(elb()), status(elbWithIdleTimeout(metav1.Duration{Duration: 2 * time.Minute}))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(elb()), status(elbWithIdleTimeout(metav1.Duration{}))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer GCP Global Access changed from unset to global",
-			ic:             makeIC(spec(gcpLB(operatorv1.GCPGlobalAccess)), status(lb(operatorv1.ExternalLoadBalancer))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(gcpLB(operatorv1.GCPGlobalAccess)), status(gcpLB(operatorv1.GCPGlobalAccess))),
+			name:                    "loadbalancer GCP Global Access changed from unset to global",
+			ic:                      makeIC(spec(gcpLB(operatorv1.GCPGlobalAccess)), status(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS)))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(gcpLB(operatorv1.GCPGlobalAccess)), status(gcpLB(operatorv1.GCPGlobalAccess))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "loadbalancer GCP Global Access changed from global to local",
-			ic:             makeIC(spec(gcpLB(operatorv1.GCPLocalAccess)), status(gcpLB(operatorv1.GCPGlobalAccess))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(gcpLB(operatorv1.GCPLocalAccess)), status(gcpLB(operatorv1.GCPLocalAccess))),
-		},
-		{
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1997226
-			name:           "nodeport protocol changed to PROXY with null status.endpointPublishingStrategy.nodePort",
-			ic:             makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePortWithNull())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
-		},
-		{
-			name:           "nodeport spec.endpointPublishingStrategy.nodePort set to null",
-			ic:             makeIC(spec(nodePortWithNull()), status(nodePort(operatorv1.TCPProtocol))),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(nodePortWithNull()), status(nodePort(operatorv1.TCPProtocol))),
-		},
-		{
-			name:           "nodeport protocol changed from empty to PROXY",
-			ic:             makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(""))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
-		},
-		{
-			name:           "nodeport protocol changed from TCP to PROXY",
-			ic:             makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
-		},
-		{
-			name:           "nodeport protocol changed from PROXY to TCP",
-			ic:             makeIC(spec(nodePort(operatorv1.TCPProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(nodePort(operatorv1.TCPProtocol)), status(nodePort(operatorv1.TCPProtocol))),
+			name:                    "loadbalancer GCP Global Access changed from global to local",
+			ic:                      makeIC(spec(gcpLB(operatorv1.GCPLocalAccess)), status(gcpLB(operatorv1.GCPGlobalAccess))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(gcpLB(operatorv1.GCPLocalAccess)), status(gcpLB(operatorv1.GCPLocalAccess))),
+			domainMatchesBaseDomain: true,
 		},
 		{
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1997226
-			name:           "hostnetwork protocol changed to PROXY with null status.endpointPublishingStrategy.hostNetwork",
-			ic:             makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetworkWithNull())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			name:                    "nodeport protocol changed to PROXY with null status.endpointPublishingStrategy.nodePort",
+			ic:                      makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePortWithNull())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork protocol changed from empty to PROXY",
-			ic:             makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(""))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			name:                    "nodeport spec.endpointPublishingStrategy.nodePort set to null",
+			ic:                      makeIC(spec(nodePortWithNull()), status(nodePort(operatorv1.TCPProtocol))),
+			expectedResult:          false,
+			expectedIC:              makeIC(spec(nodePortWithNull()), status(nodePort(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork protocol changed from TCP to PROXY",
-			ic:             makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			name:                    "nodeport protocol changed from empty to PROXY",
+			ic:                      makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(""))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork protocol changed from PROXY to TCP",
-			ic:             makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			name:                    "nodeport protocol changed from TCP to PROXY",
+			ic:                      makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nodePort(operatorv1.ProxyProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork ports changed",
-			ic:             makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			name:                    "nodeport protocol changed from PROXY to TCP",
+			ic:                      makeIC(spec(nodePort(operatorv1.TCPProtocol)), status(nodePort(operatorv1.ProxyProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nodePort(operatorv1.TCPProtocol)), status(nodePort(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork ports changed, with status null",
-			ic:             makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(hostNetworkWithNull())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1997226
+			name:                    "hostnetwork protocol changed to PROXY with null status.endpointPublishingStrategy.hostNetwork",
+			ic:                      makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetworkWithNull())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork ports removed",
-			ic:             makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			name:                    "hostnetwork protocol changed from empty to PROXY",
+			ic:                      makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(""))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "hostnetwork ports removed, with spec null",
-			ic:             makeIC(spec(hostNetworkWithNull()), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(hostNetworkWithNull()), status(hostNetwork(operatorv1.TCPProtocol))),
+			name:                    "hostnetwork protocol changed from TCP to PROXY",
+			ic:                      makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetwork(operatorv1.ProxyProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "private protocol changed to PROXY with null status.endpointPublishingStrategy.private",
-			ic:             makeIC(spec(private(operatorv1.ProxyProtocol)), status(privateWithNull())),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			name:                    "hostnetwork protocol changed from PROXY to TCP",
+			ic:                      makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.ProxyProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "private spec.endpointPublishingStrategy.private set to null",
-			ic:             makeIC(spec(privateWithNull()), status(private(operatorv1.TCPProtocol))),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(privateWithNull()), status(private(operatorv1.TCPProtocol))),
+			name:                    "hostnetwork ports changed",
+			ic:                      makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "private protocol changed from empty to PROXY",
-			ic:             makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(""))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			name:                    "hostnetwork ports changed, with status null",
+			ic:                      makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(hostNetworkWithNull())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "private protocol changed from TCP to PROXY",
-			ic:             makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.TCPProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			name:                    "hostnetwork ports removed",
+			ic:                      makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetwork(operatorv1.TCPProtocol)), status(hostNetwork(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
 		},
 		{
-			name:           "private protocol changed from PROXY to TCP",
-			ic:             makeIC(spec(private(operatorv1.TCPProtocol)), status(private(operatorv1.ProxyProtocol))),
-			expectedResult: true,
-			expectedIC:     makeIC(spec(private(operatorv1.TCPProtocol)), status(private(operatorv1.TCPProtocol))),
+			name:                    "hostnetwork ports removed, with spec null",
+			ic:                      makeIC(spec(hostNetworkWithNull()), status(customHostNetwork(8080, 8443, 8136, operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(hostNetworkWithNull()), status(hostNetwork(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "private protocol changed to PROXY with null status.endpointPublishingStrategy.private",
+			ic:                      makeIC(spec(private(operatorv1.ProxyProtocol)), status(privateWithNull())),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "private spec.endpointPublishingStrategy.private set to null",
+			ic:                      makeIC(spec(privateWithNull()), status(private(operatorv1.TCPProtocol))),
+			expectedResult:          false,
+			expectedIC:              makeIC(spec(privateWithNull()), status(private(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "private protocol changed from empty to PROXY",
+			ic:                      makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(""))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "private protocol changed from TCP to PROXY",
+			ic:                      makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.TCPProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(private(operatorv1.ProxyProtocol)), status(private(operatorv1.ProxyProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "private protocol changed from PROXY to TCP",
+			ic:                      makeIC(spec(private(operatorv1.TCPProtocol)), status(private(operatorv1.ProxyProtocol))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(private(operatorv1.TCPProtocol)), status(private(operatorv1.TCPProtocol))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "loadbalancer dnsManagementPolicy changed from Managed to Unmanaged",
+			ic:                      makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &unmanagedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS)))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &unmanagedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &unmanagedDNS)))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "loadbalancer dnsManagementPolicy changed from Unmanaged to Managed",
+			ic:                      makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &unmanagedDNS)))),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS))), status(eps(lbs(operatorv1.ExternalLoadBalancer, &managedDNS)))),
+			domainMatchesBaseDomain: true,
+		},
+		{
+			name:                    "when endpointPublishingStrategy is nil, loadbalancer dnsManagementPolicy defaults to Unmanaged due to domain mismatch with base domain",
+			ic:                      makeIC(spec(nil), status(nil)),
+			expectedResult:          true,
+			expectedIC:              makeIC(spec(nil), status(eps(lbs(operatorv1.ExternalLoadBalancer, &unmanagedDNS)))),
+			domainMatchesBaseDomain: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ic := tc.ic.DeepCopy()
 			platformStatus := &configv1.PlatformStatus{
-				Type: configv1.NonePlatformType,
+				Type: configv1.AWSPlatformType,
 			}
-			if actualResult := setDefaultPublishingStrategy(ic, platformStatus); actualResult != tc.expectedResult {
+			if actualResult := setDefaultPublishingStrategy(ic, platformStatus, tc.domainMatchesBaseDomain); actualResult != tc.expectedResult {
 				t.Errorf("expected result %v, got %v", tc.expectedResult, actualResult)
 			}
 			if diff := cmp.Diff(tc.expectedIC, ic); len(diff) != 0 {
@@ -576,9 +670,11 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 	invalidTLSVersion := configv1.TLSProtocolVersion("abc")
 	invalidCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384", "invalid cipher"}
 	validCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384"}
-	tlsVersion13Ciphers := []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+	tlsVersion13Ciphers := []string{
+		"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
 		"TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256", "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
-		"TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256"}
+		"TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_CCM_SHA256", "TLS_AES_128_CCM_8_SHA256",
+	}
 	tlsVersion1213Ciphers := []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "ECDHE-ECDSA-AES256-GCM-SHA384"}
 	testCases := []struct {
 		description  string
@@ -586,7 +682,6 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 		valid        bool
 		expectedSpec *configv1.TLSProfileSpec
 	}{
-
 		{
 			description:  "default (nil)",
 			profile:      nil,
@@ -740,7 +835,6 @@ func TestTLSProfileSpecForIngressController(t *testing.T) {
 		apiProfile   *configv1.TLSSecurityProfile
 		expectedSpec *configv1.TLSProfileSpec
 	}{
-
 		{
 			description:  "nil, nil -> intermediate",
 			icProfile:    nil,
@@ -943,7 +1037,6 @@ func TestValidateClientTLS(t *testing.T) {
 		pattern     string
 		expectError bool
 	}{
-
 		{
 			description: "glob",
 			pattern:     "*.openshift.com",
@@ -1086,7 +1179,6 @@ func TestIsProxyProtocolNeeded(t *testing.T) {
 		expect      bool
 		expectError bool
 	}{
-
 		{
 			description: "nil platformStatus should cause an error",
 			strategy:    &loadBalancerStrategy,

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -753,10 +753,8 @@ func conditionsEqual(a, b []operatorv1.OperatorCondition) bool {
 		cmpopts.EquateEmpty(),
 		cmpopts.SortSlices(func(a, b operatorv1.OperatorCondition) bool { return a.Type < b.Type }),
 	}
-	if !cmp.Equal(a, b, conditionCmpOpts...) {
-		return false
-	}
-	return true
+
+	return cmp.Equal(a, b, conditionCmpOpts...)
 }
 
 func conditionChanged(a, b operatorv1.OperatorCondition) bool {
@@ -775,7 +773,7 @@ func computeLoadBalancerStatus(ic *operatorv1.IngressController, service *corev1
 				Type:    operatorv1.LoadBalancerManagedIngressConditionType,
 				Status:  operatorv1.ConditionFalse,
 				Reason:  "EndpointPublishingStrategyExcludesManagedLoadBalancer",
-				Message: fmt.Sprintf("The configured endpoint publishing strategy does not include a managed load balancer"),
+				Message: "The configured endpoint publishing strategy does not include a managed load balancer",
 			},
 		}
 	}
@@ -902,7 +900,6 @@ func getEventsByReason(events []corev1.Event, component, reason string) []corev1
 }
 
 func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNSRecord, status *configv1.PlatformStatus, dnsConfig *configv1.DNS) []operatorv1.OperatorCondition {
-
 	if dnsConfig.Spec.PublicZone == nil && dnsConfig.Spec.PrivateZone == nil {
 		return []operatorv1.OperatorCondition{
 			{
@@ -924,25 +921,21 @@ func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNS
 			},
 		}
 	}
-
-	if !manageDNSForDomain(ic.Status.Domain, status, dnsConfig) {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    operatorv1.DNSManagedIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "DomainNotMatching",
-				Message: "DNS management is not supported for ingresscontrollers with domain not matching the baseDomain of the cluster DNS config.",
-			},
-		}
-	}
-
-	conditions := []operatorv1.OperatorCondition{
-		{
+	var conditions []operatorv1.OperatorCondition
+	if ic.Status.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy == operatorv1.UnmanagedLoadBalancerDNS {
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.DNSManagedIngressConditionType,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "UnmanagedLoadBalancerDNS",
+			Message: "The DNS management policy is set to Unmanaged.",
+		})
+	} else {
+		conditions = append(conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.DNSManagedIngressConditionType,
 			Status:  operatorv1.ConditionTrue,
 			Reason:  "Normal",
 			Message: "DNS management is supported and zones are specified in the cluster DNS config.",
-		},
+		})
 	}
 
 	switch {
@@ -953,6 +946,13 @@ func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNS
 			Reason:  "RecordNotFound",
 			Message: "The wildcard record resource was not found.",
 		})
+	case wildcardRecord.Spec.DNSManagementPolicy == iov1.UnmanagedDNS:
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.DNSReadyIngressConditionType,
+			Status:  operatorv1.ConditionUnknown,
+			Reason:  "UnmanagedDNS",
+			Message: "The DNS management policy is set to Unmanaged.",
+		})
 	case len(wildcardRecord.Status.Zones) == 0:
 		conditions = append(conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.DNSReadyIngressConditionType,
@@ -962,31 +962,48 @@ func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNS
 		})
 	case len(wildcardRecord.Status.Zones) > 0:
 		var failedZones []configv1.DNSZone
+		var unknownZones []configv1.DNSZone
 		for _, zone := range wildcardRecord.Status.Zones {
 			for _, cond := range zone.Conditions {
-				if cond.Type == iov1.DNSRecordFailedConditionType && cond.Status == string(operatorv1.ConditionTrue) {
+				if cond.Type != iov1.DNSRecordPublishedConditionType {
+					continue
+				}
+				if !checkZoneInConfig(dnsConfig, zone.DNSZone) {
+					continue
+				}
+				switch cond.Status {
+				case string(operatorv1.ConditionFalse):
 					// check to see if the zone is in the dnsConfig.Spec
 					// fix:BZ1942657 - relates to status changes when updating DNS PrivateZone config
-					if checkZoneInConfig(dnsConfig, zone.DNSZone) {
-						failedZones = append(failedZones, zone.DNSZone)
-					}
+					failedZones = append(failedZones, zone.DNSZone)
+				case string(operatorv1.ConditionUnknown):
+					unknownZones = append(unknownZones, zone.DNSZone)
 				}
 			}
 		}
-		if len(failedZones) == 0 {
-			conditions = append(conditions, operatorv1.OperatorCondition{
-				Type:    operatorv1.DNSReadyIngressConditionType,
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "NoFailedZones",
-				Message: "The record is provisioned in all reported zones.",
-			})
-		} else {
+		if len(failedZones) != 0 {
 			// TODO: Add failed condition reasons
 			conditions = append(conditions, operatorv1.OperatorCondition{
 				Type:    operatorv1.DNSReadyIngressConditionType,
 				Status:  operatorv1.ConditionFalse,
 				Reason:  "FailedZones",
 				Message: fmt.Sprintf("The record failed to provision in some zones: %v", failedZones),
+			})
+		} else if len(unknownZones) != 0 {
+			// This condition is an edge case where DNSManaged=True but
+			// there was an internal error during publishing record.
+			conditions = append(conditions, operatorv1.OperatorCondition{
+				Type:    operatorv1.DNSReadyIngressConditionType,
+				Status:  operatorv1.ConditionFalse,
+				Reason:  "UnknownZones",
+				Message: fmt.Sprintf("Provisioning of the record is in an unknown state in some zones: %v", unknownZones),
+			})
+		} else {
+			conditions = append(conditions, operatorv1.OperatorCondition{
+				Type:    operatorv1.DNSReadyIngressConditionType,
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "NoFailedZones",
+				Message: "The record is provisioned in all reported zones.",
 			})
 		}
 	}

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -21,6 +21,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1463,6 +1464,519 @@ func TestIngressStatusesEqual(t *testing.T) {
 	}
 }
 
+func TestComputeDNSStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		controller     *operatorv1.IngressController
+		record         *iov1.DNSRecord
+		platformStatus *configv1.PlatformStatus
+		dnsConfig      *configv1.DNS
+		expect         []operatorv1.OperatorCondition
+	}{
+		{
+			name: "DNSManaged false due to NoDNSZones",
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					PublicZone:  nil,
+					PrivateZone: nil,
+				},
+			},
+			expect: []operatorv1.OperatorCondition{{
+				Type:   "DNSManaged",
+				Status: operatorv1.ConditionFalse,
+				Reason: "NoDNSZones",
+			}},
+		},
+		{
+			name: "DNSManaged false due to UnsupportedEndpointPublishingStrategy",
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.HostNetworkStrategyType,
+					},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{{
+				Type:   "DNSManaged",
+				Status: operatorv1.ConditionFalse,
+				Reason: "UnsupportedEndpointPublishingStrategy",
+			}},
+		},
+		{
+			name: "DNSManaged false due to UnmanagedLoadBalancerDNS",
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.UnmanagedDNS,
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionFalse,
+					Reason: "UnmanagedLoadBalancerDNS",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionUnknown,
+					Reason: "UnmanagedDNS",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true and DNSReady is true due to NoFailedZones",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{
+						{
+							DNSZone: configv1.DNSZone{ID: "zone1"},
+							Conditions: []iov1.DNSZoneCondition{
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionTrue),
+									LastTransitionTime: metav1.Now(),
+								},
+							},
+						},
+					},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain:  "basedomain.com",
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionTrue,
+					Reason: "NoFailedZones",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true but DNSReady is false due to RecordNotFound",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: nil,
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain:  "basedomain.com",
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionFalse,
+					Reason: "RecordNotFound",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true but DNSReady is false due to NoZones",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain:  "basedomain.com",
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionFalse,
+					Reason: "NoZones",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true but DNSReady is Unknown due to UnmanagedDNS",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.UnmanagedDNS,
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain:  "basedomain.com",
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionUnknown,
+					Reason: "UnmanagedDNS",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true and DNSReady is false due to FailedZones",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{
+						{
+							DNSZone: configv1.DNSZone{ID: "zone1"},
+							Conditions: []iov1.DNSZoneCondition{
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionFalse),
+									LastTransitionTime: metav1.Now(),
+									Reason:             "FailedZones",
+								},
+							},
+						},
+					},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain: "basedomain.com",
+					PublicZone: &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{
+						ID: "zone1",
+					},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionFalse,
+					Reason: "FailedZones",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true and DNSReady is true with even with previously FailedZones",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{
+						{
+							DNSZone: configv1.DNSZone{ID: "zone1"},
+							Conditions: []iov1.DNSZoneCondition{
+								{
+									Type:               iov1.DNSRecordFailedConditionType,
+									Status:             string(operatorv1.ConditionTrue),
+									LastTransitionTime: metav1.NewTime(time.Now().Add(5 * time.Minute)),
+									Reason:             "FailedZones",
+								},
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionTrue),
+									LastTransitionTime: metav1.NewTime(time.Now().Add(15 * time.Minute)),
+									Reason:             "NoFailedZones",
+								},
+							},
+						},
+					},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain: "basedomain.com",
+					PublicZone: &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{
+						ID: "zone1",
+					},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionTrue,
+					Reason: "NoFailedZones",
+				},
+			},
+		},
+		{
+			name: "DNSManaged true and DNSReady is false due to unknown condition",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{
+						{
+							DNSZone: configv1.DNSZone{ID: "zone1"},
+							Conditions: []iov1.DNSZoneCondition{
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionUnknown),
+									LastTransitionTime: metav1.NewTime(time.Now().Add(15 * time.Minute)),
+									Reason:             "UnknownZones",
+								},
+							},
+						},
+					},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain: "basedomain.com",
+					PublicZone: &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{
+						ID: "zone1",
+					},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionFalse,
+					Reason: "UnknownZones",
+				},
+			},
+		},
+		{
+			// This text checks if precedence is given to failed zones over unknown zones.
+			name: "DNSManaged true and DNSReady is false due to failed and unknown conditions",
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.ManagedDNS,
+				},
+				Status: iov1.DNSRecordStatus{
+					Zones: []iov1.DNSZoneStatus{
+						{
+							DNSZone: configv1.DNSZone{ID: "zone1"},
+							Conditions: []iov1.DNSZoneCondition{
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionUnknown),
+									LastTransitionTime: metav1.NewTime(time.Now().Add(15 * time.Minute)),
+									Reason:             "UnknownZones",
+								},
+								{
+									Type:               iov1.DNSRecordPublishedConditionType,
+									Status:             string(operatorv1.ConditionFalse),
+									LastTransitionTime: metav1.NewTime(time.Now().Add(15 * time.Minute)),
+									Reason:             "FailedZones",
+								},
+							},
+						},
+					},
+				},
+			},
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+			},
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain: "basedomain.com",
+					PublicZone: &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{
+						ID: "zone1",
+					},
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionTrue,
+					Reason: "Normal",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionFalse,
+					Reason: "FailedZones",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		actualConditions := computeDNSStatus(tc.controller, tc.record, tc.platformStatus, tc.dnsConfig)
+		opts := cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "Message", "LastTransitionTime")
+		if !cmp.Equal(actualConditions, tc.expect, opts) {
+			t.Fatalf("%q found diff between actual and expected operator condition:\n%s", tc.name, cmp.Diff(actualConditions, tc.expect, opts))
+		}
+	}
+}
+
 func TestMergeConditions(t *testing.T) {
 	// Inject a fake clock and don't forget to reset it
 	fakeClock := utilclocktesting.NewFakeClock(time.Time{})
@@ -1537,37 +2051,43 @@ func TestZoneInConfig(t *testing.T) {
 			in:          "test",
 			zone:        "",
 			zoneType:    "ID",
-		}, {
+		},
+		{
 			description: "[PrivateZone] zone.ID with value (not equal should fail)",
 			expected:    false,
 			in:          "test",
 			zone:        "notest",
 			zoneType:    "ID",
-		}, {
+		},
+		{
 			description: "[PrivateZone] zone.ID with value (equal should pass)",
 			expected:    true,
 			in:          "test",
 			zone:        "test",
 			zoneType:    "ID",
-		}, {
+		},
+		{
 			description: "[PrivateZone] empty strings (should fail)",
 			expected:    false,
 			in:          "",
 			zone:        "",
 			zoneType:    "TAG",
-		}, {
+		},
+		{
 			description: "[PrivateZone] zone.Tags['Name'] empty string (should fail)",
 			expected:    false,
 			in:          "test",
 			zone:        "",
 			zoneType:    "TAG",
-		}, {
+		},
+		{
 			description: "[PrivateZone] zone.Tags['Name'] with value (not equal should fail)",
 			expected:    false,
 			in:          "test",
 			zone:        "notest",
 			zoneType:    "TAG",
-		}, {
+		},
+		{
 			description: "[PrivateZone] zone.tags['Name'] with value (equal should pass)",
 			expected:    true,
 			in:          "test",
@@ -1716,7 +2236,6 @@ func TestComputeIngressUpgradeableCondition(t *testing.T) {
 			if actual.Status != expectedStatus {
 				t.Errorf("%q: expected Upgradeable to be %q, got %q", tc.description, expectedStatus, actual.Status)
 			}
-
 		})
 	}
 }

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -67,6 +67,9 @@ func TestAll(t *testing.T) {
 		t.Run("TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus", TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus)
 		t.Run("TestReloadInterval", TestReloadInterval)
 		t.Run("TestAWSLBTypeChange", TestAWSLBTypeChange)
+		t.Run("TestUnmanagedDNSToManagedDNSIngressController", TestUnmanagedDNSToManagedDNSIngressController)
+		t.Run("TestManagedDNSToUnmanagedDNSIngressController", TestManagedDNSToUnmanagedDNSIngressController)
+		t.Run("TestUnmanagedDNSToManagedDNSInternalIngressController", TestUnmanagedDNSToManagedDNSInternalIngressController)
 	})
 
 	t.Run("serial", func(t *testing.T) {

--- a/test/e2e/domain_not_matching_base_test.go
+++ b/test/e2e/domain_not_matching_base_test.go
@@ -5,15 +5,15 @@ package e2e
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
-	"time"
 )
 
 func TestDomainNotMatchingBase(t *testing.T) {
@@ -33,7 +33,7 @@ func TestDomainNotMatchingBase(t *testing.T) {
 	}
 	defer assertIngressControllerDeleted(t, kclient, ic)
 
-	//Ensure the DNSManaged=False condition
+	// Ensure the DNSManaged=False condition
 	t.Logf("waiting for ingresscontroller %v", icName)
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
@@ -51,13 +51,20 @@ func TestDomainNotMatchingBase(t *testing.T) {
 		t.Fatalf("failed to get ingress controller: %v", err)
 	}
 
-	//Ensure there is no DNS record created
+	if ic.Spec.EndpointPublishingStrategy != nil &&
+		ic.Spec.EndpointPublishingStrategy.LoadBalancer != nil &&
+		ic.Spec.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy != operatorv1.UnmanagedLoadBalancerDNS {
+		t.Fatalf("dnsManagementPolicy in ingresscontroller spec is not updated to Unmanaged")
+	}
+
+	// Ensure there is a DNSRecord created with the correct DNS policy
 	wildcardRecordName := controller.WildcardDNSRecordName(ic)
 	wildcardRecord := &iov1.DNSRecord{}
-	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err == nil {
-		t.Fatalf("Expected to find no wildcard dnsrecord, but found one %s", wildcardRecordName)
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("Expected to find wildcard dnsrecord %q, but found none", wildcardRecordName)
 	}
-	if err != nil && !errors.IsNotFound(err) {
-		t.Fatalf("Unexpected error while looking for a dnsrecord: %v", err)
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.UnmanagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=UnmanagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
 	}
 }

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -51,6 +51,7 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 	for _, header := range headers {
 		extraCurlArgs = append(extraCurlArgs, "-H", header)
 	}
+	extraCurlArgs = append(extraCurlArgs, "--resolve", route.Spec.Host+":80:"+address)
 	testPodCount++
 	name := fmt.Sprintf("%s%d", route.Name, testPodCount)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -115,7 +115,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		"-H",
 		headerString,
 	}
-
+	extraCurlArgs = append(extraCurlArgs, "--resolve", echoRoute.Spec.Host+":80:"+service.Spec.ClusterIP)
 	name := "header-buffer-size-test-large-buffers"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPodValidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -103,9 +103,13 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 		t.Fatalf("failed to create kube client: %v", err)
 	}
 
+	extraCurlArgs := []string{
+		"-v",
+		"--resolve", echoRoute.Spec.Host + ":80:" + service.Spec.ClusterIP,
+	}
 	name := "header-name-case-adjustment-test"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
-	clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, "-v")
+	clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -81,7 +81,6 @@ var (
 		{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-		{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
 	}
 	availableConditionsForIngressControllerWithHostNetwork = []operatorv1.OperatorCondition{

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -81,6 +81,7 @@ var (
 		{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
 	}
 	availableConditionsForIngressControllerWithHostNetwork = []operatorv1.OperatorCondition{
@@ -90,17 +91,28 @@ var (
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 	}
+	availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS = []operatorv1.OperatorCondition{
+		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+		{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionUnknown},
+		{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
+	}
 	// The ingress canary check status condition only applies to the default ingress controller.
 	defaultAvailableConditions = append(availableConditionsForIngressControllerWithLoadBalancer, operatorv1.OperatorCondition{Type: ingresscontroller.IngressControllerCanaryCheckSuccessConditionType, Status: operatorv1.ConditionTrue})
 )
 
-var kclient client.Client
-var dnsConfig configv1.DNS
-var infraConfig configv1.Infrastructure
-var operatorNamespace = operatorcontroller.DefaultOperatorNamespace
-var operandNamespace = operatorcontroller.DefaultOperandNamespace
-var defaultName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.DefaultIngressControllerName}
-var clusterConfigName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.ClusterIngressConfigName}
+var (
+	kclient           client.Client
+	dnsConfig         configv1.DNS
+	infraConfig       configv1.Infrastructure
+	operatorNamespace = operatorcontroller.DefaultOperatorNamespace
+	operandNamespace  = operatorcontroller.DefaultOperandNamespace
+	defaultName       = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.DefaultIngressControllerName}
+	clusterConfigName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.ClusterIngressConfigName}
+)
 
 func TestMain(m *testing.M) {
 	if os.Getenv("E2E_TEST_MAIN_SKIP_SETUP") == "1" {
@@ -947,7 +959,8 @@ func TestInternalLoadBalancer(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "testinternalloadbalancer"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
-		Scope: operatorv1.InternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+		Scope:               operatorv1.InternalLoadBalancer,
 	}
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
@@ -1029,7 +1042,8 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "test-gcp"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
-		Scope: operatorv1.InternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+		Scope:               operatorv1.InternalLoadBalancer,
 		ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
 			Type: operatorv1.GCPLoadBalancerProvider,
 			GCP: &operatorv1.GCPLoadBalancerParameters{
@@ -1096,7 +1110,6 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 		}
 		return true, nil
 	})
-
 	if err != nil {
 		t.Errorf("failed to observe expected annotations on load balancer service %s: %v", controller.LoadBalancerServiceName(ic), err)
 	}
@@ -1208,7 +1221,8 @@ func TestScopeChange(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "scope"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
-		Scope: operatorv1.ExternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+		Scope:               operatorv1.ExternalLoadBalancer,
 	}
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
@@ -2288,7 +2302,8 @@ func TestNetworkLoadBalancer(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "test-nlb"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	lb := &operatorv1.LoadBalancerStrategy{
-		Scope: operatorv1.ExternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+		Scope:               operatorv1.ExternalLoadBalancer,
 		ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
 			Type: operatorv1.AWSLoadBalancerProvider,
 			AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -2336,7 +2351,8 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "test-idle-timeout"}
 	ic := newLoadBalancerController(icName, icName.Name+"."+dnsConfig.Spec.BaseDomain)
 	lb := &operatorv1.LoadBalancerStrategy{
-		Scope: operatorv1.ExternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
+		Scope:               operatorv1.ExternalLoadBalancer,
 		ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
 			Type: operatorv1.AWSLoadBalancerProvider,
 			AWS: &operatorv1.AWSLoadBalancerParameters{
@@ -2613,7 +2629,10 @@ func TestUniqueIdHeader(t *testing.T) {
 	for i := 1; i <= numRequests; i++ {
 		name := fmt.Sprintf("unique-id-header-test-%d", i)
 		image := deployment.Spec.Template.Spec.Containers[0].Image
-		clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP)
+		extraCurlArgs := []string{
+			"--resolve", echoRoute.Spec.Host + ":80:" + service.Spec.ClusterIP,
+		}
+		clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
 		if err := kclient.Create(context.TODO(), clientPod); err != nil {
 			t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
@@ -3431,7 +3450,6 @@ func waitForIngressControllerCondition(t *testing.T, cl client.Client, timeout t
 
 		return conditionsMatchExpected(expected, current), nil
 	})
-
 	if err != nil {
 		t.Errorf("Expected conditions: %v\n Current conditions: %v", expected, current)
 	}

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -18,6 +18,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// TODO: Remove this once this condition is added to all e2e test
+// and stability issue is fixed.
+var operatorProgressingFalse = operatorv1.OperatorCondition{
+	Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse,
+}
+
 func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 	t.Parallel()
 
@@ -33,7 +39,7 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 	defer assertIngressControllerDeleted(t, kclient, ic)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -72,7 +78,7 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Managed", ic.Name)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancer, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -107,7 +113,7 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	defer assertIngressControllerDeleted(t, kclient, ic)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancer, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -149,7 +155,7 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Unmanaged", ic.Name)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -192,7 +198,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	defer assertIngressControllerDeleted(t, kclient, ic)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -241,7 +247,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Managed", ic.Name)
 
 	// Wait for the load balancer and DNS to reach stable conditions.
-	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancer, operatorProgressingFalse)...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -1,0 +1,287 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	iov1 "github.com/openshift/api/operatoringress/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
+	t.Parallel()
+
+	name := types.NamespacedName{Namespace: operatorNamespace, Name: "unmanaged-migrated"}
+	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		Scope:               operatorv1.ExternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	lbService := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		t.Fatalf("failed to get LoadBalancer service: %v", err)
+	}
+
+	if ingresscontroller.IsServiceInternal(lbService) {
+		t.Fatalf("load balancer %s is internal but should be external", lbService.Name)
+	}
+
+	wildcardRecordName := controller.WildcardDNSRecordName(ic)
+	wildcardRecord := &iov1.DNSRecord{}
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.UnmanagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=UnmanagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	verifyUnmanagedDNSRecordStatus(t, wildcardRecord)
+
+	testNamespace := types.NamespacedName{Name: name.Name + "-initial", Namespace: name.Namespace}
+	verifyExternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0])
+
+	t.Logf("Updating ingresscontroller %s to dnsManagementPolicy=Managed", ic.Name)
+
+	if err := updateIngressControllerSpecWithRetryOnConflict(t, name, 5*time.Minute, func(ics *operatorv1.IngressControllerSpec) {
+		ics.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy = operatorv1.ManagedLoadBalancerDNS
+	}); err != nil {
+		t.Fatalf("failed to update ingresscontroller %s: %v", name, err)
+	}
+
+	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Managed", ic.Name)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	// Ensure DNSRecord CR is present.
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.ManagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=ManagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	if len(wildcardRecord.Status.Zones) == 0 {
+		t.Fatalf("DNSRecord %s expected allocated dnsZones but found none", wildcardRecordName.Name)
+	}
+
+	testNamespace = types.NamespacedName{Name: name.Name + "-final", Namespace: name.Namespace}
+	verifyExternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0])
+}
+
+func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
+	t.Parallel()
+
+	name := types.NamespacedName{Namespace: operatorNamespace, Name: "managed-migrated"}
+	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		Scope: operatorv1.ExternalLoadBalancer,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	lbService := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		t.Fatalf("failed to get LoadBalancer service: %v", err)
+	}
+
+	if ingresscontroller.IsServiceInternal(lbService) {
+		t.Fatalf("load balancer %s is internal but should be external", lbService.Name)
+	}
+
+	wildcardRecordName := controller.WildcardDNSRecordName(ic)
+	wildcardRecord := &iov1.DNSRecord{}
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.ManagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=ManagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	testNamespace := types.NamespacedName{Name: name.Name + "-initial", Namespace: name.Namespace}
+	verifyExternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0])
+
+	t.Logf("Updating ingresscontroller %s to dnsManagementPolicy=Unmanaged", ic.Name)
+
+	// Updating the ingresscontroller's DNSManagementPolicy to Unmanaged, meaning
+	// the DNSRecord CR associated with the controller will only be updated with
+	// dnsManagementPolicy=Unmanaged and need not be deleted. The DNS records on the
+	// cloud provider will continue to exist and must be manually deleted. (This is
+	// outside the scope of the test.)
+	if err := updateIngressControllerSpecWithRetryOnConflict(t, name, 5*time.Minute, func(ics *operatorv1.IngressControllerSpec) {
+		ics.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy = operatorv1.UnmanagedLoadBalancerDNS
+	}); err != nil {
+		t.Fatalf("failed to update ingresscontroller %s: %v", name, err)
+	}
+
+	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Unmanaged", ic.Name)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	// Ensure DNSRecord CR is present.
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.UnmanagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=UnmanagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	verifyUnmanagedDNSRecordStatus(t, wildcardRecord)
+
+	// To verify the external ingresscontroller after updating dnsManagementPolicy=Unmanaged, we use
+	// the IP address from the dnsrecord to route to the correct router pod, and we use the HTTP host
+	// header to map to the correct route.  This means the old DNS records from when
+	// dnsManagementPolicy=Managed was set are not used to verify the ingresscontroller (but they
+	// will continue to exist unless they are manually deleted).
+	testNamespace = types.NamespacedName{Name: name.Name + "-final", Namespace: name.Namespace}
+	verifyExternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0])
+}
+
+// TestUnmanagedDNSToManagedDNSInternalIngressController tests dnsManagementPolicy during
+// transitioning from Unmanaged internal ingress controller to Managed external ingress
+// controller. During the transition it deletes the load balancer so that the lb svc
+// target changes and ensures the new updated target is published to the DNSZone.
+func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
+	t.Parallel()
+
+	name := types.NamespacedName{Namespace: operatorNamespace, Name: "unmanaged-migrated-internal"}
+	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		Scope:               operatorv1.InternalLoadBalancer,
+		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	lbService := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		t.Fatalf("failed to get LoadBalancer service: %v", err)
+	}
+
+	if !ingresscontroller.IsServiceInternal(lbService) {
+		t.Fatalf("load balancer %s is external but should be internal", lbService.Name)
+	}
+
+	wildcardRecordName := controller.WildcardDNSRecordName(ic)
+	wildcardRecord := &iov1.DNSRecord{}
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.UnmanagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=UnmanagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	verifyUnmanagedDNSRecordStatus(t, wildcardRecord)
+
+	routerDeployment := &appsv1.Deployment{}
+	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), routerDeployment); err != nil {
+		t.Fatalf("failed to get router deployment: %v", err)
+	}
+
+	testNamespace := types.NamespacedName{Name: name.Name, Namespace: routerDeployment.Namespace}
+	verifyInternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0], routerDeployment.Spec.Template.Spec.Containers[0].Image)
+
+	t.Logf("Updating ingresscontroller %s to dnsManagementPolicy=Managed", ic.Name)
+
+	if err := updateIngressControllerSpecWithRetryOnConflict(t, name, 5*time.Minute, func(ics *operatorv1.IngressControllerSpec) {
+		ics.EndpointPublishingStrategy.LoadBalancer.Scope = operatorv1.ExternalLoadBalancer
+		ics.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy = operatorv1.ManagedLoadBalancerDNS
+	}); err != nil {
+		t.Fatalf("failed to update ingresscontroller %s: %v", name, err)
+	}
+
+	if err := kclient.Delete(context.TODO(), lbService); err != nil && !errors.IsNotFound(err) {
+		t.Fatalf("failed to delete svc %s: %v", lbService.Name, err)
+	}
+
+	t.Logf("Waiting for stable conditions on ingresscontroller %s after dnsManagementPolicy=Managed", ic.Name)
+
+	// Wait for the load balancer and DNS to reach stable conditions.
+	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	if !ingresscontroller.IsServiceInternal(lbService) {
+		t.Fatalf("load balancer %s is internal but should be external", lbService.Name)
+	}
+
+	// Ensure DNSRecord CR is present.
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+
+	if wildcardRecord.Spec.DNSManagementPolicy != iov1.ManagedDNS {
+		t.Fatalf("DNSRecord %s expected in dnsManagementPolicy=ManagedDNS but got dnsManagementPolicy=%s", wildcardRecordName.Name, wildcardRecord.Spec.DNSManagementPolicy)
+	}
+
+	if len(wildcardRecord.Status.Zones) != 2 {
+		t.Fatalf("DNSRecord %s expected allocated dnsZones but found none", wildcardRecordName.Name)
+	}
+
+	testNamespace = types.NamespacedName{Name: name.Name + "-final", Namespace: name.Namespace}
+	verifyExternalIngressController(t, testNamespace, "apps."+ic.Spec.Domain, wildcardRecord.Spec.Targets[0])
+}
+
+func verifyUnmanagedDNSRecordStatus(t *testing.T, record *iov1.DNSRecord) {
+	t.Helper()
+	for _, zoneInStatus := range record.Status.Zones {
+		if len(zoneInStatus.Conditions) == 0 {
+			t.Fatalf("DNSRecord zone %+v expected to have conditions", zoneInStatus.DNSZone)
+		}
+
+		t.Logf("verifying conditions on DNSRecord zone %+v", zoneInStatus.DNSZone)
+		for _, condition := range zoneInStatus.Conditions {
+			if condition.Type != iov1.DNSRecordPublishedConditionType {
+				t.Fatalf("DNSRecord zone expected to have condition type=Published but got type=%s", condition.Type)
+			}
+
+			if condition.Status != string(operatorv1.ConditionUnknown) {
+				t.Fatalf("DNSRecord zone expected to have status=Unknown but got status=%s", condition.Status)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add `dnsManagementPolicy` option to ingresscontrollers
---
- `pkg/operator/controller/dns/controller.go` 
    - Create DNS provider based on `dnsManagementPolicy` on `DNSRecord` CR.
    - Add sanitize function for purging deprecated fields on DNS record status.
    - Refactor `publishRecordToZones()`
- `pkg/operator/controller/ingress/controller.go` - Reconcile changes made to `dnsManagementPolicy` on ingress spec.
- `pkg/operator/controller/ingress/dns.go` 
    - Create desired `DNSRecord` with `dnsManagementPolicy` derived from ingresscontroller status.
    - Converge domain mismatch check with `UmanagedDNS` policy. 
- `pkg/operator/controller/ingress/status.go` - Update status of types `DNSManaged` and `DNSReady`.
- Renamed `test/e2e/util.go` -> `test/e2e/util_test.go` to allow `gopls` to index variables(`kclient`) declared under other test files.



EP: https://github.com/openshift/enhancements/pull/1114
CFE: [CFE-339](https://issues.redhat.com/browse/CFE-339), [CFE-342](https://issues.redhat.com/browse/CFE-342)

---
Signed-off-by: thejasn <thn@redhat.com>