### PR TITLE
[release-4.10] Bug 2097735: Fix loadBalancerServiceAnnotationsChanged check and update

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -586,7 +586,7 @@ func loadBalancerServiceAnnotationsChanged(current, expected *corev1.Service, an
 		updated.Annotations = map[string]string{}
 	}
 
-	for annotation := range managedLoadBalancerServiceAnnotations {
+	for annotation := range annotations {
 		currentVal, have := current.Annotations[annotation]
 		expectedVal, want := expected.Annotations[annotation]
 		if want && (!have || currentVal != expectedVal) {

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -571,12 +571,16 @@ func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev
 // loadBalancerServiceAnnotationsChanged checks if the annotations on the expected Service
 // match the ones on the current Service.
 func loadBalancerServiceAnnotationsChanged(current, expected *corev1.Service, annotations sets.String) (bool, *corev1.Service) {
-	annotationCmpOpts := []cmp.Option{
-		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
-			return !annotations.Has(k)
-		}),
+	changed := false
+	for annotation := range annotations {
+		currentVal, have := current.Annotations[annotation]
+		expectedVal, want := expected.Annotations[annotation]
+		if (want && (!have || currentVal != expectedVal)) || (have && !want) {
+			changed = true
+			break
+		}
 	}
-	if cmp.Equal(current.Annotations, expected.Annotations, annotationCmpOpts...) {
+	if !changed {
 		return false, nil
 	}
 

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -757,6 +757,20 @@ func TestLoadBalancerServiceAnnotationsChanged(t *testing.T) {
 			expect:              false,
 		},
 		{
+			description:         "if current annotations is nil and expected annotations is empty",
+			currentAnnotations:  nil,
+			expectedAnnotations: map[string]string{},
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              false,
+		},
+		{
+			description:         "if current annotations is empty and expected annotations is nil",
+			currentAnnotations:  map[string]string{},
+			expectedAnnotations: nil,
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              false,
+		},
+		{
 			description: "if an unmanaged annotation is updated",
 			currentAnnotations: map[string]string{
 				"foo": "bar",

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestDesiredLoadBalancerService(t *testing.T) {
@@ -731,6 +732,90 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			} else if changed {
 				if changedAgain, _ := loadBalancerServiceChanged(mutated, updated); changedAgain {
 					t.Error("loadBalancerServiceChanged does not behave as a fixed point function")
+				}
+			}
+		})
+	}
+}
+
+// TestLoadBalancerServiceAnnotationsChanged verifies that
+// loadBalancerServiceAnnotationsChanged behaves correctly.
+func TestLoadBalancerServiceAnnotationsChanged(t *testing.T) {
+	testCases := []struct {
+		description         string
+		mutate              func(*corev1.Service)
+		currentAnnotations  map[string]string
+		expectedAnnotations map[string]string
+		managedAnnotations  sets.String
+		expect              bool
+	}{
+		{
+			description:         "if current and expected annotations are both empty",
+			currentAnnotations:  map[string]string{},
+			expectedAnnotations: map[string]string{},
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              false,
+		},
+		{
+			description: "if an unmanaged annotation is updated",
+			currentAnnotations: map[string]string{
+				"foo": "bar",
+			},
+			expectedAnnotations: map[string]string{
+				"foo": "bar",
+				"baz": "quux",
+			},
+			managedAnnotations: sets.NewString("foo"),
+			expect:             false,
+		},
+		{
+			description:        "if a managed annotation is set",
+			currentAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				"foo": "bar",
+			},
+			managedAnnotations: sets.NewString("foo"),
+			expect:             true,
+		},
+		{
+			description: "if a managed annotation is updated",
+			currentAnnotations: map[string]string{
+				"foo": "bar",
+			},
+			expectedAnnotations: map[string]string{
+				"foo": "baz",
+			},
+			managedAnnotations: sets.NewString("foo"),
+			expect:             true,
+		},
+		{
+			description: "if a managed annotation is deleted",
+			currentAnnotations: map[string]string{
+				"foo": "bar",
+			},
+			expectedAnnotations: map[string]string{},
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			current := corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.currentAnnotations,
+				},
+			}
+			expected := corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.expectedAnnotations,
+				},
+			}
+			if changed, updated := loadBalancerServiceAnnotationsChanged(&current, &expected, tc.managedAnnotations); changed != tc.expect {
+				t.Errorf("expected loadBalancerServiceAnnotationsChanged to be %t, got %t", tc.expect, changed)
+			} else if changed {
+				if changedAgain, _ := loadBalancerServiceAnnotationsChanged(&expected, updated, tc.managedAnnotations); changedAgain {
+					t.Error("loadBalancerServiceAnnotationsChanged does not behave as a fixed point function")
 				}
 			}
 		})


### PR DESCRIPTION
This is a manual cherry-pick of #783.  #707 introduced a conflict that required resolution.  

#### `loadBalancerServiceAnnotationsChanged`: Fix update

Fix `loadBalancerServiceAnnotationsChanged` to use the provided `annotations` argument when updating annotations.  Before this change, `loadBalancerServiceAnnotationsChanged` used the `annotations` argument when checking whether annotations had changed, but then it used `managedLoadBalancerServiceAnnotations` when setting the annotations in the updated service object.

When checking whether the service is upgradeable for the purpose of setting the ingresscontroller's "Upgradeable" status condition, `loadBalancerServiceTagsModified` calls `loadBalancerServiceAnnotationsChanged` with an `annotations` argument that includes the "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" annotation key, which is not in `managedLoadBalancerServiceAnnotations`.  As a result, `loadBalancerServiceAnnotationsChanged` would report that the service was not upgradeable, but then the status condition message would not show that the "aws-load-balancer-additional-resource-tags" annotation had changed.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`loadBalancerServiceAnnotationsChanged`): Use the provided `annotations` argument instead of using `managedLoadBalancerServiceAnnotations` when updating annotations.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceAnnotationsChanged`): New test.  Verify that `loadBalancerServiceAnnotationsChanged` behaves correctly when an unmanaged annotation is updated or when a managed annotation is added, updated, or deleted.


#### `loadBalancerServiceAnnotationsChanged`: Fix check

Fix `loadBalancerServiceAnnotationsChanged` to treat nil and empty annotations maps as equal.  Before this commit, the comparison erroneously flagged an empty map and a nil map as unequal.  As a result, the ingress operator could erroneously report that an ingresscontroller with a service with no annotations was not upgradeable.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`loadBalancerServiceAnnotationsChanged`): Use a `for` loop instead of go-cmp to check whether any managed annotations have changed.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceAnnotationsChanged`): Add test cases for empty/nil current/expected annotations.