### PR TITLE
[release-4.9] Bug 2097736: Fix loadBalancerServiceAnnotationsChanged check and update

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -498,12 +498,16 @@ func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev
 // loadBalancerServiceAnnotationsChanged checks if the annotations on the expected Service
 // match the ones on the current Service.
 func loadBalancerServiceAnnotationsChanged(current, expected *corev1.Service, annotations sets.String) (bool, *corev1.Service) {
-	annotationCmpOpts := []cmp.Option{
-		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
-			return !annotations.Has(k)
-		}),
+	changed := false
+	for annotation := range annotations {
+		currentVal, have := current.Annotations[annotation]
+		expectedVal, want := expected.Annotations[annotation]
+		if (want && (!have || currentVal != expectedVal)) || (have && !want) {
+			changed = true
+			break
+		}
 	}
-	if cmp.Equal(current.Annotations, expected.Annotations, annotationCmpOpts...) {
+	if !changed {
 		return false, nil
 	}
 

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -721,6 +721,20 @@ func TestLoadBalancerServiceAnnotationsChanged(t *testing.T) {
 			expect:              false,
 		},
 		{
+			description:         "if current annotations is nil and expected annotations is empty",
+			currentAnnotations:  nil,
+			expectedAnnotations: map[string]string{},
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              false,
+		},
+		{
+			description:         "if current annotations is empty and expected annotations is nil",
+			currentAnnotations:  map[string]string{},
+			expectedAnnotations: nil,
+			managedAnnotations:  sets.NewString("foo"),
+			expect:              false,
+		},
+		{
 			description: "if an unmanaged annotation is updated",
 			currentAnnotations: map[string]string{
 				"foo": "bar",


### PR DESCRIPTION
This is a manual cherry-pick of #783.  #707 introduced a conflict that required resolution.  

#### `loadBalancerServiceAnnotationsChanged`: Fix update

Fix `loadBalancerServiceAnnotationsChanged` to use the provided `annotations` argument when updating annotations.  Before this change, `loadBalancerServiceAnnotationsChanged` used the `annotations` argument when checking whether annotations had changed, but then it used `managedLoadBalancerServiceAnnotations` when setting the annotations in the updated service object.

When checking whether the service is upgradeable for the purpose of setting the ingresscontroller's "Upgradeable" status condition, `loadBalancerServiceTagsModified` calls `loadBalancerServiceAnnotationsChanged` with an `annotations` argument that includes the "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" annotation key, which is not in `managedLoadBalancerServiceAnnotations`.  As a result, `loadBalancerServiceAnnotationsChanged` would report that the service was not upgradeable, but then the status condition message would not show that the "aws-load-balancer-additional-resource-tags" annotation had changed.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`loadBalancerServiceAnnotationsChanged`): Use the provided `annotations` argument instead of using `managedLoadBalancerServiceAnnotations` when updating annotations.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceAnnotationsChanged`): New test.  Verify that `loadBalancerServiceAnnotationsChanged` behaves correctly when an unmanaged annotation is updated or when a managed annotation is added, updated, or deleted.


#### `loadBalancerServiceAnnotationsChanged`: Fix check

Fix `loadBalancerServiceAnnotationsChanged` to treat nil and empty annotations maps as equal.  Before this commit, the comparison erroneously flagged an empty map and a nil map as unequal.  As a result, the ingress operator could erroneously report that an ingresscontroller with a service with no annotations was not upgradeable.

* `pkg/operator/controller/ingress/load_balancer_service.go` (`loadBalancerServiceAnnotationsChanged`): Use a `for` loop instead of go-cmp to check whether any managed annotations have changed.
* `pkg/operator/controller/ingress/load_balancer_service_test.go` (`TestLoadBalancerServiceAnnotationsChanged`): Add test cases for empty/nil current/expected annotations.