### PR TITLE
WIP: Factor out conditionsexpectations util package

### DIFF
--- a/pkg/util/conditionexpectations/conditionexpectations.go
+++ b/pkg/util/conditionexpectations/conditionexpectations.go
@@ -1,0 +1,109 @@
+package conditionexpectations
+
+import (
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+// Expectation contains a condition that is expected to have a specific status.
+// The expectation may be contingent on the presence of some other conditions.
+// The expectation also may specify a grace period, indicating that violating
+// the expectation is permitted as long as the elapsed time since the
+// condition's last transition time is within the grace period.
+type Expectation struct {
+	// ConditionType is the type of the expected condition.
+	ConditionType string
+	// ConditionStatus is the expected status of the condition.
+	ConditionStatus operatorv1.ConditionStatus
+	// IfConditionsTrue is a list of prerequisite conditions that should be
+	// true or else the condition is not checked.
+	IfConditionsTrue []string
+	// GracePeriod of the period of time following the condition's last
+	// transition time, during which time it is permitted that this
+	// expectation not be met.
+	GracePeriod time.Duration
+}
+
+// Expectations specifies a set of expectations for operator conditions.
+type Expectations []Expectation
+
+// MakeExpectations makes an Expectations object from the provided Expectation
+// values.  Each Expectation must have a unique ConditionType.
+func MakeExpectations(expectations []Expectation) Expectations {
+	return Expectations(expectations)
+}
+
+// Check examines the provided operator conditions to determine whether each has
+// the expected status.  If an operator condition has no expectation with a
+// matching type, the condition is ignored.  Check then returns two lists of
+// pointers to those conditions and a time duration value:
+//
+// * The first list contains pointers to all conditions that did not have the
+// expected status but are still within their respective grace periods.
+//
+// * The second list contains pointers to all conditions that did not have the
+// expected status and have exceeded their respective grace periods.
+//
+// * The time duration value has the longest remaining grace period of any of
+// the conditions in the first list, or 0 if no conditions are in grace.
+//
+// It is intended that the caller uses these results as follows:
+//
+// * If both lists are empty, then all is as expected, and no action is needed.
+//
+// * If the second list is empty, then the caller may warn the user about a
+// potential issue.
+//
+// * If the second list is not empty, then the caller should alert the user that
+// expectations were not met, and some user action may be required.
+func (expectedConds Expectations) Check(conditions []operatorv1.OperatorCondition, now time.Time) ([]*operatorv1.OperatorCondition, []*operatorv1.OperatorCondition, time.Duration) {
+	var graceConditions, degradedConditions []*operatorv1.OperatorCondition
+	var requeueAfter time.Duration
+
+	conditionsMap := make(map[string]*operatorv1.OperatorCondition)
+	for i := range conditions {
+		conditionsMap[conditions[i].Type] = &conditions[i]
+	}
+
+	for _, expected := range expectedConds {
+		condition, haveCondition := conditionsMap[expected.ConditionType]
+		if !haveCondition {
+			continue
+		}
+		if condition.Status == expected.ConditionStatus {
+			continue
+		}
+
+		failedPredicates := false
+		for _, ifCond := range expected.IfConditionsTrue {
+			predicate, havePredicate := conditionsMap[ifCond]
+			if !havePredicate || predicate.Status != operatorv1.ConditionTrue {
+				failedPredicates = true
+				break
+			}
+		}
+		if failedPredicates {
+			continue
+		}
+
+		if expected.GracePeriod != 0 {
+			t1 := now.Add(-expected.GracePeriod)
+			t2 := condition.LastTransitionTime
+			if t2.After(t1) {
+				d := t2.Sub(t1)
+				if len(graceConditions) == 0 || d < requeueAfter {
+					// Recompute status conditions again
+					// after the grace period has elapsed.
+					requeueAfter = d
+				}
+				graceConditions = append(graceConditions, condition)
+				continue
+			}
+		}
+
+		degradedConditions = append(degradedConditions, condition)
+	}
+
+	return graceConditions, degradedConditions, requeueAfter
+}

--- a/pkg/util/conditionexpectations/conditionexpectations_test.go
+++ b/pkg/util/conditionexpectations/conditionexpectations_test.go
@@ -1,0 +1,205 @@
+package conditionexpectations
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilclock "k8s.io/apimachinery/pkg/util/clock"
+)
+
+// TestCheck verifies that Check behaves as expected.
+func TestCheck(t *testing.T) {
+	fakeClock := utilclock.NewFakeClock(time.Time{})
+
+	var (
+		expectFooTrue = Expectation{
+			ConditionType:   "Foo",
+			ConditionStatus: operatorv1.ConditionTrue,
+		}
+		expectFooTrueWithFiveMinuteGrace = Expectation{
+			ConditionType:   "Foo",
+			ConditionStatus: operatorv1.ConditionTrue,
+			GracePeriod:     5 * time.Minute,
+		}
+		expectBarTrueWithThreeMinuteGrace = Expectation{
+			ConditionType:   "Bar",
+			ConditionStatus: operatorv1.ConditionTrue,
+			GracePeriod:     3 * time.Minute,
+		}
+		expectBazFalse = Expectation{
+			ConditionType:   "Baz",
+			ConditionStatus: operatorv1.ConditionFalse,
+		}
+		expectBazTrueIfFooTrue = Expectation{
+			ConditionType:    "Baz",
+			ConditionStatus:  operatorv1.ConditionTrue,
+			IfConditionsTrue: []string{"Foo"},
+		}
+		fooFalse = operatorv1.OperatorCondition{
+			Type:               "Foo",
+			Status:             operatorv1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+		}
+		fooTrue = operatorv1.OperatorCondition{
+			Type:               "Foo",
+			Status:             operatorv1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+		}
+		barFalse = operatorv1.OperatorCondition{
+			Type:               "Bar",
+			Status:             operatorv1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+		}
+		bazTrue = operatorv1.OperatorCondition{
+			Type:               "Baz",
+			Status:             operatorv1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+		}
+		bazFalse = operatorv1.OperatorCondition{
+			Type:               "Baz",
+			Status:             operatorv1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now()),
+		}
+	)
+
+	testCases := []struct {
+		description                string
+		expectations               Expectations
+		conditions                 []operatorv1.OperatorCondition
+		expectedGraceConditions    []*operatorv1.OperatorCondition
+		expectedDegradedConditions []*operatorv1.OperatorCondition
+		expectedTimeDuration       time.Duration
+		now                        time.Time
+	}{
+		{
+			description:                "empty expectations",
+			expectations:               MakeExpectations([]Expectation{}),
+			conditions:                 []operatorv1.OperatorCondition{},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: nil,
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description:                "nonempty, non-matching expectations",
+			expectations:               MakeExpectations([]Expectation{expectFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{barFalse},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: nil,
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description:                "satisfied expectation",
+			expectations:               MakeExpectations([]Expectation{expectFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{fooTrue},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: nil,
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description:                "unsatisfied expectation",
+			expectations:               MakeExpectations([]Expectation{expectFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{fooFalse},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: []*operatorv1.OperatorCondition{&fooFalse},
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description: "unsatisfied expectation with grace",
+			expectations: MakeExpectations([]Expectation{
+				expectFooTrueWithFiveMinuteGrace,
+				expectBarTrueWithThreeMinuteGrace,
+				expectBazFalse,
+			}),
+			conditions:                 []operatorv1.OperatorCondition{fooFalse, barFalse, bazTrue},
+			expectedGraceConditions:    []*operatorv1.OperatorCondition{&fooFalse, &barFalse},
+			expectedDegradedConditions: []*operatorv1.OperatorCondition{&bazTrue},
+			expectedTimeDuration:       3 * time.Minute,
+		},
+		{
+			description: "unsatisfied expectations, one with remaining grace and one expired",
+			expectations: MakeExpectations([]Expectation{
+				expectFooTrueWithFiveMinuteGrace,
+				expectBarTrueWithThreeMinuteGrace,
+				expectBazFalse,
+			}),
+			conditions:                 []operatorv1.OperatorCondition{fooFalse, barFalse, bazTrue},
+			expectedGraceConditions:    []*operatorv1.OperatorCondition{&fooFalse},
+			expectedDegradedConditions: []*operatorv1.OperatorCondition{&barFalse, &bazTrue},
+			expectedTimeDuration:       2 * time.Minute,
+			now:                        fakeClock.Now().Add(3 * time.Minute),
+		},
+		{
+			description: "unsatisfied expectations with expired grace",
+			expectations: MakeExpectations([]Expectation{
+				expectFooTrueWithFiveMinuteGrace,
+				expectBarTrueWithThreeMinuteGrace,
+				expectBazFalse,
+			}),
+			conditions:                 []operatorv1.OperatorCondition{fooFalse, barFalse, bazTrue},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: []*operatorv1.OperatorCondition{&fooFalse, &barFalse, &bazTrue},
+			expectedTimeDuration:       time.Duration(0),
+			now:                        fakeClock.Now().Add(10 * time.Minute),
+		},
+		{
+			description:                "expectation with unsatisfied predicate",
+			expectations:               MakeExpectations([]Expectation{expectBazTrueIfFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{bazFalse},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: nil,
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description:                "unsatisfied expectation with satisfied predicate",
+			expectations:               MakeExpectations([]Expectation{expectBazTrueIfFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{fooTrue, bazFalse},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: []*operatorv1.OperatorCondition{&bazFalse},
+			expectedTimeDuration:       time.Duration(0),
+		},
+		{
+			description:                "satisfied expectation with satisfied predicate",
+			expectations:               MakeExpectations([]Expectation{expectBazTrueIfFooTrue}),
+			conditions:                 []operatorv1.OperatorCondition{fooTrue, bazTrue},
+			expectedGraceConditions:    nil,
+			expectedDegradedConditions: nil,
+			expectedTimeDuration:       time.Duration(0),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualGraceConditions, actualDegradedConditions, actualTimeDuration := MakeExpectations(tc.expectations).Check(tc.conditions, tc.now)
+			if !reflect.DeepEqual(actualGraceConditions, tc.expectedGraceConditions) {
+				expected := make([]operatorv1.OperatorCondition, 0, len(tc.expectedGraceConditions))
+				for i := range tc.expectedGraceConditions {
+					expected = append(expected, *tc.expectedGraceConditions[i])
+				}
+				actual := make([]operatorv1.OperatorCondition, 0, len(actualGraceConditions))
+				for i := range actualGraceConditions {
+					actual = append(actual, *actualGraceConditions[i])
+				}
+				t.Errorf("expected grace conditions: %+v, got: %+v", expected, actual)
+			}
+			if !reflect.DeepEqual(actualDegradedConditions, tc.expectedDegradedConditions) {
+				expected := make([]operatorv1.OperatorCondition, 0, len(tc.expectedDegradedConditions))
+				for i := range tc.expectedDegradedConditions {
+					expected = append(expected, *tc.expectedDegradedConditions[i])
+				}
+				actual := make([]operatorv1.OperatorCondition, 0, len(actualDegradedConditions))
+				for i := range actualDegradedConditions {
+					actual = append(actual, *actualDegradedConditions[i])
+				}
+				t.Errorf("expected degraded conditions: %v, got: %v", expected, actual)
+			}
+			if !reflect.DeepEqual(actualTimeDuration, tc.expectedTimeDuration) {
+				t.Errorf("expected time duration: %v, got: %v", tc.expectedTimeDuration, actualTimeDuration)
+			}
+		})
+	}
+
+}

--- a/pkg/util/conditionexpectations/example_conditionexpectations_test.go
+++ b/pkg/util/conditionexpectations/example_conditionexpectations_test.go
@@ -1,0 +1,160 @@
+package conditionexpectations_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/util/conditionexpectations"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilclock "k8s.io/apimachinery/pkg/util/clock"
+)
+
+func print(gcs, dcs []*operatorv1.OperatorCondition, d time.Duration) {
+	var gss, dss []string
+	for i := range gcs {
+		gss = append(gss, fmt.Sprintf("%v=%v", gcs[i].Type, gcs[i].Status))
+	}
+	for i := range dcs {
+		dss = append(dss, fmt.Sprintf("%v=%v", dcs[i].Type, dcs[i].Status))
+	}
+	fmt.Println(gss, dss, d)
+}
+
+// ExamplePredicate shows how Expectations can be used to check two example
+// status conditions where one condition depends on the other.  In this example,
+// the first condition indicates whether the operator is managing some resource,
+// and the second condition reports whether that resource is available.
+func ExamplePredicate() {
+	expectations := conditionexpectations.MakeExpectations([]conditionexpectations.Expectation{{
+		ConditionType:    "FooAvailable",
+		ConditionStatus:  operatorv1.ConditionTrue,
+		IfConditionsTrue: []string{"FooManaged"},
+	}})
+
+	fmt.Println("If FooManaged=False:")
+
+	conditions := []operatorv1.OperatorCondition{
+		{
+			Type:   "FooManaged",
+			Status: operatorv1.ConditionFalse,
+		},
+		{
+			Type:   "FooAvailable",
+			Status: operatorv1.ConditionFalse,
+		},
+	}
+	print(expectations.Check(conditions, time.Now()))
+
+	fmt.Println("If FooManaged=True and FooAvailable=False:")
+
+	conditions = []operatorv1.OperatorCondition{{
+		Type:   "FooManaged",
+		Status: operatorv1.ConditionTrue,
+	}, {
+		Type:   "FooAvailable",
+		Status: operatorv1.ConditionFalse,
+	}}
+	print(expectations.Check(conditions, time.Now()))
+
+	fmt.Println("If FooAvailable=True:")
+
+	conditions = []operatorv1.OperatorCondition{{
+		Type:   "FooManaged",
+		Status: operatorv1.ConditionFalse,
+	}, {
+		Type:   "FooAvailable",
+		Status: operatorv1.ConditionFalse,
+	}}
+	print(expectations.Check(conditions, time.Now()))
+
+	// Output: If FooManaged=False:
+	// [] [] 0s
+	// If FooManaged=True and FooAvailable=False:
+	// [] [FooAvailable=False] 0s
+	// If FooAvailable=True:
+	// [] [] 0s
+}
+
+// ExampleGrace shows how Expectations can be used to check a set of status
+// conditions where one of the status conditions has a grace period.
+func ExampleGrace() {
+	expectations := conditionexpectations.MakeExpectations([]conditionexpectations.Expectation{{
+		ConditionType:   "FooAvailable",
+		ConditionStatus: operatorv1.ConditionTrue,
+	}, {
+		ConditionType:   "BarAvailable",
+		ConditionStatus: operatorv1.ConditionTrue,
+	}, {
+		ConditionType:   "BazAvailable",
+		ConditionStatus: operatorv1.ConditionTrue,
+		GracePeriod:     1 * time.Minute,
+	}})
+
+	fakeClock := utilclock.NewFakeClock(time.Time{})
+
+	fmt.Println("If all conditions are satisfied:")
+
+	conditions := []operatorv1.OperatorCondition{
+		{
+			Type:   "FooAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:   "BarAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:   "BazAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+	}
+	print(expectations.Check(conditions, fakeClock.Now()))
+
+	fmt.Println(`If the "Baz" condition is unsatisfied but in grace:`)
+
+	conditions = []operatorv1.OperatorCondition{
+		{
+			Type:   "FooAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:   "BarAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:               "BazAvailable",
+			Status:             operatorv1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-10 * time.Second)),
+		},
+	}
+	print(expectations.Check(conditions, fakeClock.Now()))
+
+	fmt.Println(`If the "Baz" condition is unsatisfied and past grace:`)
+
+	conditions = []operatorv1.OperatorCondition{
+		{
+			Type:   "FooAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:   "BarAvailable",
+			Status: operatorv1.ConditionTrue,
+		},
+		{
+			Type:               "BazAvailable",
+			Status:             operatorv1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-2 * time.Minute)),
+		},
+	}
+	print(expectations.Check(conditions, fakeClock.Now()))
+
+	// Output: If all conditions are satisfied:
+	// [] [] 0s
+	// If the "Baz" condition is unsatisfied but in grace:
+	// [BazAvailable=False] [] 50s
+	// If the "Baz" condition is unsatisfied and past grace:
+	// [] [BazAvailable=False] 0s
+}


### PR DESCRIPTION
Factor the expected conditions and grace logic from the status control into a separate package that can be more easily re-used.

* `pkg/operator/controller/ingress/status.go` (`expectedCondition`, `checkConditions`): Delete.  These are superseded by the `Expectation` type and `Check` method, respectively, in the new util package.
(`computeIngressAvailableCondition`, `computeIngressDegradedCondition`): Update to use the new util package.
* `pkg/util/conditionexpectations/conditionexpectations.go`: New file.
(`Expectation`): New type. Define an expectation for an operator status condition.
(`Expectations`): New type.  Define a set of expectations that can be checked against a list of operator conditions.
(`MakeExpectations`): New function.  Create an `Expectations` from a slice of `Expectation`.
(`Check`): New method.  Check a given slice of operator conditions against an `Expectations` and return a list of grace conditions, a list of degraded conditions, and a time duration value with the largest remaining grace period of any grace conditions.
* `pkg/util/conditionexpectations/conditionexpectations_test.go`: New file.
(`TestCheck`): New test.  Verify that the `Check` method behaves correctly.
* `pkg/util/conditionexpectations/example_conditionexpectations_test.go`: New file.
(`ExamplePredicate`): New example.  Show how to use `IfConditionsTrue`.
(`ExampleGrace`): New example.  Show how to use `GracePeriod`.