### PR TITLE
Add support for specifying vpc subnets- providerLoadBalancerParameter.ibm.Subnets

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -114,3 +114,25 @@ Assuming `KUBECONFIG` is set, run end-to-end tests:
 ```
 $ make test-e2e
 ```
+
+## IBM Cloud notes
+
+The cluster-version-operator (CVO) overrides changes made to the ingress operator configuration.
+
+Some of the scripts above scale down the CVO to 0 replica so that your hacks to the ingress configuration are not overwritten by the CVO.
+
+On IBM Cloud, the CVO deployment cannot be scaled down as running on a managed master node. As a workaround, to avoid overriding the changes to the ingress operator configuration, you can instead use overrides in the CVO configuration (ClusterVersion version configuration) - eg:
+
+``` yaml
+  overrides:
+    - group: apps
+      kind: Deployment
+      name: ingress-operator
+      namespace: openshift-ingress-operator
+      unmanaged: true
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: ingresscontrollers.operator.openshift.io
+      namespace: openshift-ingress-operator
+      unmanaged: true
+```

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -428,7 +428,7 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 
 			// Detect changes to provider-specific parameters.
 			// Currently the only platforms with configurable
-			// provider-specific parameters are AWS and GCP.
+			// provider-specific parameters are AWS, GCP and IBM.
 			var lbType operatorv1.LoadBalancerProviderType
 			if specLB.ProviderParameters != nil {
 				lbType = specLB.ProviderParameters.Type
@@ -488,6 +488,28 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, infraConfig 
 						statusLB.ProviderParameters.GCP = &operatorv1.GCPLoadBalancerParameters{}
 					}
 					statusLB.ProviderParameters.GCP.ClientAccess = specClientAccess
+					changed = true
+				}
+			case operatorv1.IBMLoadBalancerProvider:
+				// The only provider parameter that is supported
+				// for IBM is subnets
+				var subnetsSpec, subnetsStatus string
+				if specLB.ProviderParameters != nil && specLB.ProviderParameters.IBM != nil {
+					subnetsSpec = specLB.ProviderParameters.IBM.Subnets
+				}
+				if statusLB.ProviderParameters != nil && statusLB.ProviderParameters.IBM != nil {
+					subnetsStatus = statusLB.ProviderParameters.IBM.Subnets
+				}
+				if subnetsSpec != subnetsStatus {
+					if statusLB.ProviderParameters == nil {
+						statusLB.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{
+							Type: operatorv1.IBMLoadBalancerProvider,
+						}
+					}
+					if statusLB.ProviderParameters.IBM == nil {
+						statusLB.ProviderParameters.IBM = &operatorv1.IBMLoadBalancerParameters{}
+					}
+					statusLB.ProviderParameters.IBM.Subnets = subnetsSpec
 					changed = true
 				}
 			}


### PR DESCRIPTION
**[This depends on api addition in ingress controller - https://github.com/openshift/api/pull/1208]**

Add logic setting the "service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets" annotation on the kubernetes route-default service object (using providerLoadBalancerParameter.ibm.Subnets input).

Details on annotation at "service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets" described at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas