### PR TITLE
Enable switching of AWS CLB to NLB without deletion of IngressController object.

### DIFF
--- a/pkg/operator/controller/configurable-route/controller.go
+++ b/pkg/operator/controller/configurable-route/controller.go
@@ -101,7 +101,7 @@ func New(mgr manager.Manager, config Config, eventRecorder events.Recorder) (con
 func (r *reconciler) resourceToClusterIngressConfig(o client.Object) []reconcile.Request {
 	return []reconcile.Request{
 		{
-			operatorcontroller.IngressClusterConfigName(),
+			NamespacedName: operatorcontroller.IngressClusterConfigName(),
 		},
 	}
 }

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -478,38 +478,44 @@ func setDefaultPublishingStrategy(ic *operatorv1.IngressController, platformStat
 			}
 			switch lbType {
 			case operatorv1.AWSLoadBalancerProvider:
-				// The only provider parameter that is supported
-				// for AWS is the connection idle timeout for
-				// classic ELBs.
-				var specIdleTimeout, statusIdleTimeout metav1.Duration
-				if specLB.ProviderParameters != nil && specLB.ProviderParameters.AWS != nil && specLB.ProviderParameters.AWS.ClassicLoadBalancerParameters != nil {
-					specIdleTimeout = specLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout
+				if statusLB.ProviderParameters == nil {
+					statusLB.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{}
 				}
-				if statusLB.ProviderParameters != nil && statusLB.ProviderParameters.AWS != nil && statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters != nil {
-					statusIdleTimeout = statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout
+				if len(statusLB.ProviderParameters.Type) == 0 {
+					statusLB.ProviderParameters.Type = operatorv1.AWSLoadBalancerProvider
 				}
-				if specIdleTimeout != statusIdleTimeout {
-					if statusLB.ProviderParameters == nil {
-						statusLB.ProviderParameters = &operatorv1.ProviderLoadBalancerParameters{}
-					}
-					if len(statusLB.ProviderParameters.Type) == 0 {
-						statusLB.ProviderParameters.Type = operatorv1.AWSLoadBalancerProvider
-					}
-					if statusLB.ProviderParameters.AWS == nil {
-						statusLB.ProviderParameters.AWS = &operatorv1.AWSLoadBalancerParameters{}
-					}
-					if len(statusLB.ProviderParameters.AWS.Type) == 0 {
-						statusLB.ProviderParameters.AWS.Type = operatorv1.AWSClassicLoadBalancer
-					}
+				if statusLB.ProviderParameters.AWS == nil {
+					statusLB.ProviderParameters.AWS = &operatorv1.AWSLoadBalancerParameters{}
+				}
+				// Assume the LB type is "Classic" if the field is empty.
+				specLBType := operatorv1.AWSClassicLoadBalancer
+				if specLB.ProviderParameters.AWS != nil && len(specLB.ProviderParameters.AWS.Type) != 0 {
+					specLBType = specLB.ProviderParameters.AWS.Type
+				}
+				if specLBType != statusLB.ProviderParameters.AWS.Type {
+					statusLB.ProviderParameters.AWS.Type = specLBType
+					changed = true
+				}
+				if statusLB.ProviderParameters.AWS.Type == operatorv1.AWSClassicLoadBalancer {
 					if statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters == nil {
 						statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters = &operatorv1.AWSClassicLoadBalancerParameters{}
 					}
-					var v metav1.Duration
-					if specIdleTimeout.Duration > 0 {
-						v = specIdleTimeout
+					// The only provider parameter that is
+					// supported for AWS Classic ELBs is the
+					// connection idle timeout.
+					var specIdleTimeout metav1.Duration
+					if specLB.ProviderParameters.AWS != nil && specLB.ProviderParameters.AWS.ClassicLoadBalancerParameters != nil {
+						specIdleTimeout = specLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout
 					}
-					statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout = v
-					changed = true
+					statusIdleTimeout := statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout
+					if specIdleTimeout != statusIdleTimeout {
+						var v metav1.Duration
+						if specIdleTimeout.Duration > 0 {
+							v = specIdleTimeout
+						}
+						statusLB.ProviderParameters.AWS.ClassicLoadBalancerParameters.ConnectionIdleTimeout = v
+						changed = true
+					}
 				}
 			case operatorv1.GCPLoadBalancerProvider:
 				// The only provider parameter that is supported

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -386,16 +386,28 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 			expectedIC:     makeIC(spec(lb(operatorv1.ExternalLoadBalancer)), status(lb(operatorv1.ExternalLoadBalancer))),
 		},
 		{
+			name:           "loadbalancer type set to ELB",
+			ic:             makeIC(spec(elb()), status(elb())),
+			expectedResult: false,
+			expectedIC:     makeIC(spec(elb()), status(elbWithNullParameters())),
+		},
+		{
+			name:           "loadbalancer type set to NLB",
+			ic:             makeIC(spec(nlb()), status(nlb())),
+			expectedResult: false,
+			expectedIC:     makeIC(spec(nlb()), status(nlb())),
+		},
+		{
 			name:           "loadbalancer type changed from ELB to NLB",
 			ic:             makeIC(spec(nlb()), status(elb())),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(nlb()), status(elb())),
+			expectedResult: true,
+			expectedIC:     makeIC(spec(nlb()), status(nlb())),
 		},
 		{
 			name:           "loadbalancer type changed from NLB to ELB",
 			ic:             makeIC(spec(elb()), status(nlb())),
-			expectedResult: false,
-			expectedIC:     makeIC(spec(elb()), status(nlb())),
+			expectedResult: true,
+			expectedIC:     makeIC(spec(elb()), status(elbWithNullParameters())),
 		},
 		{
 			name:           "loadbalancer ELB connection idle timeout changed from unset with null provider parameters to 2m",

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -157,14 +157,14 @@ func TestTuningOptions(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _ := getRouterDeploymentComponents(t)
 
 	// Set up tuning options
-	ic.Spec.TuningOptions.ClientTimeout = &metav1.Duration{45 * time.Second}
-	ic.Spec.TuningOptions.ClientFinTimeout = &metav1.Duration{3 * time.Second}
-	ic.Spec.TuningOptions.ServerTimeout = &metav1.Duration{60 * time.Second}
-	ic.Spec.TuningOptions.ServerFinTimeout = &metav1.Duration{4 * time.Second}
-	ic.Spec.TuningOptions.TunnelTimeout = &metav1.Duration{30 * time.Minute}
-	ic.Spec.TuningOptions.TLSInspectDelay = &metav1.Duration{5 * time.Second}
-	ic.Spec.TuningOptions.HealthCheckInterval = &metav1.Duration{15 * time.Second}
-	ic.Spec.TuningOptions.ReloadInterval = metav1.Duration{30 * time.Second}
+	ic.Spec.TuningOptions.ClientTimeout = &metav1.Duration{Duration: 45 * time.Second}
+	ic.Spec.TuningOptions.ClientFinTimeout = &metav1.Duration{Duration: 3 * time.Second}
+	ic.Spec.TuningOptions.ServerTimeout = &metav1.Duration{Duration: 60 * time.Second}
+	ic.Spec.TuningOptions.ServerFinTimeout = &metav1.Duration{Duration: 4 * time.Second}
+	ic.Spec.TuningOptions.TunnelTimeout = &metav1.Duration{Duration: 30 * time.Minute}
+	ic.Spec.TuningOptions.TLSInspectDelay = &metav1.Duration{Duration: 5 * time.Second}
+	ic.Spec.TuningOptions.HealthCheckInterval = &metav1.Duration{Duration: 15 * time.Second}
+	ic.Spec.TuningOptions.ReloadInterval = metav1.Duration{Duration: 30 * time.Second}
 
 	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil)
 	if err != nil {

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -226,6 +226,13 @@ var (
 			// local-with-fallback annotation for kube-proxy (see
 			// <https://bugzilla.redhat.com/show_bug.cgi?id=1960284>).
 			localWithFallbackAnnotation,
+			// AWS load balancer type annotation to set either CLB/ELB or NLB
+			AWSLBTypeAnnotation,
+			// awsLBProxyProtocolAnnotation is used to enable the PROXY protocol on any
+			// AWS load balancer services created.
+			//
+			// https://kubernetes.io/docs/concepts/services-networking/service/#proxy-protocol-support-on-aws
+			awsLBProxyProtocolAnnotation,
 		)
 
 		// Azure and GCP support switching between internal and external

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -66,6 +66,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus", TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus)
 		t.Run("TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus", TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus)
 		t.Run("TestReloadInterval", TestReloadInterval)
+		t.Run("TestAWSLBTypeChange", TestAWSLBTypeChange)
 	})
 
 	t.Run("serial", func(t *testing.T) {

--- a/test/e2e/checkinterval_test.go
+++ b/test/e2e/checkinterval_test.go
@@ -48,7 +48,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	}
 
 	// set spec.tuningOptions.healthCheckInterval to a nondefault value, double the default
-	if err := setHealthCheckInterval(t, kclient, 10*time.Second, &metav1.Duration{2 * defaultHealthCheckInterval}, ic); err != nil {
+	if err := setHealthCheckInterval(t, kclient, 10*time.Second, &metav1.Duration{Duration: 2 * defaultHealthCheckInterval}, ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 
@@ -62,7 +62,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	}
 
 	// set spec.healthCheckInterval to an unacceptable value, 0s
-	if err := setHealthCheckInterval(t, kclient, 1*time.Minute, &metav1.Duration{0 * time.Second}, ic); err != nil {
+	if err := setHealthCheckInterval(t, kclient, 1*time.Minute, &metav1.Duration{Duration: 0 * time.Second}, ic); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1096,6 +1096,78 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 	}
 }
 
+func TestAWSLBTypeChange(t *testing.T) {
+	t.Parallel()
+
+	if infraConfig.Status.Platform != "AWS" {
+		t.Skipf("test skipped on platform %q", infraConfig.Status.Platform)
+	}
+
+	name := types.NamespacedName{Namespace: operatorNamespace, Name: "awslb"}
+	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
+		Scope: operatorv1.ExternalLoadBalancer,
+	}
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for the load balancer and DNS to be ready.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	lbService := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		t.Fatalf("failed to get LoadBalancer service: %v", err)
+	}
+	if v := lbService.Annotations[ingresscontroller.AWSLBTypeAnnotation]; len(v) != 0 {
+		t.Fatalf("load balancer service has unexpected %s=%s annotation", ingresscontroller.AWSLBTypeAnnotation, v)
+	}
+
+	if err := kclient.Get(context.TODO(), name, ic); err != nil {
+		t.Fatalf("failed to get ingresscontroller %s: %v", name, err)
+	}
+
+	pp := &operatorv1.ProviderLoadBalancerParameters{
+		Type: operatorv1.AWSLoadBalancerProvider,
+		AWS: &operatorv1.AWSLoadBalancerParameters{
+			Type: operatorv1.AWSNetworkLoadBalancer,
+		},
+	}
+	ic.Spec.EndpointPublishingStrategy.LoadBalancer.ProviderParameters = pp
+
+	if err := kclient.Update(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to update ingresscontroller: %v", err)
+	}
+
+	// Wait for the load balancer and DNS to be ready.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+		service := &corev1.Service{}
+		if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), service); err != nil {
+			t.Logf("failed to get service %s: %v", controller.LoadBalancerServiceName(ic), err)
+			return false, nil
+		}
+		if actual, ok := service.Annotations[ingresscontroller.AWSLBTypeAnnotation]; !ok {
+			t.Logf("load balancer has no %q annotation: %v", ingresscontroller.AWSLBTypeAnnotation, service.Annotations)
+			return false, nil
+		} else if actual != ingresscontroller.AWSNLBAnnotation {
+			t.Logf("expected %s=%s, found %s=%s", ingresscontroller.AWSLBTypeAnnotation, ingresscontroller.AWSNLBAnnotation,
+				ingresscontroller.AWSLBTypeAnnotation, actual)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for the service LB type annotation to be updated: %v", err)
+	}
+}
+
 // TestScopeChange creates an ingresscontroller with the "LoadBalancerService"
 // endpoint publishing strategy type and verifies that the operator behaves
 // correctly when the ingresscontroller's scope is mutated.  The correct

--- a/test/e2e/reloadinterval_test.go
+++ b/test/e2e/reloadinterval_test.go
@@ -58,23 +58,23 @@ func TestReloadInterval(t *testing.T) {
 	}{
 		// set ReloadInterval to a value that does not pass the regex validation
 		// expect validation error
-		{"set reloadInterval 0.5s", metav1.Duration{500 * time.Millisecond}, "5s", false},
-		{"set reloadInterval 1s", metav1.Duration{-1 * time.Second}, "5s", false},
+		{"set reloadInterval 0.5s", metav1.Duration{Duration: 500 * time.Millisecond}, "5s", false},
+		{"set reloadInterval 1s", metav1.Duration{Duration: -1 * time.Second}, "5s", false},
 
 		// the following values all pass the regex validation
 		//
 		// set Spec.TuningOptions.ReloadInterval to a nondefault value within allowed bounds
 		// expect no error
-		{"set reloadInterval 100s", metav1.Duration{100 * time.Second}, "100s", true},
-		{"set reloadInterval 1m", metav1.Duration{1 * time.Minute}, "1m", true},
+		{"set reloadInterval 100s", metav1.Duration{Duration: 100 * time.Second}, "100s", true},
+		{"set reloadInterval 1m", metav1.Duration{Duration: 1 * time.Minute}, "1m", true},
 
 		// set ReloadInterval to 0, which should give default of 5s
 		// expect no error
-		{"set reloadInterval default", metav1.Duration{0 * time.Second}, "5s", true},
+		{"set reloadInterval default", metav1.Duration{Duration: 0 * time.Second}, "5s", true},
 
 		// set ReloadInterval to a value outside of allowed bounds
 		// expect no error
-		{"set reloadInterval 130s", metav1.Duration{130 * time.Second}, "2m", true},
+		{"set reloadInterval 130s", metav1.Duration{Duration: 130 * time.Second}, "2m", true},
 	} {
 		t.Log(testCase.description)
 		// cases with values that pass the regex validation


### PR DESCRIPTION
As an user/admin, I want to switch an OCP Ingress from an AWS Classic Load Balancer to AWS Network Load Balancer. I should be able to do this without having to delete and recreate the IngressController object.
Using this fix one can update the ingress controller object with change of LB type details and get the LB service reflected with the necessary changes without the need for recreation.

Fixes https://issues.redhat.com/browse/NE-865

`pkg/operator/controller/configurable-route/controller.go` We need to mention the key or an error is thrown.
`pkg/operator/controller/ingress/controller.go` Logic added for setting the right endpoint publishing strategy while switching from ELB to NLB or vice-versa.
`pkg/operator/controller/ingress/controller_test.go` Unit tests for switching between NLB and CLB.
`pkg/operator/controller/ingress/deployment_test.go`  We need to mention the key or an error is thrown.
`pkg/operator/controller/ingress/load_balancer_service.go` Logic to check difference between desired and current service for the lb type annotation and proxy protocol annotation and update if the current service with the desired service annotations if necessary.
`pkg/operator/controller/ingress/status.go` Adds progressing status condition logic while switching between NLB and ELB and vice-versa.
` pkg/operator/controller/ingress/status_test.go` Adds a nil as the computeIngressProgressingCondition now also accepts current service as a parameter but for this unit test current lb service is not needed.
`test/e2e/all_test.go` Adds e2e test written for this PR.
`test/e2e/checkinterval_test.go` We need to mention the key or an error is thrown.
`test/e2e/operator_test.go` e2e test for this PR.
`test/e2e/reloadinterval_test.go` We need to mention the key or an error `./reloadinterval_test.go:61:31: k8s.io/apimachinery/pkg/apis/meta/v1.Duration composite literal uses unkeyed fields` is thrown.