### PR TITLE
Bug 2086887: Add better debug logging to TestIngressOperatorCacheIsNotGlobal to help debug flakes

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3153,7 +3153,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 		}
 
 		if len(ic.Status.Conditions) != 0 {
-			t.Fatalf("expected ingress controller %s to be ignored by the ingress operator", icName)
+			t.Fatalf("expected ingress controller %s to be ignored by the ingress operator: conditions: %+v", icName, ic.Status.Conditions)
 		}
 		return false, nil
 	})


### PR DESCRIPTION
Add simple debug logic because @frobware and I saw a flake for TestIngressOperatorCacheIsNotGlobal. We need to log the condition to help us understand why the test is failing.