### PR TITLE
Bug 2101878: Fix route status clearing race condition caused by using the cache

### DIFF
--- a/pkg/operator/controller/ingress/router_status.go
+++ b/pkg/operator/controller/ingress/router_status.go
@@ -60,7 +60,7 @@ func (r *reconciler) syncRouteStatus(ic *operatorv1.IngressController) []error {
 func (r *reconciler) isRouterDeploymentRolloutComplete(ic *operatorv1.IngressController) (bool, error) {
 	deployment := appsv1.Deployment{}
 	deploymentName := operatorcontroller.RouterDeploymentName(ic)
-	if err := r.cache.Get(context.TODO(), deploymentName, &deployment); err != nil {
+	if err := r.client.Get(context.TODO(), deploymentName, &deployment); err != nil {
 		return false, fmt.Errorf("failed to get deployment %s: %w", deploymentName, err)
 	}
 


### PR DESCRIPTION
This is a follow up fix to https://github.com/openshift/cluster-ingress-operator/pull/724 which resolves a race condition caused using the cache for determining if the router deployment is still rolling out. The cache says it isn't rolling out immediately after it started rolling out.