### PR TITLE
OCPBUGS-1807: Fix bad `handleSingleNode4Dot11Upgrade` log message

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -336,7 +336,7 @@ func (o *Operator) handleSingleNode4Dot11Upgrade() error {
 		return fmt.Errorf("unable to update ingress config %q: %w", ingressConfigName.Name, err)
 	}
 
-	log.Info("Patched %q ingress config defaultPlacement status to %q", ingressConfigName.Name, desiredDefaultPlacement)
+	log.Info("Patched ingress config defaultPlacement status", ingressConfigName.Name, desiredDefaultPlacement)
 
 	return nil
 }


### PR DESCRIPTION
bdb5b649635df239379b2a4d5120af36af784964 introduced a log call with
formatting that doesn't work, resulting in a log line that looks like this:

```
2022-06-22T10:04:12.616Z        INFO    operator.init   operator/operator.go:236        Patched %q ingress config defaultPlacement status to %q {"cluster": "Workers"}
```

This should fix it... It's very unlikely customers will run into this
fix because it will only happen in <=4.10 to >=4.12 upgrades, unless we
backport this. But I'm not sure it's worth the effort of backporting