### PR TITLE
Bug 2101878: Fix another issue with route status clearing race condition caused by not validating generation id

### DIFF
--- a/pkg/operator/controller/ingress/router_status.go
+++ b/pkg/operator/controller/ingress/router_status.go
@@ -64,9 +64,13 @@ func (r *reconciler) isRouterDeploymentRolloutComplete(ic *operatorv1.IngressCon
 		return false, fmt.Errorf("failed to get deployment %s: %w", deploymentName, err)
 	}
 
+	if deployment.Generation != deployment.Status.ObservedGeneration {
+		return false, nil
+	}
 	if deployment.Status.Replicas != deployment.Status.UpdatedReplicas {
 		return false, nil
 	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
I thought I fixed https://bugzilla.redhat.com/show_bug.cgi?id=2101878 with https://github.com/openshift/cluster-ingress-operator/pull/794, but it failed to pass QA. I must have gotten frustratingly lucky with testing...

Upon a more detailed investigation, I found that the check in `isRouterDeploymentRolloutComplete` of `deployment.Status.Replicas != deployment.Status.UpdatedReplicas` is sometimes prematurely successful due to another race condition. The cluster-ingress-operator reconcilation sometimes happens quicker than K8S can start the router deployment rollout; though it appears that `metadata.Generation` was incremented by 1 while `Status.ObservedGeneration` was untouched.

Therefore, this PR adds a check for generation id to validate we don't check rollout status prematurely.

