### PR TITLE
DPP-10860: Update Bugzilla links to "Networking" component

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
 - name: File a Bugzilla report
-  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Routing
+  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=router
   about: Please use Bugzilla to report issues.
 - name: Ingress Operator in OpenShift Container Platform
   url: https://docs.openshift.com/container-platform/latest/networking/ingress-operator.html

--- a/README.md
+++ b/README.md
@@ -131,6 +131,6 @@ $ oc describe --namespace=openshift-ingress-operator ingresscontroller/<name>
 
 ## Contributing
 
-Report issues in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Routing).
+Report issues in [Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=router).
 
 See [HACKING.md](HACKING.md) for development topics.


### PR DESCRIPTION
Update Bugzilla links that reference the "Routing" component" to instead use the "Networking" component and "router" subcomponent.

* `.github/ISSUE_TEMPLATE/config.yml`:
* `README.md`: Update Bugzilla links.