### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
@@ -16,6 +16,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-ingress-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   selector:
     matchLabels:


### PR DESCRIPTION
Added client certificates based on https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md
