### PR TITLE
[release-4.10] BUG 2094051: Fix removing custom created service in openshift-ingress with same naming convention

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -260,10 +260,16 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 		return false, nil, err
 	}
 
+	// BZ2054200: Don't modify/delete services that are not directly owned by this controller.
+	ownLBS := isServiceOwnedByIngressController(currentLBService, ci)
+
 	switch {
 	case !wantLBS && !haveLBS:
 		return false, nil, nil
 	case !wantLBS && haveLBS:
+		if !ownLBS {
+			return false, nil, fmt.Errorf("a conflicting load balancer service exists that is not owned by the ingress controller: %s", controller.LoadBalancerServiceName(ci))
+		}
 		if err := r.deleteLoadBalancerService(currentLBService, &crclient.DeleteOptions{}); err != nil {
 			return true, currentLBService, err
 		}
@@ -274,6 +280,9 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 		}
 		return r.currentLoadBalancerService(ci)
 	case wantLBS && haveLBS:
+		if !ownLBS {
+			return false, nil, fmt.Errorf("a conflicting load balancer service exists that is not owned by the ingress controller: %s", controller.LoadBalancerServiceName(ci))
+		}
 		if updated, err := r.normalizeLoadBalancerServiceAnnotations(currentLBService); err != nil {
 			return true, currentLBService, fmt.Errorf("failed to normalize annotations for load balancer service: %w", err)
 		} else if updated {
@@ -293,6 +302,14 @@ func (r *reconciler) ensureLoadBalancerService(ci *operatorv1.IngressController,
 		}
 	}
 	return true, currentLBService, nil
+}
+
+// isServiceOwnedByIngressController determines whether a service is owned by an ingress controller.
+func isServiceOwnedByIngressController(service *corev1.Service, ic *operatorv1.IngressController) bool {
+	if service != nil && service.Labels[manifests.OwningIngressControllerLabel] == ic.Name {
+		return true
+	}
+	return false
 }
 
 // desiredLoadBalancerService returns the desired LB service for a

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2585,6 +2585,89 @@ func TestCustomErrorpages(t *testing.T) {
 	}
 }
 
+// TestIngressControllerServiceNameCollision validates BZ2054200: Don't delete services that are not directly owned by this controller.
+// It creates a service with the same naming convention as the ingress controller creates its own load balancing services.
+// Then it triggers a reconcilation of the ingress operator to see if it will delete our service.
+func TestIngressControllerServiceNameCollision(t *testing.T) {
+	// Create the new private controller that we will later create a service to collide with the naming scheme of this.
+	icName := types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      "e2e-name-collision-test",
+	}
+	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
+	ic := newPrivateController(icName, domain)
+	if err := kclient.Create(context.TODO(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
+	}
+
+	// Clean up our new Ingress Controller after we are done.
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	// Wait for new ingress controller to come online.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
+	// Create services that could collide with the new ingress controller's naming convention for loadbalancer and nodeport.
+	// TRICKY: Our private ingress controller will reconcile and delete extra loadBalancerServices, even though the
+	//         ingress controller isn't a loadbalancer type itself.
+	conflictingLoadBalancerServiceName := types.NamespacedName{
+		Name:      "router-" + icName.Name,
+		Namespace: "openshift-ingress",
+	}
+	conflictingLoadBalancerService := buildEchoService(conflictingLoadBalancerServiceName.Name, conflictingLoadBalancerServiceName.Namespace, nil)
+	if err := kclient.Create(context.TODO(), conflictingLoadBalancerService); err != nil {
+		t.Fatalf("failed to create service %s: %v", conflictingLoadBalancerServiceName, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), conflictingLoadBalancerService); err != nil {
+			t.Fatalf("failed to delete service %s: %v", conflictingLoadBalancerServiceName, err)
+		}
+	}()
+
+	conflictingNodeportServiceName := types.NamespacedName{
+		Name:      "router-nodeport-" + icName.Name,
+		Namespace: "openshift-ingress",
+	}
+	conflictingNodeportService := buildEchoService(conflictingNodeportServiceName.Name, conflictingNodeportServiceName.Namespace, nil)
+	if err := kclient.Create(context.TODO(), conflictingNodeportService); err != nil {
+		t.Fatalf("failed to create service %s: %v", conflictingNodeportServiceName, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), conflictingNodeportService); err != nil {
+			t.Fatalf("failed to delete service %s: %v", conflictingNodeportServiceName, err)
+		}
+	}()
+
+	ic, err := getIngressController(t, kclient, icName, 1*time.Minute)
+	if err != nil {
+		t.Fatalf("failed to get ingress controller: %v", err)
+	}
+
+	// Annotate the ingress operator, to trigger a reconcilation to determine if our service is deleted.
+	// This may not be needed, but it ensures a reconcilation occurs ASAP.
+	if ic.Annotations == nil {
+		ic.Annotations = map[string]string{}
+	}
+	ic.Annotations["ingress.operator.openshift.io/e2e-name-collision-test"] = ""
+
+	if err := kclient.Update(context.TODO(), ic); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait to see if our service gets deleted by the operator due to name collision.
+	oldLoadBalancerUID := conflictingLoadBalancerService.UID
+	oldNodePortUID := conflictingNodeportService.UID
+	wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		// Check if LoadBalancer and Nodeport Service don't get deleted for the entire duration of this loop.
+		// Will throw fatal error if deleted or marked for deletion and this loop stops.
+		assertServiceNotDeleted(t, conflictingLoadBalancerServiceName, oldLoadBalancerUID)
+		assertServiceNotDeleted(t, conflictingNodeportServiceName, oldNodePortUID)
+
+		return false, nil
+	})
+}
+
 func newLoadBalancerController(name types.NamespacedName, domain string) *operatorv1.IngressController {
 	repl := int32(1)
 	return &operatorv1.IngressController{
@@ -2847,6 +2930,25 @@ func deleteIngressController(t *testing.T, cl client.Client, ic *operatorv1.Ingr
 		return fmt.Errorf("timed out waiting for ingresscontroller to be deleted: %v", err)
 	}
 	return nil
+}
+
+// assertServiceNotDeleted asserts that a provide service wasn't deleted.
+func assertServiceNotDeleted(t *testing.T, serviceName types.NamespacedName, oldUid types.UID) {
+	t.Helper()
+
+	// First check our LoadBalancer Service.
+	service := &corev1.Service{}
+	if err := kclient.Get(context.TODO(), serviceName, service); err != nil {
+		t.Fatalf("expected %s to be present: %v", serviceName, err)
+	}
+	// If there is a DeletionTimestamp, it has been marked for deletion.
+	if service.DeletionTimestamp != nil {
+		t.Fatalf("expected service %s to not be marked for deletion: %v", serviceName, service.DeletionTimestamp)
+	}
+	// If the UID has changed, then the service has been recreated.
+	if service.UID != oldUid {
+		t.Fatalf("expected service %s to have UID %v, got %v", serviceName, oldUid, service.UID)
+	}
 }
 
 func createDefaultCertTestSecret(cl client.Client, name string) (*corev1.Secret, error) {


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/cluster-ingress-operator/pull/707 due to merge conflicts for the release-4.10 branch.

Merge Conflicts:
[gspence@gspence cluster-ingress-operator]$ git cherry-pick dba837a8b5314a3baa8167554f951bbb6f458c1e
```
Auto-merging test/e2e/operator_test.go
CONFLICT (content): Merge conflict in test/e2e/operator_test.go
Auto-merging pkg/operator/controller/ingress/load_balancer_service_test.go
CONFLICT (content): Merge conflict in pkg/operator/controller/ingress/load_balancer_service_test.go
Auto-merging pkg/operator/controller/ingress/load_balancer_service.go
```
**test/e2e/operator_test.go:**
- `TestTunableRouterKubeletProbesForDefaultIngressController` and `TestTunableRouterKubeletProbesForCustomIngressController` moved/removed while I added `TestIngressControllerServiceNameCollision` right next to them

**pkg/operator/controller/ingress/load_balancer_service_test.go**
- Added `TestServiceIngressOwner` and conflicted with existing `TestLoadBalancerServiceAnnotationsChanged`
 

/assign gcs278