### PR TITLE
OCPBUGS-1049: test/e2e: Fix TestCanaryRoute security context

### DIFF
--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 )
 
 // TestCanaryRoute tests the ingress canary route
@@ -142,6 +143,16 @@ func buildCanaryCurlPod(name, namespace, image, host string) *corev1.Pod {
 					Image:   image,
 					Command: []string{"/bin/curl"},
 					Args:    curlArgs,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: pointer.Bool(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: pointer.Bool(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Specify a low-privileged security context for the curl pod that the `TestCanaryRoute` test creates so as not to run afoul of pod security constraints.

* `test/e2e/canary_test.go` (`buildCanaryCurlPod`): Specify a low-privileged security context.