### PR TITLE
Bug 2107462: Update CGO_ENABLED=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GO_GCFLAGS ?= -gcflags=all="-N -l"
 endif
 
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
-GO_BUILD_RECIPE=CGO_ENABLED=0 $(GO) build -o $(BIN) $(GO_GCFLAGS) $(MAIN_PACKAGE)
+GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build -o $(BIN) $(GO_GCFLAGS) $(MAIN_PACKAGE)
 
 TEST ?= TestAll
 
@@ -45,7 +45,7 @@ crd:
 
 .PHONY: test
 test:
-	$(GO) test ./...
+	CGO_ENABLED=1 $(GO) test ./...
 
 .PHONY: release-local
 release-local:
@@ -53,7 +53,7 @@ release-local:
 
 .PHONY: test-e2e
 test-e2e:
-	$(GO) test -timeout 1h -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
+	CGO_ENABLED=1 $(GO) test -timeout 1h -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
 
 .PHONY: test-e2e-list
 test-e2e-list:


### PR DESCRIPTION
I am updating with `CGO_ENABLED=1` per discussion/debugging of @miheer 

I've asked @miheer and @manojnkumar to review.

We are currently verifying with fips enabled on ppc64le.

Signed-off-by: Paul Bastide <pbastide@redhat.com>