### PR TITLE
Updating ose-cluster-ingress-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /ingress-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /ingress-operator/ingress-operator /usr/bin/
 COPY manifests /manifests
 ENTRYPOINT ["/usr/bin/ingress-operator"]

--- a/pkg/manifests/bindata.go
+++ b/pkg/manifests/bindata.go
@@ -946,11 +946,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/pkg/operator/controller/certificate/controller.go
+++ b/pkg/operator/controller/certificate/controller.go
@@ -1,8 +1,8 @@
-// The certificate controller is responsible for:
+// The certificate controller is responsible for the following:
 //
-//   1. Managing a CA for minting self-signed certs
-//   2. Managing self-signed certificates for any ingresscontrollers which require them
-//   3. Publishing the CA to `openshift-config-managed`
+//  1. Managing a CA for minting self-signed certs.
+//  2. Managing self-signed certificates for any ingresscontrollers which require them.
+//  3. Publishing the CA to the openshift-config-managed namespace.
 package certificate
 
 import (

--- a/pkg/util/aws/shared_credentials_file.go
+++ b/pkg/util/aws/shared_credentials_file.go
@@ -9,20 +9,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// SharedCredentialsFileFromSecret returns a location (path) to the shared credentials file that was created
-// using the provided secret.
-// Consumers can configure the aws Session using that file to use the credentials like,
+// SharedCredentialsFileFromSecret returns a location (path) to the shared
+// credentials file that was created using the provided secret.
 //
-// sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
-// if err != nil {
-// 	// handle error
-// }
-// options := session.Options{
-// 	SharedConfigState: session.SharedConfigEnable,
-// 	SharedConfigFiles: []string{sharedCredentialsFile},
-// }
-// sess := session.Must(session.NewSessionWithOptions(options))
+// Consumers can configure the aws Session using that file to use the
+// credentials as follows:
 //
+//	sharedCredentialsFile, err := SharedCredentialsFileFromSecret(secret)
+//	if err != nil {
+//		// handle error
+//	}
+//
+//	options := session.Options{
+//		SharedConfigState: session.SharedConfigEnable,
+//		SharedConfigFiles: []string{sharedCredentialsFile},
+//	}
+//	sess := session.Must(session.NewSessionWithOptions(options))
 func SharedCredentialsFileFromSecret(secret *corev1.Secret) (string, error) {
 	var data []byte
 	switch {

--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -88,13 +88,8 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 // TestTunableMaxConnectionsInvalidValues tests that invalid values
 // cannot be set for tuningOptions.maxConnections.
 //
-// Valid values are:
-//    0
-//   -1
-// 2000-2000000
-//
-// so we test outside of those value and expect validation failures
-// when we attempt to set them.
+// Valid values are 0, -1, and 2000-2000000, so we test outside of those value
+// and expect validation failures when we attempt to set them.
 func TestTunableMaxConnectionsInvalidValues(t *testing.T) {
 	t.Parallel()
 	updateMaxConnections := func(t *testing.T, client client.Client, maxConnections int32, name types.NamespacedName) error {


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/b44f15ec9e84d1831eac81f8c757b3bed985dbeb/images/ose-cluster-ingress-operator.yml

This PR is based on #802 but additionally includes changes to the formatting of `pkg/manifests/bindata.go` that result from using the updated Go 1.19 builder image, as well as formatting changes to several other files to appease gofmt.  Including these changes is necessary in order for the verify job to pass.