### PR TITLE
NE-975: Use ingress config to set default LB type on AWS

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -84,6 +84,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestDefaultIngressCertificate", TestDefaultIngressCertificate)
 		t.Run("TestDefaultIngressClass", TestDefaultIngressClass)
 		t.Run("TestOperatorRecreatesItsClusterOperator", TestOperatorRecreatesItsClusterOperator)
+		t.Run("TestAWSLBTypeDefaulting", TestAWSLBTypeDefaulting)
 		t.Run("TestHstsPolicyWorks", TestHstsPolicyWorks)
 		t.Run("TestIngressControllerCustomEndpoints", TestIngressControllerCustomEndpoints)
 		t.Run("TestIngressStatus", TestIngressStatus)


### PR DESCRIPTION
**Note:** Cloned from https://github.com/openshift/cluster-ingress-operator/pull/798 so that I could modify.

The cluster ingress config object can now specify the AWS ELB type that was specified when installing the cluster. The ingress operator will refer to this object whenever someone deletes the default ingresscontroller and the
operator has to recreate it. Before this commit, the operator would always set the default ELB type
(Classic ELB) when creating the default ingresscontroller. Fixes https://issues.redhat.com/browse/NE-975

- `pkg/operator/operator.go`: Check if infrastructure object was set with the LB type "NLB" and create the ingresscontroller accordingly.
- `pkg/operator/ingress/controller.go`: setDefaultPublishingStrategy refactoring. Introduce a new setDefaultPublishingStrategy function to simplify setDefaultPublishingStrategy, correct the defaulting behavior when status.endpointPublishingStrategy is nil.
- `pkg/operator/controller/ingress/controller_test.go`: Add some test cases to TestSetDefaultPublishingStrategySetsPlatformDefaults and
changes to TestSetDefaultPublishingStrategyHandlesUpdates.