### PR TITLE
OCPBUGS-2334: Added nil check for service object on load balancer scope change

### DIFF
--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -179,6 +179,9 @@ func computeIngressTLSProfile(oldProfile *configv1.TLSProfileSpec, deployment *a
 // by looking at the LoadBalancerSourceRanges field and service.beta.kubernetes.io/load-balancer-source-ranges
 // annotation of the LoadBalancer-typed Service. The field takes precedence over the annotation.
 func computeAllowedSourceRanges(service *corev1.Service) []operatorv1.CIDR {
+	if service == nil {
+		return nil
+	}
 	cidrs := []operatorv1.CIDR{}
 	if len(service.Spec.LoadBalancerSourceRanges) > 0 {
 		for _, r := range service.Spec.LoadBalancerSourceRanges {


### PR DESCRIPTION
Added nil check for service object which without causes the ingress operator to panic when using ingress.operator.openshift.io/auto-delete-load-balancer annotation and changing scope of loadbalancer from external to internal.

- `pkg/operator/controller/ingress/status.go`: Add nil check for `computeAllowedSourceRanges`
- `pkg/operator/controller/ingress/status_test.go`: Add unit test for `computeAllowedSourceRanges`