### PR TITLE
OCPBUGS-2435: TestRouterCompressionOperation: Nil-pointer fix

### DIFF
--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -254,7 +254,7 @@ func getHttpHeaders(client *http.Client, route *routev1.Route, addHeader bool) (
 
 	response, err := client.Do(request)
 	if err != nil {
-		return response.Header, response.StatusCode, fmt.Errorf("GET %s failed: %v", route.Spec.Host, err)
+		return nil, -1, fmt.Errorf("GET %s failed: %v", route.Spec.Host, err)
 	}
 	// Close response body
 	defer response.Body.Close()


### PR DESCRIPTION
Fix a nil-pointer dereference in the `getHttpHeaders` helper for `TestRouterCompressionOperation`.

Follow-up to #679.

* `test/e2e/router_compression_test.go` (`getHttpHeaders`): Don't dereference the response value from `client.Do` if it returned a non-nil error value.