### PR TITLE
CCO-249: Replace GCP role with explicit permissions

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -75,8 +75,12 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    predefinedRoles:
-    - roles/dns.admin
+    permissions:
+    - dns.changes.create
+    - dns.resourceRecordSets.create
+    - dns.resourceRecordSets.update
+    - dns.resourceRecordSets.delete
+    - dns.resourceRecordSets.list
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
Instead of using a predefined role in the cloud credentials request for GCP, enumerate permissions explicitly.

The Google Cloud DNS API permissions are documented here: <https://cloud.google.com/dns/docs/access-control>

Each method in the Cloud DNS API has a corresponding permission.  The operator's DNS provider implementation for GCP only calls two methods:

- `dns.changes.create`
- `dns.resourcerecordsets.list`

These methods require the following permissions:

- `dns.changes.create`
- `dns.resourceRecordSets.create`
- `dns.resourceRecordSets.update`
- `dns.resourceRecordSets.delete`
- `dns.resourceRecordSets.list`

This PR replaces the `dns.admin` role with these permissions in the credentials request.

* `manifests/00-ingress-credentials-request.yaml`: Replace the `roles/dns.admin` predefined role with an explicit list of permissions.