### PR TITLE
OCPBUGS-2247: Add explicit message to condition when domain doesn't match basedomain

### DIFF
--- a/pkg/operator/controller/ingress/dns.go
+++ b/pkg/operator/controller/ingress/dns.go
@@ -201,10 +201,15 @@ func dnsRecordChanged(current, expected *iov1.DNSRecord) (bool, *iov1.DNSRecord)
 
 // manageDNSForDomain returns true if the given domain contains the baseDomain
 // of the cluster DNS config. It is only used for AWS in the beginning, and will be expanded to other clouds
-// once we know there are no users depending on this.
+// once we know there are no users depending on this. Both PlatformStatus
+// and dnsConfig are required to be non-nil, failing which a false is returned.
 // See https://bugzilla.redhat.com/show_bug.cgi?id=2041616
 func manageDNSForDomain(domain string, status *configv1.PlatformStatus, dnsConfig *configv1.DNS) bool {
 	if len(domain) == 0 {
+		return false
+	}
+
+	if dnsConfig == nil || status == nil {
 		return false
 	}
 

--- a/pkg/operator/controller/ingress/dns_test.go
+++ b/pkg/operator/controller/ingress/dns_test.go
@@ -202,19 +202,37 @@ func TestManageDNSForDomain(t *testing.T) {
 			platformType: configv1.NonePlatformType,
 			expected:     true,
 		},
+		{
+			name:       "domain does not match because platform status is nil",
+			domain:     "apps.openshift.example.com",
+			baseDomain: "openshift.example.com",
+			expected:   false,
+		},
+		{
+			name:         "domain does not match because DNS config is nil",
+			domain:       "apps.openshift.example.com",
+			platformType: configv1.AWSPlatformType,
+			expected:     false,
+		},
 	}
 
 	for _, tc := range tests {
-		status := configv1.PlatformStatus{
-			Type: tc.platformType,
+		var status *configv1.PlatformStatus
+		if tc.platformType != "" {
+			status = &configv1.PlatformStatus{
+				Type: tc.platformType,
+			}
 		}
 
-		dnsConfig := configv1.DNS{
-			Spec: configv1.DNSSpec{
-				BaseDomain: tc.baseDomain,
-			},
+		var dnsConfig *configv1.DNS
+		if tc.baseDomain != "" {
+			dnsConfig = &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain: tc.baseDomain,
+				},
+			}
 		}
-		actual := manageDNSForDomain(tc.domain, &status, &dnsConfig)
+		actual := manageDNSForDomain(tc.domain, status, dnsConfig)
 		if actual != tc.expected {
 			t.Errorf("%q: expected to be %v, got %v", tc.name, tc.expected, actual)
 		}

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -979,7 +979,14 @@ func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNS
 		}
 	}
 	var conditions []operatorv1.OperatorCondition
-	if ic.Status.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy == operatorv1.UnmanagedLoadBalancerDNS {
+	if !manageDNSForDomain(ic.Status.Domain, status, dnsConfig) && ic.Status.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy == operatorv1.UnmanagedLoadBalancerDNS {
+		conditions = append(conditions, operatorv1.OperatorCondition{
+			Type:    operatorv1.DNSManagedIngressConditionType,
+			Status:  operatorv1.ConditionFalse,
+			Reason:  "DomainNotMatching",
+			Message: "DNS management is not supported for ingresscontrollers with domain not matching the baseDomain of the cluster DNS config.",
+		})
+	} else if ic.Status.EndpointPublishingStrategy.LoadBalancer.DNSManagementPolicy == operatorv1.UnmanagedLoadBalancerDNS {
 		conditions = append(conditions, operatorv1.OperatorCondition{
 			Type:    operatorv1.DNSManagedIngressConditionType,
 			Status:  operatorv1.ConditionFalse,

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1664,6 +1664,45 @@ func TestComputeDNSStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "DNSManaged is false due to DomainNotMatching because platformStatus is nil",
+			dnsConfig: &configv1.DNS{
+				Spec: configv1.DNSSpec{
+					BaseDomain:  "basedomain.com",
+					PublicZone:  &configv1.DNSZone{},
+					PrivateZone: &configv1.DNSZone{},
+				},
+			},
+			platformStatus: nil,
+			controller: &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					Domain: "apps.basedomain.com",
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
+						},
+					},
+				},
+			},
+			record: &iov1.DNSRecord{
+				Spec: iov1.DNSRecordSpec{
+					DNSManagementPolicy: iov1.UnmanagedDNS,
+				},
+			},
+			expect: []operatorv1.OperatorCondition{
+				{
+					Type:   "DNSManaged",
+					Status: operatorv1.ConditionFalse,
+					Reason: "DomainNotMatching",
+				},
+				{
+					Type:   "DNSReady",
+					Status: operatorv1.ConditionUnknown,
+					Reason: "UnmanagedDNS",
+				},
+			},
+		},
+		{
 			name: "DNSManaged true and DNSReady is true due to NoFailedZones",
 			controller: &operatorv1.IngressController{
 				Status: operatorv1.IngressControllerStatus{


### PR DESCRIPTION
### Description
Add additional reason to status to explain why `dnsManagementPolicy` was set to `Unmanaged` when domain of Ingress Controller doesn't match cluster base domain.

Currently, when a user creates an Ingress Controller with a custom domain (doesn't match cluster base domain) the `.spec.endpointPublishingStrategy.loadBalancer.dnsManagementPolicy` defaults to `Managed` whereas the operator correctly updates the `.status.endpointPublishingStrategy.loadBalancer.dnsManagementPolicy` to be `Unmanaged`. This result although odd is expected but may not be very clear to the end user. 

Adding a more specific reason to the existing condition `DNSManaged` when the domains are mismatched would be more clear to the end user.   