### PR TITLE
OCPBUGS-434: Absorb PodsScheduled condition into MinAvailable

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -50,7 +50,6 @@ const (
 // TODO: consider moving these to openshift/api
 const (
 	IngressControllerAdmittedConditionType                       = "Admitted"
-	IngressControllerPodsScheduledConditionType                  = "PodsScheduled"
 	IngressControllerDeploymentAvailableConditionType            = "DeploymentAvailable"
 	IngressControllerDeploymentReplicasMinAvailableConditionType = "DeploymentReplicasMinAvailable"
 	IngressControllerDeploymentReplicasAllAvailableConditionType = "DeploymentReplicasAllAvailable"

--- a/pkg/operator/controller/ingress/metrics_test.go
+++ b/pkg/operator/controller/ingress/metrics_test.go
@@ -77,7 +77,6 @@ func TestDeleteIngressControllerConditionsMetric(t *testing.T) {
 				{Type: "Available", Status: operatorv1.ConditionFalse},
 				{Type: "Degraded", Status: operatorv1.ConditionTrue},
 				{Type: "Admitted", Status: operatorv1.ConditionTrue},
-				{Type: "PodsScheduled", Status: operatorv1.ConditionTrue},
 			}),
 			expectedMetricFormat: `
             # HELP ingress_controller_conditions Report the conditions for ingress controllers. 0 is False and 1 is True.

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -208,6 +208,9 @@ func computeAllowedSourceRanges(service *corev1.Service) []operatorv1.CIDR {
 // PodsScheduled=True.  This function returns an error value indicating the
 // result of that check.
 func checkPodsScheduledForDeployment(deployment *appsv1.Deployment, pods []corev1.Pod) error {
+	if deployment == nil {
+		return errors.New("System error detected: deployment was nil.  Please report this issue to Red Hat: https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367900&priority=10300&customfield_12316142=26752")
+	}
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil || selector.Empty() {
 		return errors.New("Deployment has an invalid label selector.")

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -209,6 +209,12 @@ func Test_checkPodsScheduledForDeployment(t *testing.T) {
 		expectError bool
 	}{
 		{
+			name:        "nil deployment",
+			deployment:  nil,
+			pods:        []corev1.Pod{scheduledPod},
+			expectError: true,
+		},
+		{
 			name:        "no pods",
 			deployment:  deployment,
 			pods:        []corev1.Pod{unrelatedPod},


### PR DESCRIPTION
#### Absorb PodsScheduled condition into MinAvailable

Remove the `PodsScheduled` status condition on IngressController objects, and report the information that `PodsScheduled` reported instead in the `DeploymentReplicasMinAvailable` status condition's message when its status is "False".

Before this change, the `PodsScheduled` status condition could erroneously signal that there was a problem when some misscheduled pods existed even if there were enough correctly scheduled and available pods.

The `PodsScheduled` status condition was added in order to provide diagnostic information when there was a problem.  That is, `PodsScheduled` was intended to indicate *why* there was a problem, not *whether* there was a problem. The `DeploymentReplicasMinAvailable` status condition definitively indicates *whether* there is a problem, and its status message should indicate *why* there is a problem.  Having a separate status condition for the "why" is superfluous and unnecessarily complicated in this instance.

Follow-up to #465.

* `pkg/operator/controller/ingress/controller.go` (`IngressControllerPodsScheduledConditionType`): Delete const.
* `pkg/operator/controller/ingress/metrics_test.go` (`TestDeleteIngressControllerConditionsMetric`): Delete a reference to the "PodsScheduled" status condition in a test case.
* `pkg/operator/controller/ingress/status.go` (`syncIngressControllerStatus`): Delete the call to `computeDeploymentPodsScheduledCondition`.  Pass the list of pods to `computeDeploymentReplicasMinAvailableCondition`.
(`PruneConditions`): Delete pruning of the "DeploymentDegraded" status condition (which was removed in 4.6.0) and instead prune the "PodsScheduled" status condition.
(`computeDeploymentPodsScheduledCondition`): Rename...
(`checkPodsScheduledForDeployment`): ...to this.  Change the return value from an operator status condition to an error value.
(`computeDeploymentReplicasMinAvailableCondition`): Call `checkPodsScheduledForDeployment` and include the error string in the status condition's message if the function returns an error.
(`computeIngressDegradedCondition`): Remove `IngressControllerPodsScheduledConditionType` from the list of conditions to check.
* `pkg/operator/controller/ingress/status_test.go` (`TestComputePodsScheduledCondition`): Rename...
(`Test_checkPodsScheduledForDeployment`): ...to this.  Update for the function's new name and result value.
(`TestComputeIngressDegradedCondition`): Delete test cases for `PodsScheduled`.
(`TestComputeDeploymentReplicasMinAvailableCondition`): Update to set the deployment's label selector and pass in a list of pods (which is empty).

#### `checkPodsScheduledForDeployment`: Add nil check

`checkPodsScheduledForDeployment` takes a pointer to a deployment, which should never be nil, so return an error indicating that there is a bug if the deployment is somehow nil.

* `pkg/operator/controller/ingress/status.go` (`checkPodsScheduledForDeployment`): Check whether deployment is nil and return an error if it is.
* `pkg/operator/controller/ingress/status_test.go` (`Test_checkPodsScheduledForDeployment`): Add a "nil deployment" test case.


