### PR TITLE
OPNET-133: Support remote worker

### DIFF
--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -40,6 +40,10 @@ const (
 	// DefaultCanaryNamespace is the default namespace for
 	// the ingress canary check resources.
 	DefaultCanaryNamespace = "openshift-ingress-canary"
+
+	// Remote worker label, used for node affinity of router deployment.
+	// Router should not run on remote worker nodes
+	RemoteWorkerLabel = "node.openshift.io/remote-worker"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator


### PR DESCRIPTION
    Adding node affinity rule to router deployement that will not allow
    router to run on remote worker node (node with custom role label)