### PR TITLE
OCPBUGS-4054: configurable-route: Don't use NewKindWithCache

### DIFF
--- a/pkg/operator/controller/configurable-route/controller.go
+++ b/pkg/operator/controller/configurable-route/controller.go
@@ -86,11 +86,11 @@ func New(mgr manager.Manager, config Config, eventRecorder events.Recorder) (con
 		return ok
 	})
 
-	if err := c.Watch(source.NewKindWithCache(&rbacv1.Role{}, mgr.GetCache()), handler.EnqueueRequestsFromMapFunc(reconciler.resourceToClusterIngressConfig), defaultPredicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: &rbacv1.Role{}}, handler.EnqueueRequestsFromMapFunc(reconciler.resourceToClusterIngressConfig), defaultPredicate); err != nil {
 		return nil, err
 	}
 
-	if err := c.Watch(source.NewKindWithCache(&rbacv1.RoleBinding{}, mgr.GetCache()), handler.EnqueueRequestsFromMapFunc(reconciler.resourceToClusterIngressConfig), defaultPredicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: &rbacv1.RoleBinding{}}, handler.EnqueueRequestsFromMapFunc(reconciler.resourceToClusterIngressConfig), defaultPredicate); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Replace `source.NewKindWithCache(&foo{}, mgr.GetCache())` with `&source.Kind{Type: &foo{}}` in the configurable-route controller.

Using `source.NewKindWithCache()` is needlessly complicated since this controller uses the default cache anyway.  Moreover, using `source.NewKindWithCache()` causes controller-runtime's logging to be more noisy (see https://github.com/kubernetes-sigs/controller-runtime/pull/2057).  Before this PR, the operator emitted log messages like the following on startup:

    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "&{{%!s(*v1.Role=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] [] []} []}) %!s(*cache.multiNamespaceCache=&{map[openshift-config:0xc000712110 openshift-config-managed:0xc000712108 openshift-ingress:0xc0007120f8 openshift-ingress-canary:0xc000712100 openshift-ingress-operator:0xc0007120e8] 0xc000261ea0 0xc00010e190 0xc0007120e0}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "&{{%!s(*v1.RoleBinding=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] [] []} [] {  }}) %!s(*cache.multiNamespaceCache=&{map[openshift-config:0xc000712110 openshift-config-managed:0xc000712108 openshift-ingress:0xc0007120f8 openshift-ingress-canary:0xc000712100 openshift-ingress-operator:0xc0007120e8] 0xc000261ea0 0xc00010e190 0xc0007120e0}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting Controller     {"controller": "configurable_route_controller"}

With the change in this PR, the operator instead emits log messages like the following:

    2022-11-23T08:48:43.076-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "kind source: *v1.Role"}
    2022-11-23T08:48:43.078-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "kind source: *v1.RoleBinding"}
    2022-11-23T08:48:43.078-0600    INFO    operator.init   controller/controller.go:241    Starting Controller     {"controller": "configurable_route_controller"}

Follow-up to #552.

* `pkg/operator/controller/configurable-route/controller.go` (`New`): Replace `source.NewKindWithCache()` with `source.Kind{}`.