### PR TITLE
RFE-3360: add httpRequestTimeout to IngressController CRD

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -563,6 +563,9 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	if ci.Spec.TuningOptions.ClientTimeout != nil && ci.Spec.TuningOptions.ClientTimeout.Duration > 0*time.Second {
 		env = append(env, corev1.EnvVar{Name: "ROUTER_DEFAULT_CLIENT_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.ClientTimeout.Duration)})
 	}
+	if ci.Spec.TuningOptions.httpRequestTimeout != nil && ci.Spec.TuningOptions.ClientTimeout.Duration > 0*time.Second {
+		env = append(env, corev1.EnvVar{Name: "ROUTER_SLOWLORIS_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.httpRequestTimeout.Duration)})
+	}
 	if ci.Spec.TuningOptions.ClientFinTimeout != nil && ci.Spec.TuningOptions.ClientFinTimeout.Duration > 0*time.Second {
 		env = append(env, corev1.EnvVar{Name: "ROUTER_CLIENT_FIN_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.ClientFinTimeout.Duration)})
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -174,6 +174,7 @@ func TestTuningOptions(t *testing.T) {
 	// Verify tuning options
 	tests := []envData{
 		{"ROUTER_DEFAULT_CLIENT_TIMEOUT", true, "45s"},
+		{"ROUTER_SLOWLORIS_TIMEOUT", true, "10s"},
 		{"ROUTER_CLIENT_FIN_TIMEOUT", true, "3s"},
 		{"ROUTER_DEFAULT_SERVER_TIMEOUT", true, "1m"},
 		{"ROUTER_DEFAULT_SERVER_FIN_TIMEOUT", true, "4s"},
@@ -322,6 +323,7 @@ func TestDesiredRouterDeployment(t *testing.T) {
 		{"ROUTER_MAX_REWRITE_SIZE", false, ""},
 		{"ROUTER_SYSLOG_ADDRESS", false, ""},
 		{"ROUTER_SYSLOG_FORMAT", false, ""},
+		{"ROUTER_SLOWLORIS_TIMEOUT", false, ""},
 		{"ROUTER_TCP_BALANCE_SCHEME", true, "source"},
 		{"ROUTER_UNIQUE_ID_FORMAT", false, ""},
 		{"ROUTER_UNIQUE_ID_HEADER_NAME", false, ""},

--- a/test/e2e/haproxy_timeouts_test.go
+++ b/test/e2e/haproxy_timeouts_test.go
@@ -75,6 +75,10 @@ func TestHAProxyTimeouts(t *testing.T) {
 			if envVar.Value != clientTimeoutOutput {
 				t.Errorf("expected %s = %q, got %q", envVar.Name, clientTimeoutOutput, envVar.Value)
 			}
+		case "ROUTER_SLOWLORIS_TIMEOUT":
+			if envVar.Value != httpRequestTimeout {
+				t.Errorf("expected %s = %q, got %q", envVar.Name, clientTimeoutOutput, envVar.Value)
+			}
 		case "ROUTER_CLIENT_FIN_TIMEOUT":
 			if envVar.Value != clientFinTimeoutOutput {
 				t.Errorf("expected %s = %q, got %q", envVar.Name, clientFinTimeoutOutput, envVar.Value)
@@ -227,6 +231,7 @@ func TestHAProxyTimeoutsRejection(t *testing.T) {
 	for _, envVar := range deployment.Spec.Template.Spec.Containers[0].Env {
 		switch envVar.Name {
 		case "ROUTER_DEFAULT_CLIENT_TIMEOUT",
+			"ROUTER_SLOWLORIS_TIMEOUT",
 			"ROUTER_CLIENT_FIN_TIMEOUT",
 			"ROUTER_DEFAULT_SERVER_TIMEOUT",
 			"ROUTER_DEFAULT_SERVER_FIN_TIMEOUT",


### PR DESCRIPTION
This helps to better tune slowloris defensive actions. Setting this parameter was possible with the IngressController shipped with OCP3/Origin but we missed it somehow when the OCP4/OKD4 swithc took place.