### PR TITLE
OCPBUGS-3356: E2E test for cookie length truncation

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -37,6 +37,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestForwardedHeaderPolicyReplace", TestForwardedHeaderPolicyReplace)
 		t.Run("TestHAProxyTimeouts", TestHAProxyTimeouts)
 		t.Run("TestHAProxyTimeoutsRejection", TestHAProxyTimeoutsRejection)
+		t.Run("TestCookieLen", TestCookieLen)
 		t.Run("TestHTTPCookieCapture", TestHTTPCookieCapture)
 		t.Run("TestHTTPHeaderBufferSize", TestHTTPHeaderBufferSize)
 		t.Run("TestHTTPHeaderCapture", TestHTTPHeaderCapture)

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -1408,19 +1408,6 @@ func verifyCRLs(t *testing.T, pod *corev1.Pod, expectedCRLs map[string]*x509.Rev
 	return true, nil
 }
 
-func getPods(t *testing.T, cl client.Client, deployment *appsv1.Deployment) (*corev1.PodList, error) {
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	if err != nil {
-		return nil, fmt.Errorf("deployment %s has invalid spec.selector: %w", deployment.Name, err)
-	}
-	podList := &corev1.PodList{}
-	if err := cl.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		t.Logf("failed to list pods for deployment %q: %v", deployment.Name, err)
-		return nil, err
-	}
-	return podList, nil
-}
-
 func getActiveCRLs(t *testing.T, clientPod *corev1.Pod) ([]*x509.RevocationList, error) {
 	t.Helper()
 	cmd := []string{

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -352,6 +352,19 @@ func getDeployment(t *testing.T, client client.Client, name types.NamespacedName
 	return &dep, nil
 }
 
+func getPods(t *testing.T, cl client.Client, deployment *appsv1.Deployment) (*corev1.PodList, error) {
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("deployment %s has invalid spec.selector: %w", deployment.Name, err)
+	}
+	podList := &corev1.PodList{}
+	if err := cl.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		t.Logf("failed to list pods for deployment %q: %v", deployment.Name, err)
+		return nil, err
+	}
+	return podList, nil
+}
+
 func podExec(t *testing.T, pod corev1.Pod, stdout, stderr *bytes.Buffer, cmd []string) error {
 	t.Helper()
 	kubeConfig, err := config.GetConfig()


### PR DESCRIPTION
This PR adds a new test, `TestCookieLen`, which verifies that cookies in `spec.logging.access.httpCaptureCookies` are truncated to the specified max length.

This tests the fix in openshift/router#436