### PR TITLE
OCPBUGS-6698: Fix conflict error message in ensureNodePortService

### DIFF
--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -60,7 +60,7 @@ func (r *reconciler) ensureNodePortService(ic *operatorv1.IngressController, dep
 		return false, nil, nil
 	case !wantService && haveService:
 		if !ownLBS {
-			return false, nil, fmt.Errorf("a conflicting nodeport service exists that is not owned by the ingress controller: %s", controller.LoadBalancerServiceName(ic))
+			return false, nil, fmt.Errorf("a conflicting nodeport service exists that is not owned by the ingress controller: %s", current.Name)
 		}
 		if err := r.client.Delete(context.TODO(), current); err != nil {
 			if !errors.IsNotFound(err) {
@@ -78,7 +78,7 @@ func (r *reconciler) ensureNodePortService(ic *operatorv1.IngressController, dep
 		return r.currentNodePortService(ic)
 	case wantService && haveService:
 		if !ownLBS {
-			return false, nil, fmt.Errorf("a conflicting nodeport service exists that is not owned by the ingress controller: %s", controller.LoadBalancerServiceName(ic))
+			return false, nil, fmt.Errorf("a conflicting nodeport service exists that is not owned by the ingress controller: %s", current.Name)
 		}
 		if updated, err := r.updateNodePortService(current, desired); err != nil {
 			return true, current, fmt.Errorf("failed to update NodePort service: %v", err)


### PR DESCRIPTION
ensureNodePortService reports error with a loadbalancer-type service name, not a nodeport-type service name.

* pkg/operator/controller/ingress/nodeport_service.go
(ensureNodePortService): Report the correct name for a conflicting service.