### PR TITLE
OCPBUGS-6701: Avoid spurious updates for scope in IngressClass

### DIFF
--- a/pkg/operator/controller/ingressclass/ingressclass.go
+++ b/pkg/operator/controller/ingressclass/ingressclass.go
@@ -78,6 +78,7 @@ func desiredIngressClass(haveIngressController bool, ingressControllerName strin
 	}
 
 	name := controller.IngressClassName(ingressControllerName)
+	scope := networkingv1.IngressClassParametersReferenceScopeCluster
 	class := &networkingv1.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name.Name,
@@ -88,6 +89,7 @@ func desiredIngressClass(haveIngressController bool, ingressControllerName strin
 				APIGroup: &operatorv1.GroupName,
 				Kind:     "IngressController",
 				Name:     ingressControllerName,
+				Scope:    &scope,
 			},
 		},
 	}

--- a/pkg/operator/controller/ingressclass/ingressclass_test.go
+++ b/pkg/operator/controller/ingressclass/ingressclass_test.go
@@ -14,6 +14,7 @@ import (
 // TestDesiredIngressClass verifies that desiredIngressClass behaves as
 // expected.
 func TestDesiredIngressClass(t *testing.T) {
+	scope := "Cluster"
 	makeIngressClass := func(icName string, annotateAsDefault bool) *networkingv1.IngressClass {
 		apiGroup := "operator.openshift.io"
 		name := "openshift-" + icName
@@ -27,6 +28,7 @@ func TestDesiredIngressClass(t *testing.T) {
 					APIGroup: &apiGroup,
 					Kind:     "IngressController",
 					Name:     icName,
+					Scope:    &scope,
 				},
 			},
 		}


### PR DESCRIPTION
Specify spec.parameters.scope on ingressclasses that the operator creates.

Before this commit, the update logic would try to revert the default value that the API set for an ingressclass's scope field.

* pkg/operator/controller/ingressclass/ingressclass.go (desiredIngressClass): Specify spec.parameters.scope with the default value: "Cluster".
* pkg/operator/controller/ingressclass/ingressclass_test.go (Test_desiredIngressClass): Update test to expect spec.parameters.scope to be set.