### PR TITLE
NE-1183: Rename unit tests for specific functions

### DIFF
--- a/pkg/dns/alibaba/dns_test.go
+++ b/pkg/dns/alibaba/dns_test.go
@@ -56,7 +56,7 @@ func newFakeProvider(public, private Service) dns.Provider {
 	}
 }
 
-func TestGetRR(t *testing.T) {
+func Test_getRR(t *testing.T) {
 	cases := []struct {
 		dnsName    string
 		domainName string
@@ -90,7 +90,7 @@ func TestGetRR(t *testing.T) {
 	}
 }
 
-func TestParseZone(t *testing.T) {
+func Test_parseZone(t *testing.T) {
 	cases := []struct {
 		id       string
 		tags     map[string]string

--- a/pkg/dns/alibaba/util/numbers_test.go
+++ b/pkg/dns/alibaba/util/numbers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestClamp(t *testing.T) {
+func Test_Clamp(t *testing.T) {
 	cases := []struct {
 		val      int64
 		min      int64

--- a/pkg/dns/aws/dns_test.go
+++ b/pkg/dns/aws/dns_test.go
@@ -10,7 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-func TestZoneMatchesTags(t *testing.T) {
+func Test_zoneMatchesTags(t *testing.T) {
 	cases := []struct {
 		name        string
 		tagsForZone map[string]string
@@ -90,7 +90,7 @@ func TestZoneMatchesTags(t *testing.T) {
 	}
 }
 
-func TestZoneIDFromResource(t *testing.T) {
+func Test_zoneIDFromResource(t *testing.T) {
 	cases := []struct {
 		resource       string
 		expectedZoneID string

--- a/pkg/dns/azure/dns_test.go
+++ b/pkg/dns/azure/dns_test.go
@@ -24,7 +24,7 @@ func fakeManager(fc *client.FakeDNSClient) (dns.Provider, error) {
 	return mgr, nil
 }
 
-func TestEnsureDNS(t *testing.T) {
+func Test_Ensure(t *testing.T) {
 	c := client.Config{}
 	fc, _ := client.NewFake(c)
 	mgr, err := fakeManager(fc)
@@ -58,7 +58,7 @@ func TestEnsureDNS(t *testing.T) {
 	}
 }
 
-func TestDeleteDNS(t *testing.T) {
+func Test_Delete(t *testing.T) {
 	c := client.Config{}
 	fc, err := client.NewFake(c)
 	if err != nil {

--- a/pkg/dns/gcp/provider_test.go
+++ b/pkg/dns/gcp/provider_test.go
@@ -10,7 +10,7 @@ var (
 	DefaultProject = "defaultProject"
 )
 
-func TestParseZone(t *testing.T) {
+func Test_ParseZone(t *testing.T) {
 	cases := []struct {
 		name         string
 		providedZone string

--- a/pkg/dns/ibm/private/dnssvcs_provider_test.go
+++ b/pkg/dns/ibm/private/dnssvcs_provider_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDelete(t *testing.T) {
+func Test_Delete(t *testing.T) {
 	zone := configv1.DNSZone{
 		ID: "zoneID",
 	}
@@ -156,7 +156,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func TestCreateOrUpdate(t *testing.T) {
+func Test_createOrUpdateDNSRecord(t *testing.T) {
 	zone := configv1.DNSZone{
 		ID: "zoneID",
 	}

--- a/pkg/dns/ibm/public/cis_provider_test.go
+++ b/pkg/dns/ibm/public/cis_provider_test.go
@@ -13,7 +13,7 @@ import (
 	dnsclient "github.com/openshift/cluster-ingress-operator/pkg/dns/ibm/public/client"
 )
 
-func TestDelete(t *testing.T) {
+func Test_Delete(t *testing.T) {
 	zone := configv1.DNSZone{
 		ID: "zoneID",
 	}
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func TestCreateOrUpdate(t *testing.T) {
+func Test_createOrUpdateDNSRecord(t *testing.T) {
 	zone := configv1.DNSZone{
 		ID: "zoneID",
 	}

--- a/pkg/operator/controller/canary/controller_test.go
+++ b/pkg/operator/controller/canary/controller_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestCycleServicePort(t *testing.T) {
+func Test_cycleServicePort(t *testing.T) {
 	tPort1 := intstr.IntOrString{
 		StrVal: "80",
 	}

--- a/pkg/operator/controller/canary/daemonset_test.go
+++ b/pkg/operator/controller/canary/daemonset_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestDesiredCanaryDaemonSet(t *testing.T) {
+func Test_desiredCanaryDaemonSet(t *testing.T) {
 	// canaryImageName is the ingress-operator image
 	canaryImageName := "openshift/origin-cluster-ingress-operator:latest"
 	daemonset := desiredCanaryDaemonSet(canaryImageName)
@@ -86,7 +86,7 @@ func TestDesiredCanaryDaemonSet(t *testing.T) {
 	}
 }
 
-func TestCanaryDaemonsetChanged(t *testing.T) {
+func Test_canaryDaemonsetChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*appsv1.DaemonSet)

--- a/pkg/operator/controller/canary/namespace_test.go
+++ b/pkg/operator/controller/canary/namespace_test.go
@@ -10,7 +10,7 @@ import (
 	projectv1 "github.com/openshift/api/project/v1"
 )
 
-func TestCanaryNamespaceChanged(t *testing.T) {
+func Test_canaryNamespaceChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*corev1.Namespace)

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestDesiredCanaryRoute(t *testing.T) {
+func Test_desiredCanaryRoute(t *testing.T) {
 	daemonsetRef := metav1.OwnerReference{
 		Name: "test",
 	}
@@ -85,7 +85,7 @@ func TestDesiredCanaryRoute(t *testing.T) {
 	}
 }
 
-func TestCanaryRouteChanged(t *testing.T) {
+func Test_canaryRouteChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*routev1.Route)

--- a/pkg/operator/controller/canary/service_test.go
+++ b/pkg/operator/controller/canary/service_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestDesiredCanaryService(t *testing.T) {
+func Test_desiredCanaryService(t *testing.T) {
 	daemonsetRef := metav1.OwnerReference{
 		Name: "test",
 	}

--- a/pkg/operator/controller/certificate-publisher/publish_certs_test.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs_test.go
@@ -52,10 +52,10 @@ func newIngressController(name, defaultCertificateSecretName, domain string, adm
 	return ingresscontroller
 }
 
-// TestDesiredRouterCertsGlobalSecret verifies that we get the expected global
+// Test_desiredRouterCertsGlobalSecret verifies that we get the expected global
 // secret for the default ingresscontroller and for various combinations of
 // ingresscontrollers and default certificate secrets.
-func TestDesiredRouterCertsGlobalSecret(t *testing.T) {
+func Test_desiredRouterCertsGlobalSecret(t *testing.T) {
 	type testInputs struct {
 		ingresses []operatorv1.IngressController
 		secrets   []corev1.Secret

--- a/pkg/operator/controller/certificate/default_cert_test.go
+++ b/pkg/operator/controller/certificate/default_cert_test.go
@@ -52,7 +52,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 `
 )
 
-func TestDesiredRouterDefaultCertificateSecret(t *testing.T) {
+func Test_desiredRouterDefaultCertificateSecret(t *testing.T) {
 	ca, err := crypto.GetCAFromBytes([]byte(cert), []byte(key))
 	if err != nil {
 		t.Fatalf("failed to create CA")

--- a/pkg/operator/controller/dns/controller_test.go
+++ b/pkg/operator/controller/dns/controller_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestPublishRecordToZones(t *testing.T) {
+func Test_publishRecordToZones(t *testing.T) {
 	tests := []struct {
 		name         string
 		zones        []configv1.DNSZone
@@ -225,7 +225,7 @@ func TestPublishRecordToZonesMergesStatus(t *testing.T) {
 	}
 }
 
-func TestMigrateDNSRecordStatus(t *testing.T) {
+func Test_migrateRecordStatusConditions(t *testing.T) {
 	tests := []struct {
 		name       string
 		conditions []iov1.DNSZoneCondition
@@ -366,7 +366,7 @@ func TestMigrateDNSRecordStatus(t *testing.T) {
 	}
 }
 
-func TestDnsZoneStatusSlicesEqual(t *testing.T) {
+func Test_dnsZoneStatusSlicesEqual(t *testing.T) {
 	testCases := []struct {
 		description string
 		expected    bool
@@ -622,7 +622,7 @@ func TestDnsZoneStatusSlicesEqual(t *testing.T) {
 	}
 }
 
-func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
+func Test_recordIsAlreadyPublishedToZone(t *testing.T) {
 	var (
 		zoneWithId  = configv1.DNSZone{ID: "foo"}
 		zoneWithTag = configv1.DNSZone{Tags: map[string]string{"foo": "bar"}}
@@ -777,7 +777,7 @@ func TestRecordIsAlreadyPublishedToZone(t *testing.T) {
 	}
 }
 
-func TestCustomCABundle(t *testing.T) {
+func Test_customCABundle(t *testing.T) {
 	cases := []struct {
 		name             string
 		cm               *corev1.ConfigMap

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -14,8 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestSetDefaultDomain verifies that setDefaultDomain behaves correctly.
-func TestSetDefaultDomain(t *testing.T) {
+// Test_setDefaultDomain verifies that setDefaultDomain behaves correctly.
+func Test_setDefaultDomain(t *testing.T) {
 	ingressConfig := &configv1.Ingress{
 		Spec: configv1.IngressSpec{
 			Domain: "apps.mycluster.com",
@@ -855,7 +855,7 @@ func TestSetDefaultPublishingStrategyHandlesUpdates(t *testing.T) {
 	}
 }
 
-func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
+func Test_tlsProfileSpecForSecurityProfile(t *testing.T) {
 	invalidTLSVersion := configv1.TLSProtocolVersion("abc")
 	invalidCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384", "invalid cipher"}
 	validCiphers := []string{"ECDHE-ECDSA-AES256-GCM-SHA384"}
@@ -1017,7 +1017,7 @@ func TestTLSProfileSpecForSecurityProfile(t *testing.T) {
 	}
 }
 
-func TestTLSProfileSpecForIngressController(t *testing.T) {
+func Test_tlsProfileSpecForIngressController(t *testing.T) {
 	testCases := []struct {
 		description  string
 		icProfile    *configv1.TLSSecurityProfile
@@ -1161,7 +1161,7 @@ func TestTLSProfileSpecForIngressController(t *testing.T) {
 	}
 }
 
-func TestValidateHTTPHeaderBufferValues(t *testing.T) {
+func Test_validateHTTPHeaderBufferValues(t *testing.T) {
 	testCases := []struct {
 		description   string
 		tuningOptions operatorv1.IngressControllerTuningOptions
@@ -1220,7 +1220,7 @@ func TestValidateHTTPHeaderBufferValues(t *testing.T) {
 
 // TestValidateClientTLS verifies the validateClientTLS accepts PCRE-compliant
 // patterns and rejects invalid patterns.
-func TestValidateClientTLS(t *testing.T) {
+func Test_validateClientTLS(t *testing.T) {
 	testCases := []struct {
 		description string
 		pattern     string
@@ -1265,10 +1265,10 @@ func TestValidateClientTLS(t *testing.T) {
 	}
 }
 
-// TestIsProxyProtocolNeeded verifies that IsProxyProtocolNeeded returns the
+// Test_IsProxyProtocolNeeded verifies that IsProxyProtocolNeeded returns the
 // expected values for various platforms and endpoint publishing strategy
 // parameters.
-func TestIsProxyProtocolNeeded(t *testing.T) {
+func Test_IsProxyProtocolNeeded(t *testing.T) {
 	var (
 		awsPlatform = configv1.PlatformStatus{
 			Type: configv1.AWSPlatformType,

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -311,7 +311,7 @@ func getRouterDeploymentComponents(t *testing.T) (*operatorv1.IngressController,
 	return ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig
 }
 
-func TestDesiredRouterDeployment(t *testing.T) {
+func Test_desiredRouterDeployment(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
 	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
@@ -897,7 +897,7 @@ func checkContainerPort(t *testing.T, d *appsv1.Deployment, portName string, por
 	t.Errorf("deployment %s container does not have port with name %s and number %d", d.Name, portName, port)
 }
 
-func TestInferTLSProfileSpecFromDeployment(t *testing.T) {
+func Test_inferTLSProfileSpecFromDeployment(t *testing.T) {
 	testCases := []struct {
 		description string
 		containers  []corev1.Container
@@ -1107,7 +1107,7 @@ func TestDeploymentHash(t *testing.T) {
 	}
 }
 
-func TestDeploymentConfigChanged(t *testing.T) {
+func Test_deploymentConfigChanged(t *testing.T) {
 	pointerTo := func(ios intstr.IntOrString) *intstr.IntOrString { return &ios }
 	testCases := []struct {
 		description string
@@ -1749,7 +1749,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 	}
 }
 
-func TestDurationToHAProxyTimespec(t *testing.T) {
+func Test_durationToHAProxyTimespec(t *testing.T) {
 	testCases := []struct {
 		inputDuration  time.Duration
 		expectedOutput string
@@ -1795,7 +1795,7 @@ func TestDurationToHAProxyTimespec(t *testing.T) {
 	}
 }
 
-func TestCapReloadIntervalValue(t *testing.T) {
+func Test_capReloadIntervalValue(t *testing.T) {
 	testCases := []struct {
 		inputDuration  time.Duration
 		expectedOutput time.Duration
@@ -1828,7 +1828,7 @@ func TestCapReloadIntervalValue(t *testing.T) {
 	}
 }
 
-func TestGetMIMETypes(t *testing.T) {
+func Test_GetMIMETypes(t *testing.T) {
 	testCases := []struct {
 		mimeArrayInput []operatorv1.CompressionMIMEType
 		expectedOutput string

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func TestDesiredLoadBalancerService(t *testing.T) {
+func Test_desiredLoadBalancerService(t *testing.T) {
 	testCases := []struct {
 		description          string
 		platform             configv1.PlatformType
@@ -649,9 +649,9 @@ func checkServiceHasAnnotation(svc *corev1.Service, name string, expectValue boo
 	}
 }
 
-// TestShouldUseLocalWithFallback verifies that shouldUseLocalWithFallback
+// Test_shouldUseLocalWithFallback verifies that shouldUseLocalWithFallback
 // behaves as expected.
-func TestShouldUseLocalWithFallback(t *testing.T) {
+func Test_shouldUseLocalWithFallback(t *testing.T) {
 	testCases := []struct {
 		description string
 		local       bool
@@ -715,7 +715,7 @@ func TestShouldUseLocalWithFallback(t *testing.T) {
 	}
 }
 
-func TestLoadBalancerServiceChanged(t *testing.T) {
+func Test_loadBalancerServiceChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*corev1.Service)
@@ -920,9 +920,9 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 	}
 }
 
-// TestLoadBalancerServiceAnnotationsChanged verifies that
+// Test_loadBalancerServiceAnnotationsChanged verifies that
 // loadBalancerServiceAnnotationsChanged behaves correctly.
-func TestLoadBalancerServiceAnnotationsChanged(t *testing.T) {
+func Test_loadBalancerServiceAnnotationsChanged(t *testing.T) {
 	testCases := []struct {
 		description         string
 		mutate              func(*corev1.Service)
@@ -1018,7 +1018,7 @@ func TestLoadBalancerServiceAnnotationsChanged(t *testing.T) {
 	}
 }
 
-func TestServiceIngressOwner(t *testing.T) {
+func Test_isServiceOwnedByIngressController(t *testing.T) {
 	testCases := []struct {
 		description string
 		service     *corev1.Service

--- a/pkg/operator/controller/ingress/metrics_test.go
+++ b/pkg/operator/controller/ingress/metrics_test.go
@@ -14,7 +14,7 @@ type metricValue struct {
 	value  float64
 }
 
-func TestDeleteIngressControllerConditionsMetric(t *testing.T) {
+func Test_DeleteIngressControllerConditionsMetric(t *testing.T) {
 
 	testCases := []struct {
 		name                 string
@@ -139,7 +139,7 @@ func TestDeleteIngressControllerConditionsMetric(t *testing.T) {
 	}
 }
 
-func TestIngressControllerNLBMetric(t *testing.T) {
+func Test_SetIngressControllerNLBMetric(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		inputIngress         *operatorv1.IngressController

--- a/pkg/operator/controller/ingress/monitoring_test.go
+++ b/pkg/operator/controller/ingress/monitoring_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestServiceMonitorChanged(t *testing.T) {
+func Test_serviceMonitorChanged(t *testing.T) {
 	trueVar := true
 	ic := &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controller/ingress/namespace_test.go
+++ b/pkg/operator/controller/ingress/namespace_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestRouterNamespaceChanged(t *testing.T) {
+func Test_routerNamespaceChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*corev1.Namespace)

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestDesiredNodePortService(t *testing.T) {
+func Test_desiredNodePortService(t *testing.T) {
 	trueVar := true
 	internalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyCluster
 	deploymentRef := metav1.OwnerReference{
@@ -148,7 +148,7 @@ func TestDesiredNodePortService(t *testing.T) {
 	}
 }
 
-func TestNodePortServiceChanged(t *testing.T) {
+func Test_nodePortServiceChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*corev1.Service)

--- a/pkg/operator/controller/ingress/poddisruptionbudget_test.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestDesiredPodDisruptionBudget(t *testing.T) {
+func Test_desiredRouterPodDisruptionBudget(t *testing.T) {
 	pointerTo := func(v_ int) *int32 { v := int32(v_); return &v }
 	testCases := []struct {
 		description          string
@@ -88,7 +88,7 @@ func TestDesiredPodDisruptionBudget(t *testing.T) {
 	}
 }
 
-func TestPodDisruptionBudgetChange(t *testing.T) {
+func Test_podDisruptionBudgetChange(t *testing.T) {
 	two := int32(2)
 	three := int32(3)
 	trueVar := true

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -257,7 +257,7 @@ func Test_checkPodsScheduledForDeployment(t *testing.T) {
 	}
 }
 
-func TestComputeIngressDegradedCondition(t *testing.T) {
+func Test_computeIngressDegradedCondition(t *testing.T) {
 	// Inject a fake clock and don't forget to reset it
 	fakeClock := utilclocktesting.NewFakeClock(time.Time{})
 	clock = fakeClock
@@ -490,9 +490,9 @@ func TestComputeIngressDegradedCondition(t *testing.T) {
 	}
 }
 
-// TestComputeDeploymentRollingOutCondition verifies that
+// Test_computeDeploymentRollingOutCondition verifies that
 // computeDeploymentRollingOutCondition returns the expected status condition.
-func TestComputeDeploymentRollingOutCondition(t *testing.T) {
+func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 	tests := []struct {
 		name                  string
 		replicasWanted        *int32
@@ -596,9 +596,9 @@ func TestComputeDeploymentRollingOutCondition(t *testing.T) {
 	}
 }
 
-// TestComputeLoadBalancerProgressingStatus verifies that
+// Test_computeLoadBalancerProgressingStatus verifies that
 // computeLoadBalancerProgressingStatus returns the expected status condition.
-func TestComputeLoadBalancerProgressingStatus(t *testing.T) {
+func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 	hostNetworkIngressController := operatorv1.IngressController{
 		Status: operatorv1.IngressControllerStatus{
 			EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
@@ -812,7 +812,7 @@ func TestComputeLoadBalancerProgressingStatus(t *testing.T) {
 	}
 }
 
-func TestComputeDeploymentAvailableCondition(t *testing.T) {
+func Test_computeDeploymentAvailableCondition(t *testing.T) {
 	tests := []struct {
 		name                            string
 		deploymentConditions            []appsv1.DeploymentCondition
@@ -859,7 +859,7 @@ func TestComputeDeploymentAvailableCondition(t *testing.T) {
 	}
 }
 
-func TestComputeDeploymentReplicasMinAvailableCondition(t *testing.T) {
+func Test_computeDeploymentReplicasMinAvailableCondition(t *testing.T) {
 	pointerToInt32 := func(i int32) *int32 { return &i }
 	pointerToIntVal := func(val intstr.IntOrString) *intstr.IntOrString { return &val }
 	tests := []struct {
@@ -1072,7 +1072,7 @@ func TestComputeDeploymentReplicasMinAvailableCondition(t *testing.T) {
 	}
 }
 
-func TestComputeDeploymentReplicasAllAvailableCondition(t *testing.T) {
+func Test_computeDeploymentReplicasAllAvailableCondition(t *testing.T) {
 	pointerTo := func(i int32) *int32 { return &i }
 	tests := []struct {
 		name                                       string
@@ -1129,7 +1129,7 @@ func TestComputeDeploymentReplicasAllAvailableCondition(t *testing.T) {
 	}
 }
 
-func TestComputeLoadBalancerStatus(t *testing.T) {
+func Test_computeLoadBalancerStatus(t *testing.T) {
 	tests := []struct {
 		name       string
 		controller *operatorv1.IngressController
@@ -1207,9 +1207,9 @@ func TestComputeLoadBalancerStatus(t *testing.T) {
 	}
 }
 
-// TestComputeIngressProgressingCondition verifies that
+// Test_computeIngressProgressingCondition verifies that
 // computeIngressProgressingCondition returns the expected status condition.
-func TestComputeIngressProgressingCondition(t *testing.T) {
+func Test_computeIngressProgressingCondition(t *testing.T) {
 	testCases := []struct {
 		description string
 		conditions  []operatorv1.OperatorCondition
@@ -1331,7 +1331,7 @@ func TestComputeIngressProgressingCondition(t *testing.T) {
 	}
 }
 
-func TestComputeIngressAvailableCondition(t *testing.T) {
+func Test_computeIngressAvailableCondition(t *testing.T) {
 	testCases := []struct {
 		description string
 		conditions  []operatorv1.OperatorCondition
@@ -1411,7 +1411,7 @@ func TestComputeIngressAvailableCondition(t *testing.T) {
 	}
 }
 
-func TestIngressStatusesEqual(t *testing.T) {
+func Test_ingressStatusesEqual(t *testing.T) {
 	testCases := []struct {
 		description string
 		expected    bool
@@ -1531,7 +1531,7 @@ func TestIngressStatusesEqual(t *testing.T) {
 	}
 }
 
-func TestComputeDNSStatus(t *testing.T) {
+func Test_computeDNSStatus(t *testing.T) {
 	tests := []struct {
 		name           string
 		controller     *operatorv1.IngressController
@@ -2044,7 +2044,7 @@ func TestComputeDNSStatus(t *testing.T) {
 	}
 }
 
-func TestMergeConditions(t *testing.T) {
+func Test_MergeConditions(t *testing.T) {
 	// Inject a fake clock and don't forget to reset it
 	fakeClock := utilclocktesting.NewFakeClock(time.Time{})
 	clock = fakeClock
@@ -2094,7 +2094,7 @@ func TestMergeConditions(t *testing.T) {
 	}
 }
 
-func TestZoneInConfig(t *testing.T) {
+func Test_checkZoneInConfig(t *testing.T) {
 	var z *configv1.DNSZone
 	var dnsZone configv1.DNSZone
 	tag := make(map[string]string)
@@ -2184,7 +2184,7 @@ func TestZoneInConfig(t *testing.T) {
 	}
 }
 
-func TestComputeIngressUpgradeableCondition(t *testing.T) {
+func Test_computeIngressUpgradeableCondition(t *testing.T) {
 	makeDefaultCertificateSecret := func(cn string, sans []string) *corev1.Secret {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
@@ -2321,7 +2321,7 @@ func TestComputeIngressUpgradeableCondition(t *testing.T) {
 	}
 }
 
-func TestComputeIngressEvaluationConditionsDetectedCondition(t *testing.T) {
+func Test_computeIngressEvaluationConditionsDetectedCondition(t *testing.T) {
 	const (
 		ingressDomain = "apps.foo.com"
 	)

--- a/pkg/operator/controller/ingressclass/ingressclass_test.go
+++ b/pkg/operator/controller/ingressclass/ingressclass_test.go
@@ -11,9 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestDesiredIngressClass verifies that desiredIngressClass behaves as
+// Test_desiredIngressClass verifies that desiredIngressClass behaves as
 // expected.
-func TestDesiredIngressClass(t *testing.T) {
+func Test_desiredIngressClass(t *testing.T) {
 	scope := "Cluster"
 	makeIngressClass := func(icName string, annotateAsDefault bool) *networkingv1.IngressClass {
 		apiGroup := "operator.openshift.io"
@@ -122,9 +122,9 @@ func TestDesiredIngressClass(t *testing.T) {
 	}
 }
 
-// TestIngressClassChanged verifies that ingressClassChanged behaves as
+// Test_ingressClassChanged verifies that ingressClassChanged behaves as
 // expected.
-func TestIngressClassChanged(t *testing.T) {
+func Test_ingressClassChanged(t *testing.T) {
 	testCases := []struct {
 		description string
 		mutate      func(*networkingv1.IngressClass)

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestComputeOperatorProgressingCondition(t *testing.T) {
+func Test_computeOperatorProgressingCondition(t *testing.T) {
 	type versions struct {
 		operator, operand1, operand2 string
 	}
@@ -167,7 +167,7 @@ func TestComputeOperatorProgressingCondition(t *testing.T) {
 	}
 }
 
-func TestOperatorStatusesEqual(t *testing.T) {
+func Test_operatorStatusesEqual(t *testing.T) {
 	testCases := []struct {
 		description string
 		expected    bool
@@ -399,7 +399,7 @@ func TestOperatorStatusesEqual(t *testing.T) {
 	}
 }
 
-func TestComputeOperatorStatusVersions(t *testing.T) {
+func Test_computeOperatorStatusVersions(t *testing.T) {
 	type versions struct {
 		operator string
 		operand1 string
@@ -527,7 +527,7 @@ func TestComputeOperatorStatusVersions(t *testing.T) {
 	}
 }
 
-func TestComputeOperatorUpgradeableCondition(t *testing.T) {
+func Test_computeOperatorUpgradeableCondition(t *testing.T) {
 	testCases := []struct {
 		description                   string
 		ingresscontrollersUpgradeable []bool

--- a/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
@@ -50,9 +50,9 @@ func newConfigMap(name, namespace string, flag string) corev1.ConfigMap {
 	}
 }
 
-// TestDesiredHttpErrorCodeConfigMap verifies that
+// Test_desiredHttpErrorCodeConfigMap verifies that
 // desiredHttpErrorCodeConfigMap returns the expected configmap.
-func TestDesiredHttpErrorCodeConfigMap(t *testing.T) {
+func Test_desiredHttpErrorCodeConfigMap(t *testing.T) {
 	type testInputs struct {
 		configmap corev1.ConfigMap
 	}

--- a/pkg/resources/dnsrecord/dns_test.go
+++ b/pkg/resources/dnsrecord/dns_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestDesiredWildcardDNSRecord(t *testing.T) {
+func Test_desiredWildcardDNSRecord(t *testing.T) {
 	tests := []struct {
 		description string
 		domain      string
@@ -159,7 +159,7 @@ func TestDesiredWildcardDNSRecord(t *testing.T) {
 	}
 }
 
-func TestManageDNSForDomain(t *testing.T) {
+func Test_manageDNSForDomain(t *testing.T) {
 	tests := []struct {
 		name         string
 		domain       string

--- a/pkg/util/aws/shared_credentials_file_test.go
+++ b/pkg/util/aws/shared_credentials_file_test.go
@@ -38,7 +38,7 @@ aws_secret_access_key = som@th'n#g+/
 	}
 }
 
-func TestSharedCredentialsFileFromSecret(t *testing.T) {
+func Test_SharedCredentialsFileFromSecret(t *testing.T) {
 	cases := []struct {
 		data map[string]string
 

--- a/pkg/util/hash_test.go
+++ b/pkg/util/hash_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestHash(t *testing.T) {
+func Test_Hash(t *testing.T) {
 	if Hash("foo") != Hash("foo") {
 		t.Errorf("Hash function result should be reproducible")
 	}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 )
 
-// URI validates uri as being a valid http(s) uri and returns the uri scheme.
-func TestURI(t *testing.T) {
+// Test_URI verifies that URI correctly validates uri as being a valid http(s)
+// uri and returns the uri scheme.
+func Test_URI(t *testing.T) {
 	testCases := []struct {
 		description string
 		uri, scheme string


### PR DESCRIPTION
For each unit test "TestFoo" that specifically tests a function name "Foo"
or "foo", rename "TestFoo" to "Test_Foo" or "Test_foo", respectively.

* pkg/dns/alibaba/dns_test.go (TestGetRR): Rename from this...
(Test_getRR): ...to this.
(TestParseZone): Rename from this...
(Test_parseZone): ...to this.
* pkg/dns/alibaba/util/numbers_test.go (TestClamp): Rename from this...
(Test_Clamp): ...to this.
* pkg/dns/aws/dns_test.go (TestZoneMatchesTags): Rename from this...
(Test_zoneMatchesTags): ...to this.
(TestZoneIDFromResource): Rename from this...
(Test_zoneIDFromResource): ...to this.
* pkg/dns/azure/dns_test.go (TestEnsureDNS): Rename from this...
(Test_Ensure): ...to this.
(TestDeleteDNS): Rename from this...
(Test_Delete): ...to this.
* pkg/dns/ibm/private/dnssvcs_provider_test.go (TestDelete): Rename from
this...
(Test_Delete): ...to this.
(TestCreateOrUpdate): Rename from this...
(Test_createOrUpdateDNSRecord): ...to this.
* pkg/dns/ibm/public/cis_provider_test.go (TestDelete): Rename from this...
(Test_Delete): ...to this.
(TestCreateOrUpdate): Rename from this...
(Test_createOrUpdateDNSRecord): ...to this.
* pkg/operator/controller/canary/controller_test.go
(TestCycleServicePort): Rename from this...
(Test_cycleServicePort): ...to this.
* pkg/operator/controller/canary/daemonset_test.go
(TestDesiredCanaryService): Rename from this...
(Test_desiredCanaryService): ...to this.
* pkg/operator/controller/canary/namespace_test.go
(TestCanaryNamespaceChanged): Rename from this...
(Test_canaryNamespaceChanged): ...to this.
* pkg/operator/controller/canary/route_test.go (TestDesiredCanaryRoute):
Rename from this...
(Test_desiredCanaryRoute): ...to this.
(TestCanaryRouteChanged): Rename from this...
(Test_canaryRouteChanged): ...to this.
* pkg/operator/controller/canary/service_test.go
(TestDesiredCanaryService): Rename from this...
(Test_desiredCanaryService): ...to this.
* pkg/operator/controller/certificate-publisher/publish_certs_test.go
(TestDesiredRouterCertsGlobalSecret): Rename from this...
(Test_desiredRouterCertsGlobalSecret): ...to this.
* pkg/operator/controller/certificate/default_cert_test.go
(TestDesiredRouterDefaultCertificateSecret): Rename from this...
(Test_desiredRouterDefaultCertificateSecret): ...to this.
* pkg/operator/controller/dns/controller_test.go
(TestPublishRecordToZones): Rename from this...
(Test_publishRecordToZones): ...to this.
(TestMigrateDNSRecordStatus): Rename from this...
(Test_migrateRecordStatusConditions): ...to this.
(TestDnsZoneStatusSlicesEqual): Rename from this...
(Test_dnsZoneStatusSlicesEqual): ...to this.
(TestRecordIsAlreadyPublishedToZone): Rename from this...
(Test_recordIsAlreadyPublishedToZone): ...to this.
(TestCustomCABundle): Rename from this...
(Test_customCABundle): ...to this.
* pkg/operator/controller/ingress/controller_test.go
(TestSetDefaultDomain): Rename from this...
(Test_setDefaultDomain): ...to this.
(TestTLSProfileSpecForSecurityProfile): Rename from this...
(Test_tlsProfileSpecForSecurityProfile): ...to this.
(TestTLSProfileSpecForIngressController): Rename from this...
(Test_tlsProfileSpecForIngressController): ...to this.
(TestValidateHTTPHeaderBufferValues): Rename from this...
(Test_validateHTTPHeaderBufferValues): ...to this.
(TestValidateClientTLS): Rename from this...
(Test_validateClientTLS): ...to this.
(TestIsProxyProtocolNeeded): Rename from this...
(Test_IsProxyProtocolNeeded): ...to this.
* pkg/operator/controller/ingress/deployment_test.go
(TestDesiredRouterDeployment): Rename from this...
(Test_desiredRouterDeployment): ...to this.
(TestInferTLSProfileSpecFromDeployment): Rename from this...
(Test_inferTLSProfileSpecFromDeployment): ...to this.
(TestDeploymentConfigChanged): Rename from this...
(Test_deploymentConfigChanged): ...to this.
(TestDurationToHAProxyTimespec): Rename from this...
(Test_durationToHAProxyTimespec): ...to this.
(TestCapReloadIntervalValue): Rename from this...
(Test_capReloadIntervalValue): ...to this.
(TestGetMIMETypes): Rename from this...
(Test_GetMIMETypes): ...to this.
* pkg/operator/controller/ingress/dns_test.go
(TestDesiredWildcardDNSRecord): Rename from this...
(Test_desiredWildcardDNSRecord): ...to this.
(TestManageDNSForDomain): Rename from this...
(Test_manageDNSForDomain): ...to this.
* pkg/operator/controller/ingress/load_balancer_service_test.go
(TestDesiredLoadBalancerService): Rename from this...
(Test_desiredLoadBalancerService): ... to this.
(TestShouldUseLocalWithFallback): Rename from this...
(Test_shouldUseLocalWithFallback): ...to this.
(TestLoadBalancerServiceChanged): Rename from this...
(Test_loadBalancerServiceChanged): ...to this.
(TestLoadBalancerServiceAnnotationsChanged): Rename from this...
(Test_loadBalancerServiceAnnotationsChanged): ...to this.
(TestServiceIngressOwner): Rename from this...
(Test_isServiceOwnedByIngressController): ... to this.
* pkg/operator/controller/ingress/metrics_test.go
(TestDeleteIngressControllerConditionsMetric): Rename from this...
(Test_DeleteIngressControllerConditionsMetric): ...to this.
(TestIngressControllerNLBMetric): Rename from this...
(Test_SetIngressControllerNLBMetric): ...to this.
* pkg/operator/controller/ingress/monitoring_test.go
(TestServiceMonitorChanged): Rename from this...
(Test_serviceMonitorChanged): ...to this.
* pkg/operator/controller/ingress/namespace_test.go
(TestRouterNamespaceChanged): Rename from this...
(Test_routerNamespaceChanged): ...to this.
* pkg/operator/controller/ingress/nodeport_service_test.go
(TestDesiredNodePortService): Rename from this...
(Test_desiredNodePortService): ...to this.
(TestNodePortServiceChanged): Rename from this...
(Test_nodePortServiceChanged): ...to this.
* pkg/operator/controller/ingress/poddisruptionbudget_test.go
(TestDesiredPodDisruptionBudget): Rename from this...
(Test_desiredRouterPodDisruptionBudget): ...to this.
(TestPodDisruptionBudgetChange): Rename from this...
(Test_podDisruptionBudgetChange): ...to this.
* pkg/operator/controller/ingress/status_test.go
(TestComputePodsScheduledCondition): Rename from this...
(Test_computeDeploymentPodsScheduledCondition): ...to this.
(TestComputeIngressDegradedCondition): Rename from this...
(Test_computeIngressDegradedCondition): ...to this.
(TestComputeDeploymentRollingOutCondition): Rename from this...
(Test_computeDeploymentRollingOutCondition): ...to this.
(TestComputeLoadBalancerProgressingStatus): Rename from this...
(Test_computeLoadBalancerProgressingStatus): ...to this.
(TestComputeDeploymentAvailableCondition): Rename from this...
(Test_computeDeploymentAvailableCondition): ...to this.
(TestComputeDeploymentReplicasMinAvailableCondition): Rename from this...
(Test_computeDeploymentReplicasMinAvailableCondition): ...to this.
(TestComputeDeploymentReplicasAllAvailableCondition): Rename from this...
(Test_computeDeploymentReplicasAllAvailableCondition): ...to this.
(TestComputeLoadBalancerStatus): Rename from this...
(Test_computeLoadBalancerStatus): ...to this.
(TestComputeIngressProgressingCondition): Rename from this...
(Test_computeIngressProgressingCondition): ...to this.
(TestComputeIngressAvailableCondition): Rename from this...
(Test_computeIngressAvailableCondition): ...to this.
(TestIngressStatusesEqual): Rename from this...
(Test_ingressStatusesEqual): ...to this.
(TestComputeDNSStatus): Rename from this...
(Test_computeDNSStatus): ...to this.
(TestMergeConditions): Rename from this...
(Test_MergeConditions): ...to this.
(TestZoneInConfig): Rename from this...
(Test_checkZoneInConfig): ...to this.
(TestComputeIngressUpgradeableCondition): Rename from this...
(Test_computeIngressUpgradeableCondition): ...to this.
(TestComputeIngressEvaluationConditionsDetectedCondition): Rename from
this...
(Test_computeIngressEvaluationConditionsDetectedCondition): ...to this.
* pkg/operator/controller/ingressclass/ingressclass_test.go
(TestDesiredIngressClass): Rename from this...
(Test_desiredIngressClass): ...to this.
(TestIngressClassChanged): Rename from this...
(Test_ingressClassChanged): ...to this.
* pkg/operator/controller/status/controller_test.go
(TestComputeOperatorProgressingCondition): Rename from this...
(Test_computeOperatorProgressingCondition): ...to this.
(TestOperatorStatusesEqual): Rename from this...
(Test_operatorStatusesEqual): ...to this.
(TestComputeOperatorStatusVersions): Rename from this...
(Test_computeOperatorStatusVersions): ...to this.
(TestComputeOperatorUpgradeableCondition): Rename from this...
(Test_computeOperatorUpgradeableCondition): ...to this.
* pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
(TestDesiredHttpErrorCodeConfigMap): Rename from this...
(Test_desiredHttpErrorCodeConfigMap): ...to this.
* pkg/util/aws/shared_credentials_file_test.go
(TestSharedCredentialsFileFromSecret): Rename from this...
(Test_SharedCredentialsFileFromSecret): ...to this.
* pkg/util/hash_test.go (TestHash): Rename from this...
(Test_Hash): ...to this.
* pkg/util/network_test.go (TestURI): Rename from this...
(Test_URI): ...to this.
* pkg/dns/gcp/provider_test.go: (TestParseZone): Rename from this...
(Test_ParseZone): ...to this.