### PR TITLE
NE-1184: Test_desiredHttpErrorCodeConfigMap: Kill dead code and fix format

### DIFF
--- a/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
@@ -147,15 +147,5 @@ func TestDesiredHttpErrorCodeConfigMap(t *testing.T) {
 		if !reflect.DeepEqual(expected.Data, actual.Data) {
 			t.Errorf("expected #{expected} and actual #{actual} configmap don't match")
 		}
-
-		if expected == nil || actual == nil {
-			if expected != nil {
-				t.Errorf("%q: expected %v, got nil", tc.description, expected)
-			}
-			if actual != nil {
-				t.Errorf("%q: expected nil, got %v", tc.description, actual)
-			}
-			continue
-		}
 	}
 }

--- a/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
@@ -145,7 +145,7 @@ func TestDesiredHttpErrorCodeConfigMap(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(expected.Data, actual.Data) {
-			t.Errorf("expected #{expected} and actual #{actual} configmap don't match")
+			t.Errorf("expected configmap and actual configmap don't match\nexpected:\n%v\nactual:\n%v", expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Test_desiredHttpErrorCodeConfigMap: Kill dead code

* pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
(Test_desiredHttpErrorCodeConfigMap): Delete some dead code.

[NE-1185](https://issues.redhat.com//browse/NE-1185): Test_desiredHttpErrorCodeConfigMap: Fix format
    
* pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
    (Test_desiredHttpErrorCodeConfigMap): Replace Ruby-style #{} syntax for
    string interpolation with Go string formats.
