### PR TITLE
NE-1185: Test_desiredHttpErrorCodeConfigMap: Fix format

### DIFF
--- a/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/controller_test.go
@@ -145,7 +145,7 @@ func TestDesiredHttpErrorCodeConfigMap(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(expected.Data, actual.Data) {
-			t.Errorf("expected #{expected} and actual #{actual} configmap don't match")
+			t.Errorf("expected configmap and actual configmap don't match\nexpected:\n%v\nactual:\n%v", expected, actual)
 		}
 
 		if expected == nil || actual == nil {


### PR DESCRIPTION
Test_desiredHttpErrorCodeConfigMap: Fix format

* pkg/operator/controller/sync-http-error-code-configmap/controller_test.go (Test_desiredHttpErrorCodeConfigMap): Replace Ruby-style #{} syntax for string interpolation with Go string formats.