### PR TITLE
NE-1188: Test_desiredLoadBalancerService: Delete extra case

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -64,13 +64,6 @@ func TestDesiredLoadBalancerService(t *testing.T) {
 			expectedResourceTags: "classic-load-balancer-key-with-value=100,classic-load-balancer-key-with-empty-value=",
 		},
 		{
-			description:  "external classic load balancer without scope for aws platform",
-			platform:     configv1.AWSPlatformType,
-			strategyType: operatorv1.LoadBalancerServiceStrategyType,
-			proxyNeeded:  true,
-			expect:       true,
-		},
-		{
 			description:  "external classic load balancer without LoadBalancerStrategy for aws platform",
 			platform:     configv1.AWSPlatformType,
 			strategyType: operatorv1.LoadBalancerServiceStrategyType,


### PR DESCRIPTION
Test_desiredLoadBalancerService: Delete extra case

* pkg/operator/controller/ingress/load_balancer_service_test.go (Test_desiredLoadBalancerService): Delete an extra test case: "external classic load balancer without scope for aws platform" is a duplicate of "external classic load balancer without LoadBalancerStrategy for aws platform".