### PR TITLE
NE-1276: Expose other DCM controls as unsupportedConfigOverrides in ingresscontroller CR

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -26,7 +26,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestCustomErrorpages", TestCustomErrorpages)
 		t.Run("TestCustomIngressClass", TestCustomIngressClass)
 		t.Run("TestDomainNotMatchingBase", TestDomainNotMatchingBase)
-		t.Run("TestDynamicConfigManagerUnsupportedConfigOverride", TestDynamicConfigManagerUnsupportedConfigOverride)
+		t.Run("TestUnsupportedConfigOverride", TestUnsupportedConfigOverride)
 		t.Run("TestForwardedHeaderPolicyAppend", TestForwardedHeaderPolicyAppend)
 		t.Run("TestForwardedHeaderPolicyIfNone", TestForwardedHeaderPolicyIfNone)
 		t.Run("TestForwardedHeaderPolicyNever", TestForwardedHeaderPolicyNever)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2955,48 +2955,71 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 	}
 }
 
-// TestDynamicConfigManagerUnsupportedConfigOverride verifies that the operator
-// configures router pod replicas to use the dynamic config manager if the
-// ingresscontroller is so configured using an unsupported config override.
-func TestDynamicConfigManagerUnsupportedConfigOverride(t *testing.T) {
+// TestUnsupportedConfigOverride verifies that the operator
+// configures router pod replicas to use the:
+// - dynamic config manager
+// - commitInterval
+// - blueprintRouteNamespace
+// - blueprintRouteLabels
+// - blueprintRoutePoolSize
+// - blueprintMaxDynamicServers
+// if the ingresscontroller is so configured using an unsupported config override.
+func TestUnsupportedConfigOverride(t *testing.T) {
 	t.Parallel()
-	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "dynamic-config-manager"}
-	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
-	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
-		t.Fatalf("failed to create ingresscontroller: %v", err)
-	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
 
-	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
-		t.Errorf("failed to observe expected conditions: %v", err)
-	}
-
-	deployment := &appsv1.Deployment{}
-	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "ROUTER_HAPROXY_CONFIG_MANAGER", ""); err != nil {
-		t.Fatalf("expected initial deployment not to set ROUTER_HAPROXY_CONFIG_MANAGER=true: %v", err)
+	var tests = []struct {
+		name, unsupportedConfigOverrideName, unsupportedConfigOverrideValue, env string
+	}{
+		{"dynamic-config-manager", "dynamicConfigManager", "true", "ROUTER_HAPROXY_CONFIG_MANAGER"},
+		{"commit-interval", "commitInterval", "5s", "COMMIT_INTERVAL"},
+		{"blueprint-route-namespace", "blueprintRouteNamespace", "foo", "ROUTER_BLUEPRINT_ROUTE_NAMESPACE"},
+		{"blueprint-route-labels", "blueprintRouteLabels", "foo=bar", "ROUTER_BLUEPRINT_ROUTE_LABELS"},
+		{"blueprint-root-pool-size", "blueprintRoutePoolSize", "5", "ROUTER_BLUEPRINT_ROUTE_POOL_SIZE"},
+		{"max-dynamic-servers", "maxDynamicServers", "5", "ROUTER_MAX_DYNAMIC_SERVERS"},
 	}
 
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
-	ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-		Raw: []byte(`{"dynamicConfigManager":"true"}`),
-	}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
-		t.Fatalf("failed to update ingresscontroller: %v", err)
-	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_HAPROXY_CONFIG_MANAGER", "true"); err != nil {
-		t.Fatalf("expected updated deployment to set ROUTER_HAPROXY_CONFIG_MANAGER=true: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icName := types.NamespacedName{Namespace: operatorNamespace, Name: tt.name}
+			domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
+			ic := newPrivateController(icName, domain)
+			if err := kclient.Create(context.TODO(), ic); err != nil {
+				t.Fatalf("failed to create ingresscontroller: %v", err)
+			}
+			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
+
+			if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
+				t.Errorf("failed to observe expected conditions: %v", err)
+			}
+
+			deployment := &appsv1.Deployment{}
+			if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
+				t.Fatalf("failed to get ingresscontroller deployment: %v", err)
+			}
+			if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, tt.env, ""); err != nil {
+				t.Fatalf("expected initial deployment not to set %s=true: %v", tt.env, err)
+			}
+
+			if err := kclient.Get(context.TODO(), icName, ic); err != nil {
+				t.Fatalf("failed to get ingresscontroller: %v", err)
+			}
+			ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(`{"%s":"%s"}`, tt.unsupportedConfigOverrideName, tt.unsupportedConfigOverrideValue)),
+			}
+			if err := kclient.Update(context.TODO(), ic); err != nil {
+				t.Fatalf("failed to update ingresscontroller: %v", err)
+			}
+			if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, tt.env, tt.unsupportedConfigOverrideValue); err != nil {
+				t.Fatalf("expected updated deployment to set %s=true: %v", tt.env, err)
+			}
+		})
+
 	}
 }
 
 // TestLocalWithFallbackOverrideForLoadBalancerService verifies that the
 // operator does not set the local-with-fallback annotation on a LoadBalancer
-// service if the the localWithFallback unsupported config override is set to
+// service if the localWithFallback unsupported config override is set to
 // "false".
 //
 // Note: This test mutates the default ingresscontroller rather than creating a


### PR DESCRIPTION


Signed-off-by: kwall <kwall@apache.org>