### PR TITLE
OCPBUGS-10846: Fix TestClientTLS flakes

### DIFF
--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -349,8 +349,8 @@ func TestClientTLS(t *testing.T) {
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_MUTUAL_TLS_AUTH", "required"); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_MUTUAL_TLS_AUTH=required: %v", err)
 	}
-	if err := waitForDeploymentComplete(t, kclient, deployment, 3*time.Minute); err != nil {
-		t.Fatalf("failed to observe expected conditions: %v", err)
+	if err := waitForDeploymentCompleteWithCleanup(t, kclient, deploymentName, 3*time.Minute); err != nil {
+		t.Fatalf("timed out waiting for old router generation to be cleaned up: %v", err)
 	}
 
 	requiredPolicyTestCases := []struct {

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -349,7 +349,7 @@ func TestClientTLS(t *testing.T) {
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_MUTUAL_TLS_AUTH", "required"); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_MUTUAL_TLS_AUTH=required: %v", err)
 	}
-	if err := waitForDeploymentCompleteWithCleanup(t, kclient, deploymentName, 3*time.Minute); err != nil {
+	if err := waitForDeploymentCompleteWithOldPodTermination(t, kclient, deploymentName, 3*time.Minute); err != nil {
 		t.Fatalf("timed out waiting for old router generation to be cleaned up: %v", err)
 	}
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3579,6 +3579,36 @@ func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.
 	return err
 }
 
+// waitForDeploymentCompleteWithCleanup waits for a deployment to complete its rollout, then waits for the old
+// generation's pods to finish terminating.
+func waitForDeploymentCompleteWithCleanup(t *testing.T, cl client.Client, deploymentName types.NamespacedName, timeout time.Duration) error {
+	t.Helper()
+	deployment := &appsv1.Deployment{}
+	if err := cl.Get(context.TODO(), deploymentName, deployment); err != nil {
+		return fmt.Errorf("failed to get deployment %s: %w", deploymentName.Name, err)
+	}
+
+	if deployment.Generation != deployment.Status.ObservedGeneration {
+		if err := waitForDeploymentComplete(t, cl, deployment, timeout); err != nil {
+			return fmt.Errorf("timed out waiting for deployment %s to complete rollout: %w", deploymentName.Name, err)
+		}
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("deployment %s has invalid spec.selector: %w", deploymentName.Name, err)
+	}
+
+	return wait.PollImmediate(2*time.Second, timeout, func() (bool, error) {
+		pods := &corev1.PodList{}
+		if err := cl.List(context.TODO(), pods, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			t.Logf("failed to list pods for deployment %q: %v", deploymentName.Name, err)
+			return false, nil
+		}
+		return len(pods.Items) == int(*deployment.Spec.Replicas), nil
+	})
+}
+
 func clusterOperatorConditionMap(conditions ...configv1.ClusterOperatorStatusCondition) map[string]string {
 	conds := map[string]string{}
 	for _, cond := range conditions {


### PR DESCRIPTION
Wait for old router pods to be cleaned up before testing new mTLS config.

After updating the ingresscontroller configuration, the router deployment reports when all new pods are ready, but sometimes the pods from the older generation still haven't terminated. If those older generation pods are still marked ready when `TestClientTLS` curls an endpoint, sometimes the connections are handled by the older generation router, and that test case will fail.

This PR makes the test wait until the older generation pod(s) are completely terminated before running curl, ensuring that only the correct router pods are used.