### PR TITLE
OCPBUGS-12790: Replace Bugzilla link with Red Hat Issue Tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
-- name: File a Bugzilla report
-  url: https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Networking&sub_component=router
-  about: Please use Bugzilla to report issues.
+- name: File a bug report
+  url: https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367900&priority=10300&customfield_12316142=26752
+  about: Please use the Red Hat Issue Tracker to report bugs.
 - name: Ingress Operator in OpenShift Container Platform
   url: https://docs.openshift.com/container-platform/latest/networking/ingress-operator.html
   about: Refer to the OpenShift Container Platform documentation for information about the Ingress Operator in OpenShift Container Platform.

--- a/OWNERS
+++ b/OWNERS
@@ -1,33 +1,26 @@
 approvers:
-  - ironcladlou
   - knobunc
-  - pravisankar
-  - ramr
   - Miciah
   - frobware
-  - danehans
-  - sgreene570
   - candita
   - rfredette
   - alebedev87
-  - lmzuccarelli
   - miheer
   - gcs278
-  - Ethany-RH
 reviewers:
-  - ironcladlou
   - knobunc
-  - pravisankar
-  - ramr
   - Miciah
   - frobware
-  - danehans
-  - sgreene570
   - candita
   - rfredette
   - alebedev87
-  - lmzuccarelli
   - miheer 
   - gcs278
+emeritus_approvers:
+  - ironcladlou
+  - pravisankar
+  - ramr
+  - danehans
+  - sgreene570
+  - lmzuccarelli
   - Ethany-RH
-component: Routing


### PR DESCRIPTION
* `.github/ISSUE_TEMPLATE/config.yml`: Update the Bugzilla link to point instead to the Red Hat Issue Tracker.
* `OWNERS`: Remove the `component` field.  Add past approvers to `emeritus_approvers` and remove them from the `approvers` and `reviewers` lists.