### PR TITLE
OCPBUGS-13106: Add ingress controller status logging on waitForIngressControllerCondition

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -3714,6 +3715,13 @@ func waitForIngressControllerCondition(t *testing.T, cl client.Client, timeout t
 	})
 	if err != nil {
 		t.Errorf("Expected conditions: %v\n Current conditions: %v", expected, current)
+		if ic != nil {
+			if icStatusPretty, err := json.MarshalIndent(ic.Status, "", "  "); err != nil {
+				t.Fatal(err)
+			} else {
+				t.Logf("Ingress Controller %s/%s status: %s\n", ic.Namespace, ic.Name, string(icStatusPretty))
+			}
+		}
 	}
 	return err
 }


### PR DESCRIPTION
This will help **debug** flakes in which `waitForIngressControllerCondition` fails, but there is no logging of status condition reasons or messages which would help with debugging.

`test/e2e/operator_test.go`: Add ingress controller status logging on `waitForIngressControllerCondition`

For OCPBUGS-13106, TestInternalLoadBalancer* and TestScopeChange GCP CI flakes, it fails because `DNSReady:False` and `LoadBalancerReady:False` are false, but doesn't provide additional information presented in the Ingress Controller Status conditions. 

This is also a general improvement that would help with future failures of `waitForIngressControllerCondition`