### PR TITLE
NE-1244: Use permissions instead of the "Contributor" role in Azure CredentialsRequest

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -49,8 +49,11 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
+    permissions:
+    - Microsoft.Network/dnsZones/A/delete
+    - Microsoft.Network/dnsZones/A/write
+    - Microsoft.Network/privateDnsZones/A/delete
+    - Microsoft.Network/privateDnsZones/A/write
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
Instead of requesting the "Contributor" role, request the individual permissions that the operator requires in order to manage DNS records on Azure.

* `manifests/00-ingress-credentials-request.yaml`: Replace the "Contributor" role with a list of permissions.

---

Notes for reviewers:  Per discussions on [NE-1244](https://issues.redhat.com//browse/NE-1244), this PR restricts the CredentialsRequest for Azure to a specific set of permissions.  Because of the way the e2e-azure-operator job is configured, this job doesn't actually use the precise rules or permissions that are listed in the CredentialsRequest, but the e2e-azure-manual-oidc job that was added by https://github.com/openshift/release/pull/41502 does.  