### PR TITLE
OCPBUGS-7546: Allow only 1 disruption with 3 replicas

### DIFF
--- a/pkg/operator/controller/ingress/poddisruptionbudget.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget.go
@@ -69,7 +69,8 @@ func desiredRouterPodDisruptionBudget(ic *operatorv1.IngressController, deployme
 	}
 
 	maxUnavailable := "50%"
-	if ic.Spec.Replicas != nil && int(*ic.Spec.Replicas) >= 4 {
+	// OCPBUGS-7546 - make sure number of available pods is always 2 when there are only 3 replicas.
+	if ic.Spec.Replicas != nil && int(*ic.Spec.Replicas) >= 3 {
 		maxUnavailable = "25%"
 	}
 

--- a/pkg/operator/controller/ingress/poddisruptionbudget_test.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget_test.go
@@ -36,10 +36,10 @@ func TestDesiredPodDisruptionBudget(t *testing.T) {
 			expectMaxUnavailable: intstr.FromString("50%"),
 		},
 		{
-			description:          "if replicas is 3, PDB should be 50%",
+			description:          "if replicas is 3, PDB should be 25%",
 			replicas:             pointerTo(3),
 			expectPDB:            true,
-			expectMaxUnavailable: intstr.FromString("50%"),
+			expectMaxUnavailable: intstr.FromString("25%"),
 		},
 		{
 			description:          "if replicas is 4, PDB should be 25%",
@@ -84,6 +84,69 @@ func TestDesiredPodDisruptionBudget(t *testing.T) {
 			t.Errorf("%q: expected PDB with non-nil MaxUnavailable, got %#v", tc.description, pdb)
 		} else if *pdb.Spec.MaxUnavailable != tc.expectMaxUnavailable {
 			t.Errorf("%q: expected %#v, got %#v", tc.description, tc.expectMaxUnavailable, pdb.Spec.MaxUnavailable)
+		}
+	}
+}
+
+func TestPodDisruptionBudgetChange(t *testing.T) {
+	two := int32(2)
+	three := int32(3)
+	trueVar := true
+
+	testCases := []struct {
+		description string
+		mutate      func(ic *operatorv1.IngressController)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *operatorv1.IngressController) {},
+			expect:      false,
+		},
+		{
+			description: "if replicas changes from 2 to 3",
+			mutate: func(ic *operatorv1.IngressController) {
+				ic.Spec.Replicas = &three
+			},
+			expect: true,
+		},
+	}
+
+	// Set up the original ingress controller with 2 replicas
+	ic := &operatorv1.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: operatorv1.IngressControllerSpec{
+			Replicas: &two,
+		},
+	}
+	deploymentRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "router-default",
+		UID:        "1",
+		Controller: &trueVar,
+	}
+	// Get the original pdb based on the ingress controller and deployment
+	_, originalPdb, err := desiredRouterPodDisruptionBudget(ic, deploymentRef)
+	if err != nil {
+		t.Errorf("expected setup to succeed, but there was a failure: %v", err)
+	}
+
+	for _, tc := range testCases {
+		// Change the ingress controller and check the resulting pdb
+		tc.mutate(ic)
+		_, mutatedPdb, err := desiredRouterPodDisruptionBudget(ic, deploymentRef)
+		if err != nil {
+			t.Errorf("expected setup to succeed, but there was a failure: %v", err)
+		}
+		if changed, updatedPdb := podDisruptionBudgetChanged(originalPdb, mutatedPdb); changed != tc.expect {
+			t.Errorf("%s, expect podDisruptionBudgetChanged to be %t, got %t", tc.description, tc.expect, changed)
+		} else if changed {
+			if changedAgain, _ := podDisruptionBudgetChanged(mutatedPdb, updatedPdb); changedAgain {
+				t.Errorf("%s, podDisruptionBudgetChanged does not behave as a fixed point function", tc.description)
+			}
 		}
 	}
 }


### PR DESCRIPTION
We currently set maxUnavailable as a 50% percentage for replica count < 4, and in the pod disruption budget, Kubernetes rounds up the number of Pods that may be disrupted.   With 3 pods if you set maxUnavailable to "50%", it means 2 pods may be disrupted.  We currently set it to 25% for replica count >= 4, and this changes it for replica count >= 3.

Update the test.

[Git history for PDB](https://github.com/openshift/cluster-ingress-operator/commits/master/pkg/operator/controller/ingress/poddisruptionbudget.go) shows that we went back and forth on how low to set this because some teams would want to use very small clusters and didn't care about high availability. "Pod disruption budgets cause problems for people who want to run small clusters or drain all workers at once"  

Hopefully fulfilling this request is a good compromise between ensuring high availability and allowing small clusters.