### PR TITLE
NE-1277: status: Add Gateway API objects to relatedObjects

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -212,6 +212,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		IngressControllerImage: config.IngressControllerImage,
 		CanaryImage:            config.CanaryImage,
 		OperatorReleaseVersion: config.OperatorReleaseVersion,
+		GatewayAPIEnabled:      gatewayAPIEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create status controller: %v", err)
 	}

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -366,27 +366,27 @@ func ensureGatewayObjectCreation(ns *corev1.Namespace) error {
 // ensureGatewayObjectSuccess tests that gateway class, gateway, and http route objects were accepted as valid,
 // and that a curl to the application via the http route returns with a valid response.
 func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
-	t.Helper()
 	errs := []string{}
 	gateway := &gatewayapiv1.Gateway{}
 
-	// Make sure gateway class was created successfully.
+	t.Log("Making sure the gatewayclass is created and accepted...")
 	_, err := assertGatewayClassSuccessful(t, operatorcontroller.OpenShiftDefaultGatewayClassName)
 	if err != nil {
 		errs = append(errs, error.Error(err))
 	}
 
-	// Make sure gateway was created successfully.
+	t.Log("Making sure the gateway is created and accepted...")
 	gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, testGatewayName)
 	if err != nil {
 		errs = append(errs, error.Error(err))
 	}
 
+	t.Log("Making sure the httproute is created and accepted...")
 	_, err = assertHttpRouteSuccessful(t, ns.Name, "test-httproute", gateway)
 	if err != nil {
 		errs = append(errs, error.Error(err))
 	} else {
-		// Validate the connectivity to the backend app via http route.
+		t.Log("Validating the connectivity to the backend application via the httproute...")
 		err = assertHttpRouteConnection(t, defaultRoutename, gateway)
 		if err != nil {
 			errs = append(errs, error.Error(err))


### PR DESCRIPTION
* `pkg/operator/controller/names.go` (`GlobalOperatorsNamespace`): New const for the "openshift-operators" namespace.
(`ServiceMeshSubscriptionName`): Use `GlobalOperatorsNamespace`.
* `pkg/operator/controller/status/controller.go` (`New`): Add a watch for subscriptions so that the status controller updates `relatedObjects` when the OSSM subscription is added or removed.
(`Config`): Add `GatewayAPIEnabled` field.
(`Reconcile`): If `GatewayAPIEnabled` is true, add resources related to Gateway API to `relatedObjects`.  If `haveOSSMSubscription` is true, add resources that require the subscription.
(`operatorState`): Add `haveOSSMSubscription` field.
(`getOperatorState`): Set `haveOSSMSubscription`.
* `pkg/operator/operator.go` (`New`): Watch the "openshift-operators" namespace, and specify `GatewayAPIEnabled` in the status controller's config.