### PR TITLE
Stop propagating proxy env to router pod

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -17,8 +17,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/operator-framework/operator-lib/proxy"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
@@ -1040,12 +1038,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		mimes := GetMIMETypes(ci.Spec.HTTPCompression.MimeTypes)
 		env = append(env, corev1.EnvVar{Name: RouterCompressionMIMETypes, Value: strings.Join(mimes, " ")})
 	}
-
-	proxyVars := proxy.ReadProxyVarsFromEnv()
-	if len(proxyVars) != 0 {
-		env = append(env, proxyVars...)
-	}
-
+	
 	// Add the environment variables to the container
 	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, env...)
 


### PR DESCRIPTION
This was merged in https://github.com/openshift/cluster-ingress-operator/pull/930. In hypershift the operator pod runs in a different cluster than the router pod, and so they might have different proxy configs. We set ootb proxy settings for the operator to go through konnectivity. I think because this got introduced in this PR https://github.com/openshift/cluster-ingress-operator/pull/930/files\#diff-03760f03eeac1174e38e1ec5fecadcab4cb38d05e00509f201d7ae64dc1c7c36R1044-R1048 now those proxy settings are being propagated down to the router pod and so breaking hypershift.

See an example on how we diferenciate in the cluster network operator https://github.com/openshift/hypershift/blob/f03113aec2545aa08f85ab0e2fa0a790f709aacb/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go\#L341-L347

https://github.com/openshift/cluster-network-operator/blob/7df32ec5213e2abfcff18cd22a63e7f20a5cccdc/pkg/network/cloud_network.go\#L98