### PR TITLE
OCPBUGS-13810: Update TestAWSELBConnectionIdleTimeout to not use wildcard DNS record

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2642,10 +2642,17 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 		t.Fatalf("expected %s=%s, found %s=%s", key, expected, key, v)
 	}
 
-	// Make sure we can resolve the route's host name.  It may take some
-	// time for the ingresscontroller's wildcard DNS record to propagate.
+	// Get the ELB's hostname via the wildcard DNS record
+	wildcardRecordName := controller.WildcardDNSRecordName(ic)
+	wildcardRecord := &iov1.DNSRecord{}
+	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
+	}
+	elbHostname := wildcardRecord.Spec.Targets[0]
+
+	// Wait until we can resolve the ELB's hostname
 	if err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := net.LookupIP(route.Spec.Host)
+		_, err := net.LookupIP(elbHostname)
 		if err != nil {
 			t.Log(err)
 			return false, nil
@@ -2658,10 +2665,14 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 
 	// Open a connection to the route, send a request, and verify that the
 	// connection times out after ~10 seconds.
-	request, err := http.NewRequest("GET", "http://"+route.Spec.Host, nil)
+	request, err := http.NewRequest("GET", "http://"+elbHostname, nil)
 	if err != nil {
 		t.Fatalf("failed to create HTTP request: %v", err)
 	}
+	// Add the "Host" header to direct request to ELB to the route we are testing which bypasses the need
+	// for the wildcard DNS record to propagate to the CI test runner cluster's DNS servers which has gotten very slow.
+	// See https://issues.redhat.com/browse/OCPBUGS-13810
+	request.Host = route.Spec.Host
 
 	client := &http.Client{}
 


### PR DESCRIPTION
TestAWSELBConnectionIdleTimeout has been very flakey due to the fact that the CI test runner cluster is failing to resolve the newly created wildcard DNS Record in a reasonable time. To work around this, we switch to using ELB's hostname, which is consistently resolving and adding the "Host" header to the HTTP request.

`test/e2e/operator_test.go`: Modify TestAWSELBConnectionIdleTimeout to use ELB hostname and Host header with route hostname

WIP PR with debugging output (which helped me arrive at this solution): https://github.com/openshift/cluster-ingress-operator/pull/940

**Why it's failing:**

- It's important to note that TestAWSELBConnectionIdleTimeout is the only test where we create a new ingress controller, wait for the new wildcard DNS Record to propagate to DNS Servers in our CI test runner cluster. So it's unique.
- TestAWSELBConnectionIdleTimeout tries to resolve new wildcard DNS record from the CI Test Runner Cluster (usually build01 which is AWS too). Note, this is from another cluster (two clusters here: The CI Test Runner and the Cluster under test, also known as ephemeral cluster)
- Wildcard DNS record resolves in a 1-2 minute window from within the AWS cluster under test (aka the ephemeral cluster)
- However, it's taking up to [15 minutes](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/940/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-operator/1666451227052871680/build-log.txt) for the DNS wildcard record to resolve consistently for the CI Test Runner Cluster now
  - I'm not completely sure why this happened.
  - Theory is, there are ebbs and flows in DNS record propagation across clusters/internet, especially when you consider caching.
- Serializing the test doesn't help as Andy and I both found
- Testing shows that the ELB's hostname resolves consistently (seems like a difference in route53 wildcard vs. ELB hostname propagation)
- Querying 8.8.8.8 (google dns) also shows failure to resolve and inconsistent results for at least 10 minutes (i.e. seems like not just our CI Test Runner Cluster DNS is faulty, it's a global issue)

**Resolution:**

- This PR circumvents using the Wildcard DNS Record and uses the ELB hostname with the request Host header set to the value of the route hostname
  - We already do this in the `unmanaged_dns_test.go,` just using the same pattern
  - It doesn't impact the goal of testing the ELB Connection Idle Timeout (Wildcard DNS propagation is auxiliary)
- I suggest adding a backlog item to add an E2E test that tests the propagation of wildcard DNS Records to the test runner cluster, possible have it be historical for seeing trends

**Alternative Solutions:**

- Resolve the DNS name inside of the cluster under test, and pass it back to the E2E test
  - I started this, but the moving parts of running dig in a pod and trying to get the output felt some what fragile to me. Seemed less appealing, since we already do the solution I created above.
- Run the test as serial, and use the default ingress controller
- Increase the timeout to 20 minutes or so to safely let DNS Propagate