### PR TITLE
OCPBUGS-14995: desiredRouterDeployment: Set HostPort if needed

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -891,6 +891,9 @@ func checkContainerPort(t *testing.T, d *appsv1.Deployment, portName string, por
 	t.Helper()
 	for _, p := range d.Spec.Template.Spec.Containers[0].Ports {
 		if p.Name == portName && p.ContainerPort == port {
+			if d.Spec.Template.Spec.HostNetwork && p.ContainerPort != p.HostPort {
+				t.Errorf("deployment %q specifies HostNetwork but specifies port %q with container port %d and hostport %d", d.Name, portName, p.ContainerPort, p.HostPort)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Set `spec.template.spec.containers[*].ports[*].hostPort` on a router deployment if the deployment sets `spec.template.spec.hostNetwork` to true.

Before this change, the operator left the `hostPort` field unspecified. As a result, the API set a default value for `hostPort`.  The operator detected this as an external update and attempted to revert it.  The change in this PR prevents the operator from making these spurious updates in response to API defaulting.

* `pkg/operator/controller/ingress/deployment.go` (`desiredRouterDeployment`): Set each container port's `HostPort` to the port's `ContainerPort` value when `HostNetwork` is enabled for the deployment.
* `pkg/operator/controller/ingress/deployment_test.go` (`checkContainerPort`): Verify that `HostPort` is set to `ContainerPort` if `HostNetwork` is enabled.