### PR TITLE
OCPBUGS-15100: Create valid DNS names for Gateway API on GCP

### DIFF
--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -3,6 +3,7 @@ package gateway_service_dns
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -222,6 +223,10 @@ func (r *reconciler) ensureDNSRecordsForGateway(ctx context.Context, gateway *ga
 	var errs []error
 	for _, domain := range domains {
 		name := operatorcontroller.GatewayDNSRecordName(gateway, domain)
+		// If domain doesn't have a trailing dot, add it
+		if !strings.HasSuffix(domain, ".") {
+			domain = domain + "."
+		}
 		_, _, err := dnsrecord.EnsureDNSRecord(r.client, name, labels, ownerRef, domain, service)
 		errs = append(errs, err)
 	}

--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -138,13 +138,13 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-5bfc88bc87-wildcard", "*.prod.example.com", "lb.example.com"),
-				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com", "lb.example.com"),
+				dnsrecord("example-gateway-5bfc88bc87-wildcard", "*.prod.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},
 		{
-			name: "gateway with two listeners and one dnsrecord with a stale target",
+			name: "gateway with two listeners and one dnsrecord with a stale target, hostname already has trailing dot",
 			existingObjects: []runtime.Object{
 				gw(
 					"example-gateway",
@@ -161,13 +161,38 @@ func Test_Reconcile(t *testing.T) {
 					},
 					ingHost("newlb.example.com"),
 				),
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com", "oldlb.example.com"),
+				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "oldlb.example.com"),
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate:     []client.Object{},
 			expectUpdate: []client.Object{
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com", "newlb.example.com"),
+				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "newlb.example.com"),
 			},
+		},
+		{
+			name: "gateway with two listeners and one host name, no dnsrecords, name ends up with trailing dot",
+			existingObjects: []runtime.Object{
+				gw(
+					"example-gateway",
+					l("stage-http", "*.stage.example.com", 80),
+					l("stage-https", "*.stage.example.com", 443),
+				),
+				svc(
+					"example-gateway",
+					map[string]string{
+						"gateway.istio.io/managed": "example-gateway",
+					},
+					map[string]string{
+						"istio.io/gateway-name": "example-gateway",
+					},
+					ingHost("lb.example.com"),
+				),
+			},
+			reconcileRequest: req("openshift-ingress", "example-gateway"),
+			expectCreate: []client.Object{
+				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
+			},
+			expectUpdate: []client.Object{},
 		},
 	}
 


### PR DESCRIPTION
Before this change, in `ensureDNSRecordsForGateway` we didn't add a trailing dot to the domain before creating the dnsrecord, causing the DNS name to fail to be published on a GCP platform.

Add a trailing dot if one doesn't exist, add test to check that only one dot is added, and change expectations of other tests to check for a trailing dot in the domain name.