### PR TITLE
NE-1317: manifests - add ingress capability annotation

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -6,6 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -6,7 +6,7 @@ metadata:
   name: openshift-ingress
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -38,7 +38,7 @@ metadata:
   name: openshift-ingress-azure
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -67,7 +67,7 @@ metadata:
   name: openshift-ingress-gcp
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -93,7 +93,7 @@ metadata:
   name: openshift-ingress-ibmcloud
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
@@ -123,7 +123,7 @@ metadata:
   name: openshift-ingress-powervs
   namespace: openshift-cloud-credential-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
@@ -153,7 +153,7 @@ metadata:
   name: openshift-ingress-alibabacloud
   namespace: openshift-ingress-operator
   annotations:
-    capability.openshift.io/name: CloudCredential
+    capability.openshift.io/name: CloudCredential+Ingress
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/manifests/00-namespace.yaml
+++ b/manifests/00-namespace.yaml
@@ -2,6 +2,7 @@ kind: Namespace
 apiVersion: v1
 metadata:
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_ingress-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_ingress-operator_00_prometheusrole.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_ingress-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_ingress-operator_01_prometheusrolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     role: alert-rules
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-cluster-role-binding.yaml
+++ b/manifests/01-cluster-role-binding.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-role-binding.yaml
+++ b/manifests/01-role-binding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -25,6 +26,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-config
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
@@ -45,6 +46,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-config
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-service-account.yaml
+++ b/manifests/01-service-account.yaml
@@ -6,6 +6,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-service.yaml
+++ b/manifests/01-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-trusted-ca-configmap.yaml
+++ b/manifests/01-trusted-ca-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    capability.openshift.io/name: Ingress
     config.openshift.io/inject-proxy: ingress-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
   name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ingress-operator
   namespace: openshift-ingress-operator
   annotations:
+    capability.openshift.io/name: Ingress
     config.openshift.io/inject-proxy: ingress-operator
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/03-cluster-operator.yaml
+++ b/manifests/03-cluster-operator.yaml
@@ -6,6 +6,7 @@ kind: ClusterOperator
 metadata:
   name: ingress
   annotations:
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/profile-patches/ibm-cloud-managed/02-deployment.yaml.patch
+++ b/profile-patches/ibm-cloud-managed/02-deployment.yaml.patch
@@ -1,6 +1,7 @@
 - op: replace
   path: /metadata/annotations
   value:
+    capability.openshift.io/name: Ingress
     config.openshift.io/inject-proxy: ingress-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
 - op: replace


### PR DESCRIPTION
This PR adds the `Ingress` capability annotation to all the resources related to the cluster-ingress-operator: CRDS, Deployment, RBAC, CredentialsRequests. 

Enhancement Proposal: https://github.com/openshift/enhancements/pull/1415.
PR which added the `Ingress` capability to the API: https://github.com/openshift/api/pull/1724.