### PR TITLE
OCPBUGS-15434: [release-4.13] Fix invalid DNS name formatting for GCP

### DIFF
--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -3,6 +3,7 @@ package gateway_service_dns
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -219,6 +220,10 @@ func (r *reconciler) ensureDNSRecordsForGateway(ctx context.Context, gateway *ga
 	var errs []error
 	for _, domain := range domains {
 		name := operatorcontroller.GatewayDNSRecordName(gateway, domain)
+		// If domain doesn't have a trailing dot, add it
+		if !strings.HasSuffix(domain, ".") {
+			domain = domain + "."
+		}
 		_, _, err := dnsrecord.EnsureDNSRecord(r.client, name, labels, ownerRef, domain, service)
 		errs = append(errs, err)
 	}

--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -189,14 +189,19 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 // getGatewayHostnames returns a sets.String with the hostnames from the given
-// gateway's listeners.
+// gateway's listeners.  Adds a trailing dot if it's missing from the hostname.
 func getGatewayHostnames(gateway *gatewayapiv1beta1.Gateway) sets.String {
 	domains := sets.NewString()
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.Hostname == nil || len(*listener.Hostname) == 0 {
 			continue
 		}
-		domains.Insert(string(*listener.Hostname))
+		domain := string(*listener.Hostname)
+		// If domain doesn't have a trailing dot, add it.
+		if !strings.HasSuffix(domain, ".") {
+			domain = domain + "."
+		}
+		domains.Insert(domain)
 	}
 	return domains
 }
@@ -220,10 +225,6 @@ func (r *reconciler) ensureDNSRecordsForGateway(ctx context.Context, gateway *ga
 	var errs []error
 	for _, domain := range domains {
 		name := operatorcontroller.GatewayDNSRecordName(gateway, domain)
-		// If domain doesn't have a trailing dot, add it
-		if !strings.HasSuffix(domain, ".") {
-			domain = domain + "."
-		}
 		_, _, err := dnsrecord.EnsureDNSRecord(r.client, name, labels, ownerRef, domain, service)
 		errs = append(errs, err)
 	}

--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -138,8 +138,8 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-5bfc88bc87-wildcard", "*.prod.example.com.", "lb.example.com"),
-				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-76456f8647-wildcard", "*.prod.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},
@@ -161,12 +161,12 @@ func Test_Reconcile(t *testing.T) {
 					},
 					ingHost("newlb.example.com"),
 				),
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "oldlb.example.com"),
+				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "oldlb.example.com"),
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate:     []client.Object{},
 			expectUpdate: []client.Object{
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "newlb.example.com"),
+				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "newlb.example.com"),
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},

--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -138,13 +138,13 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-5bfc88bc87-wildcard", "*.prod.example.com", "lb.example.com"),
-				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com", "lb.example.com"),
+				dnsrecord("example-gateway-5bfc88bc87-wildcard", "*.prod.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},
 		{
-			name: "gateway with two listeners and one dnsrecord with a stale target",
+			name: "gateway with two listeners and one dnsrecord with a stale target, hostname already has trailing dot",
 			existingObjects: []runtime.Object{
 				gw(
 					"example-gateway",
@@ -161,13 +161,38 @@ func Test_Reconcile(t *testing.T) {
 					},
 					ingHost("newlb.example.com"),
 				),
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com", "oldlb.example.com"),
+				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "oldlb.example.com"),
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate:     []client.Object{},
 			expectUpdate: []client.Object{
-				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com", "newlb.example.com"),
+				dnsrecord("example-gateway-55bcfdb97d-wildcard", "*.example.com.", "newlb.example.com"),
 			},
+		},
+		{
+			name: "gateway with two listeners and one host name, no dnsrecords, name ends up with trailing dot",
+			existingObjects: []runtime.Object{
+				gw(
+					"example-gateway",
+					l("stage-http", "*.stage.example.com", 80),
+					l("stage-https", "*.stage.example.com", 443),
+				),
+				svc(
+					"example-gateway",
+					map[string]string{
+						"gateway.istio.io/managed": "example-gateway",
+					},
+					map[string]string{
+						"istio.io/gateway-name": "example-gateway",
+					},
+					ingHost("lb.example.com"),
+				),
+			},
+			reconcileRequest: req("openshift-ingress", "example-gateway"),
+			expectCreate: []client.Object{
+				dnsrecord("example-gateway-57b76476b6-wildcard", "*.stage.example.com.", "lb.example.com"),
+			},
+			expectUpdate: []client.Object{},
 		},
 	}
 


### PR DESCRIPTION
Backport of b58456ac0d60c6a749c and 8ad42fa58ec2232169bb.

Before this change, in ensureDNSRecordsForGateway we didn't add a trailing dot to the domain
before creating the dnsrecord, causing the DNS name to fail to be published on a GCP platform.
    
Add a trailing dot if one doesn't exist, add test to check that only one dot is added, and
change expectations of other tests to check for a trailing dot in the domain name.
