### PR TITLE
OCPBUGS-9037: If mTLS is required and the canary receives a "certificate required" TLS error, consider the canary probe successful

### DIFF
--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -22,7 +22,7 @@ const (
 
 // probeRouteEndpoint probes the given route's host
 // and returns an error when applicable.
-func probeRouteEndpoint(route *routev1.Route) error {
+func (r *reconciler) probeRouteEndpoint(route *routev1.Route) error {
 	routeHost := getRouteHost(route)
 	if len(routeHost) == 0 {
 		return fmt.Errorf("route host is empty, cannot test route")
@@ -48,7 +48,7 @@ func probeRouteEndpoint(route *routev1.Route) error {
 	request = request.WithContext(ctx)
 
 	// Send the HTTP request
-	timeout, _ := time.ParseDuration("10s")
+	timeout := 10 * time.Second
 	client := &http.Client{
 		Timeout: timeout,
 		// The canary route uses edge termination and the
@@ -68,17 +68,39 @@ func probeRouteEndpoint(route *routev1.Route) error {
 	response, err := client.Do(request)
 
 	if err != nil {
-		// Check if err is a DNS error
+		// Check if err is a DNS error.
 		dnsErr := &net.DNSError{}
 		if errors.As(err, &dnsErr) {
 			// Handle DNS error
 			CanaryRouteDNSError.WithLabelValues(routeHost, dnsErr.Server).Inc()
 			return fmt.Errorf("error sending canary HTTP request: DNS error: %v", err)
 		}
-		// Check if err is a timeout error
+		// Check if err is a timeout error.
 		if os.IsTimeout(err) {
-			// Handle timeout error
+			// Handle timeout error.
 			return fmt.Errorf("error sending canary HTTP Request: Timeout: %v", err)
+		}
+		// Check if err is a TLS alert.
+		opErr := &net.OpError{}
+		if errors.As(err, &opErr) {
+			if opErr.Op == "remote error" {
+				// If the operation is "remote error," it may be a TLS alert, as described in RFC 8446 section 6.
+				// crypto/tls doesn't expose its TLS alert type, but we can check the error string. If the alert is
+				// "certificate required", it means the canary lacks the client certificate necessary to complete its
+				// check. In that case, verify that the router is configured to require mTLS, and if so, assume the
+				// router is working as intended.
+				if opErr.Err.Error() == "tls: certificate required" {
+					if mtlsRequired, mtlsErr := r.isMTLSRequired(); mtlsErr != nil {
+						// Log the error from isMTLSRequired(), but continue the function so the actual request error is
+						// returned.
+						log.Error(mtlsErr, "Failed to verify mTLS status of default ingress controller")
+					} else if mtlsRequired {
+						// Since mTLS is required in the ingress config and our probe was rejected due to a missing
+						// certificate, consider this a successful probe.
+						return nil
+					}
+				}
+			}
 		}
 		return fmt.Errorf("error sending canary HTTP request to %q: %v", routeHost, err)
 	}

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -108,6 +108,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouterCompressionOperation", TestRouterCompressionOperation)
 		t.Run("TestUpdateDefaultIngressControllerSecret", TestUpdateDefaultIngressControllerSecret)
 		t.Run("TestCanaryRoute", TestCanaryRoute)
+		t.Run("TestCanaryWithMTLS", TestCanaryWithMTLS)
 		t.Run("TestRouteHTTP2EnableAndDisableIngressConfig", TestRouteHTTP2EnableAndDisableIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)


### PR DESCRIPTION
Without an API to provide the canary with a valid client certificate, the canary probes are guaranteed to fail when mTLS is required by the default ingress controller. However, if the failure is determined to be because the canary is missing a client certificate, it's reasonable to assume that the ingress controller is functional.

This change checks specifically for the TLS alert "certificate required", and if the default ingress controller also has mTLS required, the probe function returns nil, indicating a successful probe.