### PR TITLE
NETOBSERV-1052: Add monitoring dashboard controller to create dashboard configmap

### DIFF
--- a/pkg/operator/controller/monitoring-dashboard/controller.go
+++ b/pkg/operator/controller/monitoring-dashboard/controller.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -31,13 +30,13 @@ func New(mgr manager.Manager) (controller.Controller, error) {
 	reconciler := &reconciler{
 		client: mgr.GetClient(),
 	}
-	c, err := runtimecontroller.New(controllerName, mgr, runtimecontroller.Options{Reconciler: reconciler})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
 		return nil, err
 	}
 
 	CMPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetName() == dashboardConfigmapName
+		return o.GetName() == dashboardConfigMapName
 	})
 
 	if err := c.Watch(source.Kind(operatorCache, &corev1.ConfigMap{}), &handler.EnqueueRequestForObject{}, CMPredicate); err != nil {

--- a/pkg/operator/controller/monitoring-dashboard/controller.go
+++ b/pkg/operator/controller/monitoring-dashboard/controller.go
@@ -1,0 +1,71 @@
+package monitoringdashboard
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName = "monitoring_dashboard_controller"
+)
+
+var log = logf.Logger.WithName(controllerName)
+
+// New creates the monitoring dashboard controller. This is the controller
+// that handles all the logic about the monitoring dashboard
+func New(mgr manager.Manager) (controller.Controller, error) {
+	operatorCache := mgr.GetCache()
+	reconciler := &reconciler{
+		client: mgr.GetClient(),
+	}
+	c, err := runtimecontroller.New(controllerName, mgr, runtimecontroller.Options{Reconciler: reconciler})
+	if err != nil {
+		return nil, err
+	}
+
+	CMPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == dashboardConfigmapName
+	})
+
+	if err := c.Watch(source.Kind(operatorCache, &corev1.ConfigMap{}), &handler.EnqueueRequestForObject{}, CMPredicate); err != nil {
+		return nil, err
+	}
+
+	if err := c.Watch(source.Kind(operatorCache, &configv1.Infrastructure{}), &handler.EnqueueRequestForObject{}); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// reconciler handles the actual monitoringdashboard reconciliation logic in response to events.
+type reconciler struct {
+	client client.Client
+}
+
+// Reconcile will look at the cluster configuration and create the monitoring dashboard accordingly
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	infraConfig := &configv1.Infrastructure{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get infrastructure 'config': %v", err)
+	}
+
+	if err := r.ensureMonitoringDashboard(ctx, infraConfig.Status); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to ensure monitoring dashboard: %v", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/operator/controller/monitoring-dashboard/controller.go
+++ b/pkg/operator/controller/monitoring-dashboard/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
-	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,8 +19,6 @@ import (
 const (
 	controllerName = "monitoring_dashboard_controller"
 )
-
-var log = logf.Logger.WithName(controllerName)
 
 // New creates the monitoring dashboard controller. This is the controller
 // that handles all the logic about the monitoring dashboard

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -314,7 +314,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP average response latency",
+          "title": "HTTP server average response latency",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -402,7 +402,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{route!=\"\"}[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -480,7 +480,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{route!=\"\"}[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -558,7 +558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (route))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -636,7 +636,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (route))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{route!=\"\"} != 0) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -646,7 +646,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP average response latency",
+          "title": "HTTP server average response latency in milliseconds",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -726,7 +726,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{exported_namespace!=\"\"}[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -804,7 +804,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{exported_namespace!=\"\"}[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -882,7 +882,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (exported_namespace))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{exported_namespace!=\"\"}[180s])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -960,7 +960,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (exported_namespace))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{exported_namespace!=\"\"} != 0) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -970,7 +970,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP average response latency",
+          "title": "HTTP server average response latency in milliseconds",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1294,7 +1294,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP average response latency",
+          "title": "HTTP server average response latency in milliseconds",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1372,7 +1372,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Number of route",
+          "title": "Number of routes",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -65,7 +65,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Current total incoming bandwidth",
+          "title": "Current Total Incoming Bandwidth",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -146,7 +146,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Current total outgoing bandwidth",
+          "title": "Current Total Outgoing Bandwidth",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -230,7 +230,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total HTTP response error",
+          "title": "Total HTTP Server Response Error",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -314,7 +314,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP server average response latency",
+          "title": "HTTP Server Average Response Latency",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -402,7 +402,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{route!=\"\"}[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{route!=\"\"}[1m])) by (route) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -412,7 +412,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Incoming bytes",
+          "title": "Incoming Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -480,7 +480,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{route!=\"\"}[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{route!=\"\"}[1m])) by (route) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -490,7 +490,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Outgoing bytes",
+          "title": "Outgoing Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -558,7 +558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (route))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (route) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -568,7 +568,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP response errors rate",
+          "title": "HTTP Server Response Error Rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -636,7 +636,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{route!=\"\"} != 0) by (route))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{route!=\"\"} != 0) by (route) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -676,7 +676,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Top 10 per route",
+      "title": "Top 10 Per Route",
       "titleSize": "h6"
     },
     {
@@ -726,7 +726,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{exported_namespace!=\"\"}[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{exported_namespace!=\"\"}[1m])) by (exported_namespace) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -736,7 +736,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Incoming bytes",
+          "title": "Incoming Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -804,7 +804,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{exported_namespace!=\"\"}[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{exported_namespace!=\"\"}[1m])) by (exported_namespace) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -814,7 +814,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Outgoing bytes",
+          "title": "Outgoing Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -882,7 +882,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{exported_namespace!=\"\"}[180s])) by (exported_namespace))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{exported_namespace!=\"\"}[180s])) by (exported_namespace) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -892,7 +892,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP response errors rate",
+          "title": "HTTP Server Response Error Rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -960,7 +960,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{exported_namespace!=\"\"} != 0) by (exported_namespace))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{exported_namespace!=\"\"} != 0) by (exported_namespace) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -1000,7 +1000,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Top 10 per namespace",
+      "title": "Top 10 Per Namespace",
       "titleSize": "h6"
     },
     {
@@ -1050,7 +1050,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (service))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total{route!=\"\"}[1m])) by (service) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1060,7 +1060,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Incoming bytes",
+          "title": "Incoming Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1128,7 +1128,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (service))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total{route!=\"\"}[1m])) by (service) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1138,7 +1138,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Outgoing bytes",
+          "title": "Outgoing Bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1206,7 +1206,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (service))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (service) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1216,7 +1216,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP response errors rate",
+          "title": "HTTP Server Response Error Rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1284,7 +1284,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (service))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds{route!=\"\"} != 0) by (service) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1362,7 +1362,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,count(count(haproxy_server_up == 1) by (route, service)) by (service))",
+              "expr": "topk(10,count(count(haproxy_server_up == 1) by (route, service)) by (service) != 0)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1372,7 +1372,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Number of routes",
+          "title": "Number of Routes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1402,7 +1402,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Top 10 per shard",
+      "title": "Top 10 Per Shard",
       "titleSize": "h6"
     }
   ],

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -59,24 +59,24 @@
           "steppedLine": false,
           "targets": [
             {
-		"expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (instance, pod, namespace))",
-		"format": "time_series",
-		"intervalFactor": 2,
-		"legendFormat": "Instance: {{instance}} Pod: {{pod}} Namespace: {{namespace}}",
-		"refId": "A"
+              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (instance, pod, namespace))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Instance: {{instance}} Pod: {{pod}} Namespace: {{namespace}}",
+              "refId": "A"
             }
           ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Traffic volume on each ingress instance",
-            "tooltip": {
-		"shared": true,
-		"sort": 0,
-		"value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Traffic volume on each ingress instance",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
             "buckets": null,
             "mode": "time",
             "name": null,
@@ -124,31 +124,31 @@
     "to": "now"
   },
   "timepicker": {
-      "refresh_intervals": [
-	  "5s",
-	  "10s",
-	  "30s",
-	  "1m",
-	  "5m",
-	  "15m",
-	  "30m",
-	  "1h",
-	  "2h",
-	  "1d"
-      ],
-      "time_options": [
-	  "5m",
-	  "15m",
-	  "1h",
-	  "6h",
-	  "12h",
-	  "24h",
-	  "2d",
-	  "7d",
-	  "30d"
-      ]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
-    "timezone": "browser",
-    "title": "Networking / Ingress",
-    "version": 0
+  "timezone": "browser",
+  "title": "Networking / Ingress",
+  "version": 0
 }

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -1,0 +1,154 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "",
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+		"expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (instance, pod, namespace))",
+		"format": "time_series",
+		"intervalFactor": 2,
+		"legendFormat": "Instance: {{instance}} Pod: {{pod}} Namespace: {{namespace}}",
+		"refId": "A"
+            }
+          ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Traffic volume on each ingress instance",
+            "tooltip": {
+		"shared": true,
+		"sort": 0,
+		"value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Traffic",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "netobserv-mixin"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now",
+    "to": "now"
+  },
+  "timepicker": {
+      "refresh_intervals": [
+	  "5s",
+	  "10s",
+	  "30s",
+	  "1m",
+	  "5m",
+	  "15m",
+	  "30m",
+	  "1h",
+	  "2h",
+	  "1d"
+      ],
+      "time_options": [
+	  "5m",
+	  "15m",
+	  "1h",
+	  "6h",
+	  "12h",
+	  "24h",
+	  "2d",
+	  "7d",
+	  "30d"
+      ]
+  },
+    "timezone": "browser",
+    "title": "Networking / Ingress",
+    "version": 0
+}

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -217,7 +217,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[$__range])) / sum(increase(haproxy_server_http_responses_total[$__range]))",
+              "expr": "sum(increase(haproxy_server_http_responses_total{code=~\"4xx|5xx\", route!=\"\"}[$__range])) / sum(increase(haproxy_server_http_responses_total{route!=\"\"}[$__range]))",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 2,
@@ -230,7 +230,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-            "title": "HTTP error rate",
+            "title": "HTTP Error Rate",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -558,7 +558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (route) / sum(rate(haproxy_server_http_responses_total[1m])) by (route))",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\", route!=\"\"}[1m]) != 0) by (route) / sum(rate(haproxy_server_http_responses_total{route!=\"\"}[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -882,7 +882,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (exported_namespace) / sum(rate(haproxy_server_http_responses_total[1m])) by (exported_namespace))",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\", route!=\"\"}[1m]) != 0) by (exported_namespace) / sum(rate(haproxy_server_http_responses_total{route!=\"\"}[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -1206,7 +1206,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (service) / sum(rate(haproxy_server_http_responses_total[1m])) by (service))",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\", route!=\"\"}[1m]) != 0) by (service) / sum(rate(haproxy_server_http_responses_total{route!=\"\"}[1m])) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -65,7 +65,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total incoming bytes",
+          "title": "Current total incoming bandwidth",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -146,7 +146,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total outgoing bytes",
+          "title": "Current total outgoing bandwidth",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -402,7 +402,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -480,7 +480,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (route))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -558,7 +558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (route))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -636,7 +636,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (route))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -676,7 +676,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Per route",
+      "title": "Top 10 per route",
       "titleSize": "h6"
     },
     {
@@ -726,7 +726,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -804,7 +804,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (exported_namespace))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -882,7 +882,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (exported_namespace))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -960,7 +960,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (exported_namespace))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -1000,7 +1000,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Per namespace",
+      "title": "Top 10 per namespace",
       "titleSize": "h6"
     },
     {
@@ -1050,7 +1050,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (service))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_in_total[1m])) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1128,7 +1128,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (service))",
+              "expr": "topk(10,sum(rate(haproxy_server_bytes_out_total[1m])) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1206,7 +1206,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (service))",
+              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total[180s])) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1284,7 +1284,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (service))",
+              "expr": "topk(10,avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1362,7 +1362,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "count(count(haproxy_server_up == 1) by (route, service)) by (service)",
+              "expr": "topk(10,count(count(haproxy_server_up == 1) by (route, service)) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",
@@ -1402,7 +1402,7 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "Per shard",
+      "title": "Top 10 per shard",
       "titleSize": "h6"
     }
   ],

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -646,7 +646,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP server average response latency in milliseconds",
+          "title": "Average HTTP Server Response Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -970,7 +970,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP server average response latency in milliseconds",
+          "title": "Average HTTP Server Response Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1294,7 +1294,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP server average response latency in milliseconds",
+          "title": "Average HTTP Server Response Latency (ms)",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -1002,6 +1002,408 @@
       "showTitle": true,
       "title": "Per namespace",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (service))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Incoming bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (service))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Outgoing bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (service))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP response errors rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (service))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP average response latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "count(count(haproxy_server_up == 1) by (route, service)) by (service)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ service }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of route",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Per shard",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 16,

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -15,6 +15,348 @@
   "rows": [
     {
       "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "format": "Bps",
+          "id": 1,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(haproxy_server_bytes_in_total[1m]))",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total incoming bytes",
+          "tooltip": {
+            "shared": false,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "singlestat",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "format": "Bps",
+          "id": 1,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(haproxy_server_bytes_out_total[1m]))",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total outgoing bytes",
+          "tooltip": {
+            "shared": false,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "singlestat",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "format": "",
+          "id": 1,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "round(sum(increase(haproxy_server_response_errors_total[$__range])), 1)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            2,
+            10
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total HTTP response error",
+          "tooltip": {
+            "shared": false,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "singlestat",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "format": "ms",
+          "id": 1,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(haproxy_server_http_average_response_latency_milliseconds != 0)",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            2,
+            10
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP average response latency",
+          "tooltip": {
+            "shared": false,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "singlestat",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "stats",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
       "height": "250px",
       "panels": [
         {
@@ -70,7 +412,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Incoming bytes per route",
+          "title": "Incoming bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -148,7 +490,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Outgoing bytes per route",
+          "title": "Outgoing bytes",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -172,19 +514,7 @@
               "show": true
             }
           ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
-      "title": "Traffic",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": "250px",
-      "panels": [
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -238,7 +568,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP response errors rate per route",
+          "title": "HTTP response errors rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -316,7 +646,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "HTTP average response latency per route",
+          "title": "HTTP average response latency",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -346,13 +676,337 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": true,
-      "title": "HTTP",
+      "title": "Per route",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (exported_namespace))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ exported_namespace }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Incoming bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (exported_namespace))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ exported_namespace }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Outgoing bytes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (exported_namespace))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ exported_namespace }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP response errors rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (exported_namespace))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ exported_namespace }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP average response latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Per namespace",
       "titleSize": "h6"
     }
   ],
   "schemaVersion": 16,
   "tags": [
-    "network-mixin"
+    "networking-mixin"
   ],
   "templating": {
     "list": []

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -55,21 +55,22 @@
           "repeat": null,
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (instance, pod, namespace))",
+              "expr": "(sum(rate(haproxy_server_bytes_in_total[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Instance: {{instance}} Pod: {{pod}} Namespace: {{namespace}}",
+              "legendFormat": "{{ route }}",
               "refId": "A"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Traffic volume on each ingress instance",
+          "title": "Incoming bytes per route",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -91,7 +92,77 @@
               "max": null,
               "min": null,
               "show": true
-            },
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(rate(haproxy_server_bytes_out_total[1m])) by (route))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ route }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Outgoing bytes per route",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
               "format": "short",
               "label": null,
@@ -109,12 +180,179 @@
       "showTitle": true,
       "title": "Traffic",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(sum(irate(haproxy_server_response_errors_total[180s])) by (route))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ route }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP response errors rate per route",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(avg(haproxy_server_http_average_response_latency_milliseconds != 0) by (route))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ route }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HTTP average response latency per route",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "HTTP",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 16,
-  "style": "dark",
   "tags": [
-    "netobserv-mixin"
+    "network-mixin"
   ],
   "templating": {
     "list": []

--- a/pkg/operator/controller/monitoring-dashboard/dashboard.json
+++ b/pkg/operator/controller/monitoring-dashboard/dashboard.json
@@ -217,7 +217,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "round(sum(increase(haproxy_server_response_errors_total[$__range])), 1)",
+              "expr": "sum(increase(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[$__range])) / sum(increase(haproxy_server_http_responses_total[$__range]))",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 2,
@@ -230,7 +230,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total HTTP Server Response Error",
+            "title": "HTTP error rate",
           "tooltip": {
             "shared": false,
             "sort": 2,
@@ -558,7 +558,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (route) != 0)",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (route) / sum(rate(haproxy_server_http_responses_total[1m])) by (route))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ route }}",
@@ -882,7 +882,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{exported_namespace!=\"\"}[180s])) by (exported_namespace) != 0)",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (exported_namespace) / sum(rate(haproxy_server_http_responses_total[1m])) by (exported_namespace))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ exported_namespace }}",
@@ -1206,7 +1206,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10,sum(irate(haproxy_server_response_errors_total{route!=\"\"}[180s])) by (service) != 0)",
+              "expr": "topk(10, sum(rate(haproxy_server_http_responses_total{code=~\"4xx|5xx\"}[1m]) != 0) by (service) / sum(rate(haproxy_server_http_responses_total[1m])) by (service))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ service }}",

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
@@ -17,9 +17,10 @@ const (
 	dashboardConfigMapName      = "grafana-dashboard-ingress-operator"
 	dashboardConfigMapNamespace = "openshift-config-managed"
 	consoleDashboardLabel       = "console.openshift.io/dashboard"
+	DashboardFileName           = "dashboard.json"
 )
 
-// ensureMonitoringDashboard creates or deletes an operator generated
+// ensureMonitoringDashboard creates, updates or deletes an operator generated
 // configmap containing the dashboard for ingress operator monitoring.
 // Return any errors.
 func (r *reconciler) ensureMonitoringDashboard(ctx context.Context, infraStatus configv1.InfrastructureStatus) error {
@@ -88,7 +89,7 @@ func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.Infras
 			},
 		},
 		Data: map[string]string{
-			"dashboard.json": dashboardJSON,
+			DashboardFileName: dashboardJSON,
 		},
 	}
 	if current != nil {
@@ -97,10 +98,10 @@ func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.Infras
 	return &desired
 }
 
-// dashboardDataNeedsUpdate compares the dashboard data within current
+// dashboardNeedsUpdate compares the current dashboard configmap
 // and desired ConfigMaps. It returns true if the data within the
 // current ConfigMap does not match the desired ConfigMap, or if the
-// console label dashboard is false or not present. This indicate
+// console label dashboard is false or not present. This indicates
 // that the dashboard data requires an update.
 func dashboardNeedsUpdate(current *corev1.ConfigMap, desired *corev1.ConfigMap) bool {
 	if labelValue, ok := current.ObjectMeta.Labels[consoleDashboardLabel]; !ok || labelValue != "true" {

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
@@ -79,7 +79,6 @@ func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.Infras
 	if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
 		return nil
 	}
-
 	desired := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dashboardConfigMapName,
@@ -92,11 +91,9 @@ func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.Infras
 			"dashboard.json": dashboardJSON,
 		},
 	}
-
 	if current != nil {
 		desired.SetResourceVersion(current.GetResourceVersion())
 	}
-
 	return &desired
 }
 

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	dashboardConfigmapName      = "ingress-operator-dashboard"
-	dashboardConfigmapNamespace = "openshift-config-managed"
+	dashboardConfigMapName      = "grafana-dashboard-ingress-operator"
+	dashboardConfigMapNamespace = "openshift-config-managed"
+	consoleDashboardLabel       = "console.openshift.io/dashboard"
 )
 
 // ensureMonitoringDashboard creates or deletes an operator generated
@@ -27,22 +28,19 @@ func (r *reconciler) ensureMonitoringDashboard(ctx context.Context, infraStatus 
 		return fmt.Errorf("failed to get current monitoring dashboard: %v", err)
 	}
 
-	desired := desiredMonitoringDashboard(ctx, infraStatus)
+	desired := desiredMonitoringDashboard(ctx, infraStatus, current)
 
 	switch {
 	case current == nil && desired != nil:
 		err = r.client.Create(ctx, desired)
 	case current != nil && desired != nil:
 		if dashboardNeedsUpdate(current, desired) {
-
-			current.SetResourceVersion(current.GetResourceVersion())
 			err = r.client.Update(ctx, desired)
 		}
 	case current != nil && desired == nil:
 		err = r.client.Delete(ctx, current)
 	case current == nil && desired == nil:
 		// nothing to do
-
 	}
 
 	return err
@@ -50,8 +48,8 @@ func (r *reconciler) ensureMonitoringDashboard(ctx context.Context, infraStatus 
 
 func ConfigMapName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: dashboardConfigmapNamespace,
-		Name:      dashboardConfigmapName,
+		Namespace: dashboardConfigMapNamespace,
+		Name:      dashboardConfigMapName,
 	}
 }
 
@@ -70,12 +68,13 @@ func (r *reconciler) currentMonitoringDashboard(ctx context.Context) (*corev1.Co
 }
 
 // dashboardJSON is the string representation of the embedded 'dashboard.json' file.
+//
 //go:embed dashboard.json
 var dashboardJSON string
 
 // desiredMonitoringDashboard return the desired configmap for the monitoring dashboard or nil if the
 // configmap should not be deployed
-func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.InfrastructureStatus) *corev1.ConfigMap {
+func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.InfrastructureStatus, current *corev1.ConfigMap) *corev1.ConfigMap {
 	// If control plane topology is set to external, we do not deploy the dashboard
 	if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
 		return nil
@@ -83,21 +82,32 @@ func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.Infras
 
 	desired := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dashboardConfigmapName,
-			Namespace: dashboardConfigmapNamespace,
+			Name:      dashboardConfigMapName,
+			Namespace: dashboardConfigMapNamespace,
 			Labels: map[string]string{
-				"console.openshift.io/dashboard": "true",
+				consoleDashboardLabel: "true",
 			},
 		},
 		Data: map[string]string{
-			"dashboard.json": dashboardEmbed,
+			"dashboard.json": dashboardJSON,
 		},
 	}
-	return &desired
 
+	if current != nil {
+		desired.SetResourceVersion(current.GetResourceVersion())
+	}
+
+	return &desired
 }
 
-// dashboardNeedsUpdate compare desired and current configmap and returns true if current should be updated
+// dashboardDataNeedsUpdate compares the dashboard data within current
+// and desired ConfigMaps. It returns true if the data within the
+// current ConfigMap does not match the desired ConfigMap, or if the
+// console label dashboard is false or not present. This indicate
+// that the dashboard data requires an update.
 func dashboardNeedsUpdate(current *corev1.ConfigMap, desired *corev1.ConfigMap) bool {
+	if labelValue, ok := current.ObjectMeta.Labels[consoleDashboardLabel]; !ok || labelValue != "true" {
+		return true
+	}
 	return !reflect.DeepEqual(current.Data, desired.Data)
 }

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
@@ -1,0 +1,101 @@
+package monitoringdashboard
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"reflect"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	dashboardConfigmapName      = "ingress-operator-dashboard"
+	dashboardConfigmapNamespace = "openshift-config-managed"
+)
+
+// ensureMonitoringDashboard creates or deletes an operator generated
+// configmap containing the dashboard for ingress operator monitoring.
+// Return any errors.
+func (r *reconciler) ensureMonitoringDashboard(ctx context.Context, infraStatus configv1.InfrastructureStatus) error {
+	current, err := r.currentMonitoringDashboard(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current monitoring dashboard: %v", err)
+	}
+
+	desired := desiredMonitoringDashboard(ctx, infraStatus)
+
+	switch {
+	case current == nil && desired != nil:
+		err = r.client.Create(ctx, desired)
+	case current != nil && desired != nil:
+		if dashboardNeedsUpdate(current, desired) {
+
+			current.SetResourceVersion(current.GetResourceVersion())
+			err = r.client.Update(ctx, desired)
+		}
+	case current != nil && desired == nil:
+		err = r.client.Delete(ctx, current)
+	case current == nil && desired == nil:
+		//nothing to do
+
+	}
+
+	return err
+}
+
+func ConfigMapName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: dashboardConfigmapNamespace,
+		Name:      dashboardConfigmapName,
+	}
+}
+
+// currentMonitoringDashboard return the existing configmap if exist or nil, as well as any errors
+func (r *reconciler) currentMonitoringDashboard(ctx context.Context) (*corev1.ConfigMap, error) {
+	configmap := &corev1.ConfigMap{}
+	name := ConfigMapName()
+	if err := r.client.Get(ctx, name, configmap); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return configmap, nil
+}
+
+//go:embed dashboard.json
+var dashboardEmbed string
+
+// desiredMonitoringDashboard return the desired configmap for the monitoring dashboard or nil if the
+// configmap should not be deployed
+func desiredMonitoringDashboard(ctx context.Context, infraStatus configv1.InfrastructureStatus) *corev1.ConfigMap {
+	// If control plane topology is set to external, we do not deploy the dashboard
+	if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		return nil
+	}
+
+	desired := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dashboardConfigmapName,
+			Namespace: dashboardConfigmapNamespace,
+			Labels: map[string]string{
+				"console.openshift.io/dashboard": "true",
+			},
+		},
+		Data: map[string]string{
+			"dashboard.json": dashboardEmbed,
+		},
+	}
+	return &desired
+
+}
+
+// dashboardNeedsUpdate compare desired and current configmap and returns true if current should be updated
+func dashboardNeedsUpdate(current *corev1.ConfigMap, desired *corev1.ConfigMap) bool {
+	return !reflect.DeepEqual(current.Data, desired.Data)
+}

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard.go
@@ -41,7 +41,7 @@ func (r *reconciler) ensureMonitoringDashboard(ctx context.Context, infraStatus 
 	case current != nil && desired == nil:
 		err = r.client.Delete(ctx, current)
 	case current == nil && desired == nil:
-		//nothing to do
+		// nothing to do
 
 	}
 
@@ -55,7 +55,8 @@ func ConfigMapName() types.NamespacedName {
 	}
 }
 
-// currentMonitoringDashboard return the existing configmap if exist or nil, as well as any errors
+// currentMonitoringDashboard retrieves the existing monitoring dashboard ConfigMap if it exists, otherwise returns nil.
+// If an error occurs during the retrieval, it returns the error.
 func (r *reconciler) currentMonitoringDashboard(ctx context.Context) (*corev1.ConfigMap, error) {
 	configmap := &corev1.ConfigMap{}
 	name := ConfigMapName()
@@ -68,8 +69,9 @@ func (r *reconciler) currentMonitoringDashboard(ctx context.Context) (*corev1.Co
 	return configmap, nil
 }
 
+// dashboardJSON is the string representation of the embedded 'dashboard.json' file.
 //go:embed dashboard.json
-var dashboardEmbed string
+var dashboardJSON string
 
 // desiredMonitoringDashboard return the desired configmap for the monitoring dashboard or nil if the
 // configmap should not be deployed

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
@@ -25,8 +25,8 @@ func newConfigMap() *corev1.ConfigMap {
 	}
 }
 
-// TestDashboardNeedsUpdate verifies that we update the dashboard when needed
-// and we do not when not needed
+// TestDashboardNeedsUpdate checks if the dashboardNeedsUpdate function 
+// accurately determines the need for dashboard ConfigMap updates under various scenarios.
 func TestDashboardNeedsUpdate(t *testing.T) {
 	type testInputs struct {
 		current *corev1.ConfigMap
@@ -41,7 +41,7 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 		output      testOutputs
 	}{
 		{
-			description: "Identicals configmaps",
+			description: "Identical configmaps",
 			inputs: testInputs{
 				current: newConfigMap(),
 				desired: newConfigMap(),
@@ -125,9 +125,11 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 	}
 }
 
-// TestDesiredRouterCertsGlobalSecret verifies that we get the expected global
-// secret for the default ingresscontroller and for various combinations of
-// ingresscontrollers and default certificate secrets.
+// TestDesiredMonitoringDashboard verifies that the function
+// desiredMonitoringDashboard correctly creates a monitoring dashboard
+// ConfigMap based on the ControlPlaneTopology value. It ensures no ConfigMap
+// is returned for ExternalTopologyMode and checks for a correct ConfigMap in 
+// other cases.
 func TestDesiredMonitoringDashboard(t *testing.T) {
 	type testInputs struct {
 		infraStatus configv1.InfrastructureStatus
@@ -141,7 +143,7 @@ func TestDesiredMonitoringDashboard(t *testing.T) {
 		output      testOutputs
 	}{
 		{
-			description: "No dashboad if topology is external",
+			description: "No dashboard if topology is external",
 			inputs: testInputs{
 				infraStatus: configv1.InfrastructureStatus{
 					ControlPlaneTopology: configv1.ExternalTopologyMode,
@@ -152,7 +154,7 @@ func TestDesiredMonitoringDashboard(t *testing.T) {
 			},
 		},
 		{
-			description: "Dashboard if topology is not external",
+			description: "Dashboard expected if topology is not external",
 			inputs: testInputs{
 				infraStatus: configv1.InfrastructureStatus{
 					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
@@ -1,0 +1,180 @@
+package monitoringdashboard
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress-operator-dashboard",
+			Namespace: "openshift-config-managed",
+			Labels: map[string]string{
+				"console.openshift.io/dashboard": "true",
+			},
+		},
+		Data: map[string]string{
+			"dashboard.json": dashboardEmbed,
+		},
+	}
+}
+
+// TestDashboardNeedsUpdate verifies that we update the dashboard when needed
+// and we do not when not needed
+func TestDashboardNeedsUpdate(t *testing.T) {
+	type testInputs struct {
+		current *corev1.ConfigMap
+		desired *corev1.ConfigMap
+	}
+	type testOutputs struct {
+		res bool
+	}
+	testCases := []struct {
+		description string
+		inputs      testInputs
+		output      testOutputs
+	}{
+		{
+			description: "Identicals configmaps",
+			inputs: testInputs{
+				current: newConfigMap(),
+				desired: newConfigMap(),
+			},
+			output: testOutputs{
+				res: false,
+			},
+		},
+		{
+			description: "Missing dashboard in configmap",
+			inputs: testInputs{
+				current: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-controller-dashboard",
+						Namespace: "openshift-config-managed",
+						Labels: map[string]string{
+							"console.openshift.io/dashboard": "true",
+						},
+					},
+					Data: map[string]string{},
+				},
+				desired: newConfigMap(),
+			},
+			output: testOutputs{
+				res: true,
+			},
+		},
+		{
+			description: "Wrong dashboard value",
+			inputs: testInputs{
+				current: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-controller-dashboard",
+						Namespace: "openshift-config-managed",
+						Labels: map[string]string{
+							"console.openshift.io/dashboard": "true",
+						},
+					},
+					Data: map[string]string{
+						"dashboard.json": "corrupted text",
+					},
+				},
+				desired: newConfigMap(),
+			},
+			output: testOutputs{
+				res: true,
+			},
+		},
+		{
+			description: "Second unwanted dashboard",
+			inputs: testInputs{
+				current: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-controller-dashboard",
+						Namespace: "openshift-config-managed",
+						Labels: map[string]string{
+							"console.openshift.io/dashboard": "true",
+						},
+					},
+					Data: map[string]string{
+						"dashboard.json":  dashboardEmbed,
+						"dashboard2.json": dashboardEmbed,
+					},
+				},
+				desired: newConfigMap(),
+			},
+			output: testOutputs{
+				res: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			expected := tc.output.res
+			actual := dashboardNeedsUpdate(tc.inputs.current, tc.inputs.desired)
+			if expected != actual {
+				t.Errorf("expected %v, got %v", expected, actual)
+			}
+		})
+	}
+}
+
+// TestDesiredRouterCertsGlobalSecret verifies that we get the expected global
+// secret for the default ingresscontroller and for various combinations of
+// ingresscontrollers and default certificate secrets.
+func TestDesiredMonitoringDashboard(t *testing.T) {
+	type testInputs struct {
+		infraStatus configv1.InfrastructureStatus
+	}
+	type testOutputs struct {
+		configMap *corev1.ConfigMap
+	}
+	testCases := []struct {
+		description string
+		inputs      testInputs
+		output      testOutputs
+	}{
+		{
+			description: "No dashboad if topology is external",
+			inputs: testInputs{
+				infraStatus: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.ExternalTopologyMode,
+				},
+			},
+			output: testOutputs{
+				configMap: nil,
+			},
+		},
+		{
+			description: "Dashboard if topology is not external",
+			inputs: testInputs{
+				infraStatus: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
+				},
+			},
+			output: testOutputs{
+				configMap: newConfigMap(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			expected := tc.output.configMap
+			actual := desiredMonitoringDashboard(context.TODO(), tc.inputs.infraStatus)
+			if expected == nil && actual != nil {
+				t.Errorf("expected %v, got %v", expected, actual)
+			} else if expected != nil && actual == nil {
+				t.Errorf("expected %v, got %v", expected, actual)
+			} else if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("expected %v, got %v", expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
+++ b/pkg/operator/controller/monitoring-dashboard/monitoring_dashboard_test.go
@@ -20,7 +20,7 @@ func newConfigMap() *corev1.ConfigMap {
 			},
 		},
 		Data: map[string]string{
-			"dashboard.json": dashboardJSON,
+			DashboardFileName: dashboardJSON,
 		},
 	}
 }
@@ -81,7 +81,7 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"dashboard.json": "corrupted text",
+						DashboardFileName: "corrupted text",
 					},
 				},
 				desired: newConfigMap(),
@@ -102,7 +102,7 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"dashboard.json":  dashboardJSON,
+						DashboardFileName: dashboardJSON,
 						"dashboard2.json": dashboardJSON,
 					},
 				},
@@ -122,7 +122,7 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 						Labels:    map[string]string{},
 					},
 					Data: map[string]string{
-						"dashboard.json": dashboardJSON,
+						DashboardFileName: dashboardJSON,
 					},
 				},
 				desired: newConfigMap(),
@@ -143,7 +143,7 @@ func TestDashboardNeedsUpdate(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						"dashboard.json": dashboardJSON,
+						DashboardFileName: dashboardJSON,
 					},
 				},
 				desired: newConfigMap(),
@@ -223,7 +223,7 @@ func TestDesiredMonitoringDashboard(t *testing.T) {
 						ResourceVersion: "32",
 					},
 					Data: map[string]string{
-						"dashboard.json": dashboardJSON,
+						DashboardFileName: dashboardJSON,
 					},
 				},
 			},
@@ -238,7 +238,7 @@ func TestDesiredMonitoringDashboard(t *testing.T) {
 						ResourceVersion: "32",
 					},
 					Data: map[string]string{
-						"dashboard.json": dashboardJSON,
+						DashboardFileName: dashboardJSON,
 					},
 				},
 			},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	monitoringdashboard "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/monitoring-dashboard"
 	routemetricscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/route-metrics"
 	errorpageconfigmapcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/sync-http-error-code-configmap"
 	"github.com/openshift/library-go/pkg/operator/onepodpernodeccontroller"
@@ -272,6 +273,11 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	// Set up the route metrics controller.
 	if _, err := routemetricscontroller.New(mgr, config.Namespace); err != nil {
 		return nil, fmt.Errorf("failed to create route metrics controller: %w", err)
+	}
+
+	// Set up the route monitoring dashboard controller.
+	if _, err := monitoringdashboard.New(mgr); err != nil {
+		return nil, fmt.Errorf("failed to create monitoring dashboard controller: %w", err)
 	}
 
 	// Set up the gatewayclass controller.  This controller is unmanaged by

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -81,6 +81,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouteMetricsControllerRouteAndNamespaceSelector", TestRouteMetricsControllerRouteAndNamespaceSelector)
 		t.Run("TestSetIngressControllerResponseHeaders", TestSetIngressControllerResponseHeaders)
 		t.Run("TestSetRouteResponseHeaders", TestSetRouteResponseHeaders)
+		t.Run("TestDashboardCreation", TestDashboardCreation)
 	})
 
 	t.Run("serial", func(t *testing.T) {

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -81,7 +81,6 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouteMetricsControllerRouteAndNamespaceSelector", TestRouteMetricsControllerRouteAndNamespaceSelector)
 		t.Run("TestSetIngressControllerResponseHeaders", TestSetIngressControllerResponseHeaders)
 		t.Run("TestSetRouteResponseHeaders", TestSetRouteResponseHeaders)
-		t.Run("TestDashboardCreation", TestDashboardCreation)
 	})
 
 	t.Run("serial", func(t *testing.T) {
@@ -114,5 +113,6 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)
 		t.Run("TestHostNetworkPortBinding", TestHostNetworkPortBinding)
+		t.Run("TestDashboardCreation", TestDashboardCreation)
 	})
 }

--- a/test/e2e/dashboard_test.go
+++ b/test/e2e/dashboard_test.go
@@ -5,6 +5,12 @@ package e2e
 
 import (
 	"context"
+	"testing"
+	"time"
+
+	monitoringdashboard "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/monitoring-dashboard"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	monitoringdashboard "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/monitoring-dashboard"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,12 +35,12 @@ func TestDashboardCreation(t *testing.T) {
 	}
 	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), monitoringdashboard.ConfigMapName(), dashboardCM); err != nil {
-			t.Logf("failed to get configmap: %v", err)
+			t.Logf("failed to get configmap: %v, retrying...", err)
 			return false, nil
 		}
 		dashboard, ok := dashboardCM.Data["dashboard.json"]
 		if !(ok && len(dashboard) > 0) {
-			t.Logf("Controller did not modify back the configmap")
+			t.Logf("Controller did not modify the ConfigMap back to its original state, retrying...")
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/dashboard_test.go
+++ b/test/e2e/dashboard_test.go
@@ -1,0 +1,64 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	monitoringdashboard "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/monitoring-dashboard"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"testing"
+	"time"
+)
+
+func TestDashboardCreation(t *testing.T) {
+	t.Parallel()
+
+	dashboardCM := &corev1.ConfigMap{}
+	if err := kclient.Get(context.TODO(), monitoringdashboard.ConfigMapName(), dashboardCM); err != nil {
+		t.Fatalf("failed to get dashboard configmap: %v", err)
+	}
+
+	// Change dashboard in configmap and check for update from the operator
+	dashboardCM.Data = map[string]string{
+		"dashboard.json": "",
+	}
+	if err := kclient.Update(context.TODO(), dashboardCM); err != nil {
+		t.Fatalf("failed to update dashboard configmap: %v", err)
+	}
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), monitoringdashboard.ConfigMapName(), dashboardCM); err != nil {
+			t.Logf("failed to get configmap: %v", err)
+			return false, nil
+		}
+		dashboard, ok := dashboardCM.Data["dashboard.json"]
+		if !(ok && len(dashboard) > 0) {
+			t.Logf("Controller did not modify back the configmap")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe configmap: %v", err)
+	}
+
+	// Delete configmap and check for update from the operator
+	dashboardCM.Data = map[string]string{
+		"dashboard.json": "",
+	}
+	if err := kclient.Delete(context.TODO(), dashboardCM); err != nil {
+		t.Fatalf("failed to delete dashboard configmap: %v", err)
+	}
+	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), monitoringdashboard.ConfigMapName(), dashboardCM); err != nil {
+			t.Logf("failed to get configmap: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to observe configmap: %v", err)
+	}
+
+}


### PR DESCRIPTION
This PR add a new controller to manage a configmap to deploy monitoring dashboard.

The configmap is deployed as long as the controlPlaneTopology is not set to external.

The dashboard itself is there as an example but I wanted to open the PR to start getting review on the controller part.

I am going to look more precisely about what would be the most valuable to display in the dashboard.