### PR TITLE
OCPBUGS-16089: Set spec.subdomain on the canary route

### DIFF
--- a/pkg/operator/controller/canary/controller.go
+++ b/pkg/operator/controller/canary/controller.go
@@ -280,7 +280,7 @@ func (r *reconciler) startCanaryRoutePolling(stop <-chan struct{}) error {
 		err = probeRouteEndpoint(route)
 		if err != nil {
 			log.Error(err, "error performing canary route check")
-			SetCanaryRouteReachableMetric(route.Spec.Host, false)
+			SetCanaryRouteReachableMetric(getRouteHost(route), false)
 			successiveFail += 1
 			// Mark the default ingress controller degraded after 5 successive canary check failures
 			if successiveFail >= canaryCheckFailureCount {
@@ -291,7 +291,7 @@ func (r *reconciler) startCanaryRoutePolling(stop <-chan struct{}) error {
 			return
 		}
 
-		SetCanaryRouteReachableMetric(route.Spec.Host, true)
+		SetCanaryRouteReachableMetric(getRouteHost(route), true)
 		if err := r.setCanaryPassingStatusCondition(); err != nil {
 			log.Error(err, "error updating canary status condition")
 		}

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -1,6 +1,7 @@
 package canary
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -33,6 +34,7 @@ func Test_desiredCanaryRoute(t *testing.T) {
 
 	assert.Equal(t, route.Name, expectedRouteName.Name, "unexpected route name")
 	assert.Equal(t, route.Namespace, expectedRouteName.Namespace, "unexpected route namespace")
+	assert.Equal(t, route.Spec.Subdomain, "canary-openshift-ingress-canary", "unexpected route spec.subdomain")
 
 	expectedAnnotations := map[string]string{
 		"haproxy.router.openshift.io/balance": "roundrobin",
@@ -76,6 +78,20 @@ func Test_canaryRouteChanged(t *testing.T) {
 			description: "if nothing changes",
 			mutate:      func(_ *routev1.Route) {},
 			expect:      false,
+		},
+		{
+			description: "if route spec.host is changes",
+			mutate: func(route *routev1.Route) {
+				route.Spec.Host = "test"
+			},
+			expect: true,
+		},
+		{
+			description: "if route spec.subdomain changes",
+			mutate: func(route *routev1.Route) {
+				route.Spec.Subdomain = "test"
+			},
+			expect: true,
 		},
 		{
 			description: "if route spec.To changes",
@@ -122,6 +138,70 @@ func Test_canaryRouteChanged(t *testing.T) {
 					t.Error("canaryRouteChanged does not behave as a fixed point function")
 				}
 			}
+		})
+	}
+}
+
+// Test_getRouteHost verifies that getRouteHost returns the expected value for a
+// route.
+func Test_getRouteHost(t *testing.T) {
+	canaryRoute := func(ingresses []routev1.RouteIngress) *routev1.Route {
+		return &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-ingress-canary",
+				Name:      "canary",
+			},
+			Status: routev1.RouteStatus{
+				Ingress: ingresses,
+			},
+		}
+	}
+	admittedBy := func(names ...string) []routev1.RouteIngress {
+		ingresses := []routev1.RouteIngress{}
+		for _, name := range names {
+			ingress := routev1.RouteIngress{
+				RouterName: name,
+				Host:       fmt.Sprintf("%s.apps.example.xyz", name),
+			}
+			ingresses = append(ingresses, ingress)
+		}
+		return ingresses
+	}
+	testCases := []struct {
+		name   string
+		route  *routev1.Route
+		expect string
+	}{
+		{
+			name:   "nil route",
+			route:  nil,
+			expect: "",
+		},
+		{
+			name:   "not admitted route",
+			route:  canaryRoute(admittedBy()),
+			expect: "",
+		},
+		{
+			name:   "admitted by some other ingresscontroller",
+			route:  canaryRoute(admittedBy("foo")),
+			expect: "",
+		},
+		{
+			name:   "admitted by default ingresscontroller",
+			route:  canaryRoute(admittedBy("default")),
+			expect: "default.apps.example.xyz",
+		},
+		{
+			name:   "admitted by default and others",
+			route:  canaryRoute(admittedBy("foo", "default", "bar")),
+			expect: "default.apps.example.xyz",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, getRouteHost(tc.route))
 		})
 	}
 }

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -73,7 +73,10 @@ func Test_desiredCanaryRoute(t *testing.T) {
 
 	expectedOwnerRefs := []metav1.OwnerReference{daemonsetRef}
 	if !cmp.Equal(route.OwnerReferences, expectedOwnerRefs) {
-		t.Errorf("expected service owner references %#v, but got %#v", expectedOwnerRefs, route.OwnerReferences)
+		t.Errorf("expected route owner references %#v, but got %#v", expectedOwnerRefs, route.OwnerReferences)
+	}
+	if !cmp.Equal(service.OwnerReferences, expectedOwnerRefs) {
+		t.Errorf("expected service owner references %#v, but got %#v", expectedOwnerRefs, service.OwnerReferences)
 	}
 
 	expectedTLS := &routev1.TLSConfig{

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -68,13 +68,14 @@ func TestCanaryRoute(t *testing.T) {
 
 		return true, nil
 	})
-
 	if err != nil {
 		t.Fatalf("failed to observe canary route: %v", err)
 	}
 
+	canaryRouteHost := getRouteHost(t, canaryRoute, defaultName.Name)
+
 	image := deployment.Spec.Template.Spec.Containers[0].Image
-	clientPod := buildCanaryCurlPod("canary-route-check", canaryRoute.Namespace, image, canaryRoute.Spec.Host)
+	clientPod := buildCanaryCurlPod("canary-route-check", canaryRoute.Namespace, image, canaryRouteHost)
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -138,6 +138,8 @@ func TestClientTLS(t *testing.T) {
 		t.Fatalf("failed to observe route %q: %v", routeName, err)
 	}
 
+	routeHost := getRouteHost(t, route, ic.Name)
+
 	// We need an IP address to which to send requests.  The test client
 	// runs inside the cluster, so we can use the custom router's internal
 	// service address.
@@ -260,7 +262,7 @@ func TestClientTLS(t *testing.T) {
 		expectAllowed: false,
 	}}
 	for _, tc := range optionalPolicyTestCases {
-		_, err := curlGetStatusCode(t, clientPod, tc.cert, route.Spec.Host, service.Spec.ClusterIP, true)
+		_, err := curlGetStatusCode(t, clientPod, tc.cert, routeHost, service.Spec.ClusterIP, true)
 		if err == nil && !tc.expectAllowed {
 			t.Errorf("%q: expected error, got success", tc.description)
 		}
@@ -306,7 +308,7 @@ func TestClientTLS(t *testing.T) {
 		expectAllowed: false,
 	}}
 	for _, tc := range requiredPolicyTestCases {
-		_, err := curlGetStatusCode(t, clientPod, tc.cert, route.Spec.Host, service.Spec.ClusterIP, true)
+		_, err := curlGetStatusCode(t, clientPod, tc.cert, routeHost, service.Spec.ClusterIP, true)
 		if err == nil && !tc.expectAllowed {
 			t.Errorf("%q: expected error, got success", tc.description)
 		}
@@ -1010,6 +1012,8 @@ func TestMTLSWithCRLs(t *testing.T) {
 				t.Fatalf("failed to observe route %q: %v", routeName, err)
 			}
 
+			routeHost := getRouteHost(t, route, ic.Name)
+
 			// If the canary route is used, normally the default ingress controller will handle the request, but by
 			// using curl's --resolve flag, we can send an HTTP request intended for the canary pod directly to our
 			// ingress controller instead. In order to do that, we need the ingress controller's service IP.
@@ -1020,12 +1024,12 @@ func TestMTLSWithCRLs(t *testing.T) {
 			}
 
 			for certName := range tcCerts.ClientCerts.Accepted {
-				if _, err := curlGetStatusCode(t, clientPod, certName, route.Spec.Host, service.Spec.ClusterIP, false); err != nil {
+				if _, err := curlGetStatusCode(t, clientPod, certName, routeHost, service.Spec.ClusterIP, false); err != nil {
 					t.Errorf("Failed to curl route with cert %q: %v", certName, err)
 				}
 			}
 			for certName := range tcCerts.ClientCerts.Rejected {
-				if httpStatusCode, err := curlGetStatusCode(t, clientPod, certName, route.Spec.Host, service.Spec.ClusterIP, false); err != nil {
+				if httpStatusCode, err := curlGetStatusCode(t, clientPod, certName, routeHost, service.Spec.ClusterIP, false); err != nil {
 					if httpStatusCode == 0 {
 						// TLS/SSL verification failures result in a 0 http status code (no connection is made to the backend, so no http status code is returned).
 						continue

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2584,6 +2584,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
 		t.Fatalf("failed to get the console route: %v", err)
 	}
+	routeHost := getRouteHost(t, route, ic.Name)
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "headertest",
@@ -2601,8 +2602,8 @@ func TestHTTPHeaderCapture(t *testing.T) {
 						"-H", "x-test-header-1:foo",
 						"-H", "x-test-header-2:bar",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
-						"https://" + route.Spec.Host,
+						routeHost + ":443:" + podList.Items[0].Status.PodIP,
+						"https://" + routeHost,
 					},
 				},
 			},
@@ -2724,6 +2725,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
 		t.Fatalf("failed to get the console route: %v", err)
 	}
+	routeHost := getRouteHost(t, route, ic.Name)
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cookietest",
@@ -2742,8 +2744,8 @@ func TestHTTPCookieCapture(t *testing.T) {
 						"-H", "cookie:foo=xyzzypop",
 						"-H", "cookie:foobaz=abc",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
-						"https://" + route.Spec.Host,
+						routeHost + ":443:" + podList.Items[0].Status.PodIP,
+						"https://" + routeHost,
 					},
 				},
 			},

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -688,3 +688,27 @@ func assertDeletedWaitForCleanup(t *testing.T, cl client.Client, thing client.Ob
 		t.Fatalf("Timed out waiting for %s to be cleaned up: %v", thing.GetName(), err)
 	}
 }
+
+// getRouteHost returns the host name of the given route for the named
+// IngressController.  If the IngressController has not added its host name to
+// the route's status, this function causes a fatal error.  For simplicity, this
+// function does not check the "Admitted" status condition, so it will return
+// the host name if it is set even if the IngressController has rejected the
+// route.
+func getRouteHost(t *testing.T, route *routev1.Route, router string) string {
+	t.Helper()
+
+	if route == nil {
+		t.Fatal("route is nil")
+		return ""
+	}
+
+	for _, ingress := range route.Status.Ingress {
+		if ingress.RouterName == router {
+			return ingress.Host
+		}
+	}
+
+	t.Fatalf("failed to find host name for default router in route: %#v", route)
+	return ""
+}


### PR DESCRIPTION
#### `Test_desiredCanaryRoute`: Fix owner reference check

Change `Test_desiredCanaryRoute` to check both the route's and the service's owner references, and print the correct error message if either the route or the service has an unexpected value.

Before this change, `Test_desiredCanaryRoute` checked the route's owner references but erroneously referred to the service in the failure message if the route had an unexpected value.

* `pkg/operator/controller/canary/route_test.go` (`Test_desiredCanaryRoute`): Fix checks for owner references.


#### `Test_desiredCanaryRoute`: Use testify

* `pkg/operator/controller/canary/route_test.go` (`Test_desiredCanaryRoute`): Use `assert.Equal` and `assert.True` from the testify package.


#### Set `spec.subdomain` on the canary route

Set `spec.subdomain` on the canary route so that the route is exposed using the respective domain of any shard that exposes the route.

Before this change, the canary route specified neither `spec.subdomain` nor `spec.host`, and so the API server would set a default value for `spec.host` using the cluster ingress domain.  If the cluster ingress domain didn't match the default IngressController's domain, then this would cause canary checks to fail.

For example, the cluster-admin could end up in this situation by first using the cluster ingress config's `appsDomain` option to set a custom domain different from the domain of the default IngressController and then deleting the canary route so that it would be recreated with the custom domain.  This change ensures that the canary route continues to work in this example.

* `pkg/operator/controller/canary/controller.go` (`startCanaryRoutePolling`):
* `pkg/operator/controller/canary/http.go` (`probeRouteEndpoint`): Use the new `getRouteHost` helper function.
* `pkg/operator/controller/canary/route.go` (`canaryRouteChanged`): Check whether `spec.host` or `spec.subdomain` have changed, and update them if they have.
(`desiredCanaryService`): Specify `spec.subdomain`.
(`getRouteHost`): New function.  Return the host name of the route for the default IngressController.
* `pkg/operator/controller/canary/route_test.go` (`Test_desiredCanaryRoute`): Verify that the route has the expected value for `spec.subdomain`.
(`Test_canaryRouteChanged`): Verify that `canaryRouteChanged` checks and updates the `spec.host` and `spec.subdomain` fields.
(`Test_getRouteHost`): New test.  Verify that `getRouteHost` behaves correctly.
* `test/e2e/canary_test.go` (`TestCanaryRoute`):
* `test/e2e/client_tls_test.go` (`TestClientTLS`, `TestMTLSWithCRLs`): 
* `test/e2e/operator_test.go` (`TestHTTPHeaderCapture`, `TestHTTPCookieCapture`): 
* `test/e2e/router_compression_test.go` (`TestRouterCompressionOperation`)
(`testCompressionPolicy`, `getHttpHeaders`): Use the new `getRouteHost` test helper function.
* `test/e2e/util_test.go` (`getRouteHost`): New test helper function.  Return the host name of the route for the default IngressController.

---

~/hold~
I'll need to rebase after #880 merges.