### PR TITLE
WIP: OCPBUGS-8526: gateway-service-dns: Use gateway addresses to configure DNS

### DIFF
--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -67,7 +67,7 @@ func Test_Reconcile(t *testing.T) {
 			Hostname: hostname,
 		}
 	}
-	dnsrecord := func(name, dnsName string, targets ...string) *iov1.DNSRecord {
+	dnsrecord := func(name, dnsName string, recordType string, targets ...string) *iov1.DNSRecord {
 		return &iov1.DNSRecord{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "openshift-ingress",
@@ -75,7 +75,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			Spec: iov1.DNSRecordSpec{
 				DNSName:             dnsName,
-				RecordType:          iov1.CNAMERecordType,
+				RecordType:          iov1.DNSRecordType(recordType),
 				Targets:             targets,
 				RecordTTL:           30,
 				DNSManagementPolicy: iov1.ManagedDNS,
@@ -138,8 +138,8 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-76456f8647-wildcard", "*.prod.example.com.", "lb.example.com"),
-				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-76456f8647-wildcard", "*.prod.example.com.", "CNAME", "lb.example.com"),
+				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "CNAME", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},
@@ -161,12 +161,12 @@ func Test_Reconcile(t *testing.T) {
 					},
 					ingHost("newlb.example.com"),
 				),
-				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "oldlb.example.com"),
+				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "CNAME", "oldlb.example.com"),
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate:     []client.Object{},
 			expectUpdate: []client.Object{
-				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "newlb.example.com"),
+				dnsrecord("example-gateway-7bdcfc8f68-wildcard", "*.example.com.", "CNAME", "newlb.example.com"),
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			reconcileRequest: req("openshift-ingress", "example-gateway"),
 			expectCreate: []client.Object{
-				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "lb.example.com"),
+				dnsrecord("example-gateway-64754456b8-wildcard", "*.stage.example.com.", "CNAME", "lb.example.com"),
 			},
 			expectUpdate: []client.Object{},
 		},

--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Test_Reconcile(t *testing.T) {
-	gw := func(name string, listeners ...gatewayapiv1beta1.Listener) *gatewayapiv1beta1.Gateway {
+	gw := func(name string, listeners []gatewayapiv1beta1.Listener) *gatewayapiv1beta1.Gateway {
 		return &gatewayapiv1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "openshift-ingress",
@@ -100,7 +100,7 @@ func Test_Reconcile(t *testing.T) {
 		{
 			name: "gateway with no listeners",
 			existingObjects: []runtime.Object{
-				gw("example-gateway"),
+				gw("example-gateway", []gatewayapiv1beta1.Listener{}),
 				svc(
 					"example-gateway",
 					map[string]string{
@@ -121,9 +121,11 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{
 				gw(
 					"example-gateway",
-					l("stage-http", "*.stage.example.com", 80),
-					l("stage-https", "*.stage.example.com", 443),
-					l("prod-https", "*.prod.example.com", 443),
+					[]gatewayapiv1beta1.Listener{
+						l("stage-http", "*.stage.example.com", 80),
+						l("stage-https", "*.stage.example.com", 443),
+						l("prod-https", "*.prod.example.com", 443),
+					},
 				),
 				svc(
 					"example-gateway",
@@ -148,8 +150,10 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{
 				gw(
 					"example-gateway",
-					l("http", "*.example.com", 80),
-					l("https", "*.example.com", 443),
+					[]gatewayapiv1beta1.Listener{
+						l("http", "*.example.com", 80),
+						l("https", "*.example.com", 443),
+					},
 				),
 				svc(
 					"example-gateway",
@@ -174,8 +178,10 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{
 				gw(
 					"example-gateway",
-					l("stage-http", "*.stage.example.com", 80),
-					l("stage-https", "*.stage.example.com", 443),
+					[]gatewayapiv1beta1.Listener{
+						l("stage-http", "*.stage.example.com", 80),
+						l("stage-https", "*.stage.example.com", 443),
+					},
 				),
 				svc(
 					"example-gateway",


### PR DESCRIPTION
#### gateway-service-dns: `Test_Reconcile`: Parameterize record type

* `pkg/operator/controller/gateway-service-dns/controller_test.go` (`Test_Reconcile`): Change `dnsrecord` helper to parameterize the DNS record type in test cases for `Test_Reconcile`.


#### gateway-service-dns: `Test_Reconcile`: Change listeners to slice

* `pkg/operator/controller/gateway-service-dns/controller_test.go` (`Test_Reconcile`): Change `gw` helper's `listeners` parameter from a variadic parameter to slice.


#### gateway-service-dns: Use gateway addresses to configure DNS records

* `pkg/operator/controller/gateway-service-dns/controller.go` (`managedByIstioLabelKey`): Remove const, which is no longer needed after subsequent changes.
(`NewUnmanaged`): Remove the watch on services and the watch's associated predicates. Enqueue reconciliation requests for gateways instead of services.  Define a predicate that checks the gateway addresses, using the new `gatewayAddressesChanged` helper function, and use this predicate to enqueue a reconciliation request for a gateway when any of its addresses changes.
(`gatewayAddressesChanged`): New function.  Return a Boolean value indicating whether the given gateway's addresses have changed.
(`Reconcile`): Expect the reconciliation request to be for a gateway instead of a service.  Use the new `getGatewayAddresses` helper function to get the gateway's addresses, and pass these addresses to `ensureDNSRecordsForGateway` and `deleteStaleDNSRecordsForGateway`.
(`getGatewayAddresses`): New helper function.  Return a list of addresses that can be used as targets for a DNSRecord CR, as well as a record type.
(`ensureDNSRecordsForGateway`): Replace the `service` parameter with "targets" and "recordType" parameters.  Pass `targets` and `recordType` to `EnsureDNSRecord`.  Change the owner reference for the DNSRecord CR to specify the gateway instead of the service.
(`deleteStaleDNSRecordsForGateway`): Replace the `service` parameter with a "targets" parameter.  Use the new `targets` parameter and existing `domains` parameter to preserve any DNSRecord CR that has both a valid domain and a valid target.
* `pkg/operator/controller/gateway-service-dns/controller_test.go` (`Test_Reconcile`): Add addresses to gateway test inputs, and remove services as test inputs.  Add a test case for a gateway with an address but no listeners, as well as a test case for various combinations of addresses.
(`Test_gatewayAddressesChanged`): New test.  Verify that `gatewayAddressesChanged` behaves as expected.
* `pkg/resources/dnsrecord/dns.go` (`EnsureDNSRecord`): Replace the `service` parameter with "targets" and "recordType" parameters.  Pass these new parameters to `desiredDNSRecord`.
(`desiredDNSRecord`): Replace the `service` parameter with "targets" and "recordType" parameters.  Move service-specific logic from here...
(`desiredWildcardDNSRecord`): ...to here.


