### PR TITLE
OCPBUGS-9037: Change Canary to use passthrough route

### DIFF
--- a/pkg/manifests/assets/canary/daemonset.yaml
+++ b/pkg/manifests/assets/canary/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-          - containerPort: 8080
+          - containerPort: 8443
             protocol: TCP
           - containerPort: 8888
             protocol: TCP
@@ -33,11 +33,24 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          volumeMounts:
+          - name: cert
+            mountPath: /etc/tls-cert
+          env:
+          - name: TLS_CERT
+            value: /etc/tls-cert/tls.crt
+          - name: TLS_KEY
+            value: /etc/tls-cert/tls.key
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
         - key: node-role.kubernetes.io/infra
           operator: Exists
+      volumes:
+      - name: cert
+        secret:
+          secretName: canary-serving-cert
+          defaultMode: 0420
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/pkg/manifests/assets/canary/route.yaml
+++ b/pkg/manifests/assets/canary/route.yaml
@@ -8,12 +8,12 @@ metadata:
     haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   port:
-    targetPort: 8080-tcp
+    targetPort: 8443-tcp
   to:
     kind: Service
     # Service name set at run time
     weight: 100
   tls:
-    termination: edge
+    termination: passthrough
     insecureEdgeTerminationPolicy: Redirect
   wildcardPolicy: None

--- a/pkg/manifests/assets/canary/service.yaml
+++ b/pkg/manifests/assets/canary/service.yaml
@@ -2,14 +2,17 @@
 # Specific values are applied at runtime
 kind: Service
 apiVersion: v1
-# name and namespace are set at runtime.
+metadata:
+  # name and namespace are set at runtime.
+  annotations:
+      service.beta.openshift.io/serving-cert-secret-name: canary-serving-cert
 spec:
   type: ClusterIP
   ports:
-  - name: 8080-tcp
-    port: 8080
+  - name: 8443-tcp
+    port: 8443
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8443
   - name: 8888-tcp
     port: 8888
     protocol: TCP

--- a/pkg/operator/controller/canary/daemonset_test.go
+++ b/pkg/operator/controller/canary/daemonset_test.go
@@ -190,6 +190,41 @@ func Test_canaryDaemonsetChanged(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			description: "if canary daemonset environment changed",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "foo", Value: "bar"})
+			},
+			expect: true,
+		},
+		{
+			description: "if canary daemonset volume mount changed",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].VolumeMounts = append(ds.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "foo", MountPath: "/bar"})
+			},
+			expect: true,
+		},
+		{
+			description: "if canary daemonset volume changed",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, corev1.Volume{
+					Name: "foo",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "bar",
+						},
+					},
+				})
+			},
+			expect: true,
+		},
+		{
+			description: "if canary daemonset ports changed",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.Containers[0].Ports = append(ds.Spec.Template.Spec.Containers[0].Ports, corev1.ContainerPort{Name: "foo", ContainerPort: 1234})
+			},
+			expect: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -62,7 +62,7 @@ func Test_desiredCanaryRoute(t *testing.T) {
 	assert.Equal(t, service.OwnerReferences, expectedOwnerRefs, "unexpected service owner references")
 
 	expectedTLS := &routev1.TLSConfig{
-		Termination:                   routev1.TLSTerminationEdge,
+		Termination:                   routev1.TLSTerminationPassthrough,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
 	assert.Equal(t, route.Spec.TLS, expectedTLS, "unexpected route TLS config")

--- a/pkg/operator/controller/canary/service.go
+++ b/pkg/operator/controller/canary/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
@@ -12,23 +14,71 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ensureCanaryService ensures the ingress canary service exists
+// CanaryPorts is the list of ports exposed by the canary service
+var CanaryPorts = []int32{8443, 8888}
+
+// ensureCanaryService ensures the ingress canary service exists.
 func (r *reconciler) ensureCanaryService(daemonsetRef metav1.OwnerReference) (bool, *corev1.Service, error) {
 	desired := desiredCanaryService(daemonsetRef)
 	haveService, current, err := r.currentCanaryService()
 	if err != nil {
 		return false, nil, err
 	}
-	if haveService {
-		return true, current, nil
+	switch {
+	case haveService:
+		if updated, err := r.updateCanaryService(current, desired); err != nil {
+			return true, current, err
+		} else if updated {
+			return r.currentCanaryService()
+		}
+	case !haveService:
+		if err := r.createCanaryService(desired); err != nil {
+			return false, nil, err
+		}
+		return true, desired, nil
 	}
-	if err := r.createCanaryService(desired); err != nil {
-		return false, nil, err
-	}
-	return true, desired, nil
+	return true, current, nil
 }
 
-// currentCanaryService gets the current ingress canary service resource
+// updateCanaryService updates the canary service if an appropriate change is detected.
+func (r *reconciler) updateCanaryService(current, desired *corev1.Service) (bool, error) {
+	changed, updated := canaryServiceChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		return false, fmt.Errorf("failed to update canary service %s/%s: %w", updated.Namespace, updated.Name, err)
+	}
+	log.Info("updated canary service", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+	return true, nil
+}
+
+// canaryServiceChanged returns true if the canary service's ports or annotations have changed. If a change occurred, it
+// also returns a copy of the service with the relevant changes merged.
+func canaryServiceChanged(current, desired *corev1.Service) (bool, *corev1.Service) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !cmp.Equal(current.Spec.Ports, desired.Spec.Ports, cmpopts.EquateEmpty()) {
+		updated.Spec.Ports = desired.Spec.Ports
+		changed = true
+	}
+	if !cmp.Equal(current.Annotations, desired.Annotations, cmpopts.EquateEmpty()) {
+		updated.Annotations = desired.Annotations
+		changed = true
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	return true, updated
+}
+
+// currentCanaryService gets the current ingress canary service resource.
 func (r *reconciler) currentCanaryService() (bool, *corev1.Service, error) {
 	current := &corev1.Service{}
 	err := r.client.Get(context.TODO(), controller.CanaryServiceName(), current)
@@ -41,17 +91,17 @@ func (r *reconciler) currentCanaryService() (bool, *corev1.Service, error) {
 	return true, current, nil
 }
 
-// createCanaryService creates the given service resource
+// createCanaryService creates the given service resource.
 func (r *reconciler) createCanaryService(service *corev1.Service) error {
 	if err := r.client.Create(context.TODO(), service); err != nil {
-		return fmt.Errorf("failed to create canary service %s/%s: %v", service.Namespace, service.Name, err)
+		return fmt.Errorf("failed to create canary service %s/%s: %w", service.Namespace, service.Name, err)
 	}
 
 	log.Info("created canary service", "namespace", service.Namespace, "name", service.Name)
 	return nil
 }
 
-// desiredCanaryService returns the desired canary service read in from manifests
+// desiredCanaryService returns the desired canary service read in from manifests.
 func desiredCanaryService(daemonsetRef metav1.OwnerReference) *corev1.Service {
 	s := manifests.CanaryService()
 

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -110,6 +110,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouterCompressionOperation", TestRouterCompressionOperation)
 		t.Run("TestUpdateDefaultIngressControllerSecret", TestUpdateDefaultIngressControllerSecret)
 		t.Run("TestCanaryRoute", TestCanaryRoute)
+		t.Run("TestCanaryWithMTLS", TestCanaryWithMTLS)
 		t.Run("TestRouteHTTP2EnableAndDisableIngressConfig", TestRouteHTTP2EnableAndDisableIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)

--- a/test/http/serve-healthcheck.go
+++ b/test/http/serve-healthcheck.go
@@ -33,11 +33,11 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func listenAndServe(port string) {
-	fmt.Printf("serving on %s\n", port)
-	err := http.ListenAndServe(":"+port, nil)
+func listenAndServeTLS(port, certFile, keyFile string) {
+	fmt.Printf("serving TLS on %s\n", port)
+	err := http.ListenAndServeTLS(":"+port, certFile, keyFile, nil)
 	if err != nil {
-		panic("ListenAndServe: " + err.Error())
+		panic("ListenAndServeTLS: " + err.Error())
 	}
 }
 
@@ -56,17 +56,21 @@ func NewServeHealthCheckCommand() *cobra.Command {
 
 func serveHealthCheck() {
 	http.HandleFunc("/", healthCheckHandler)
+
+	tlsCertFile := os.Getenv("TLS_CERT")
+	tlsKeyFile := os.Getenv("TLS_KEY")
+
 	port := os.Getenv("PORT")
 	if len(port) == 0 {
-		port = "8080"
+		port = "8443"
 	}
-	go listenAndServe(port)
+	go listenAndServeTLS(port, tlsCertFile, tlsKeyFile)
 
 	port = os.Getenv("SECOND_PORT")
 	if len(port) == 0 {
 		port = "8888"
 	}
-	go listenAndServe(port)
+	go listenAndServeTLS(port, tlsCertFile, tlsKeyFile)
 
 	select {}
 }


### PR DESCRIPTION
When the default ingress controller is configured to use mTLS, connecting to edge or reencrypt routes requires the client to have a valid certificate/key pair. There is no way for a user to provide a client certificate or key to the ingress operator, so canary checks using edge encryption fail. This PR changes the canary route to be passthrough and has the canary host handle the TLS handshake, allowing it to function even if mTLS is otherwise required.