### PR TITLE
OCPBUGS-20192: Require non-readonly filesystem in router container

### DIFF
--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -20,6 +20,7 @@ spec:
           securityContext:
             # See https://bugzilla.redhat.com/2007246
             allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: false
           terminationMessagePolicy: FallbackToLogsOnError
           # Merged at runtime.
           env:


### PR DESCRIPTION
Setting the filesystem to read only in the router container prevents it from rendering the haproxy config, and causes haproxy to be unable to start. Adding the security context constraint `readOnlyRootFilesystem: false` makes sure the security profile it is assigned does not require a read only filesystem.