### PR TITLE
OCPBUGS-21803: test/e2e: Add test case for 2000000 maxConnections

### DIFF
--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -71,6 +71,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 		{"set maxconn 12345", 12345, "12345"},
 		{"set maxconn auto", -1, "auto"},
 		{"set maxconn to default", 0, ""},
+		{"set maxconn to 2000000", 2000000, "2000000"},
 	} {
 		t.Log(testCase.description)
 		if err := updateMaxConnections(t, kclient, time.Minute, testCase.maxConnections, icName); err != nil {


### PR DESCRIPTION
This commit adds a test case to verify that the maxConnections setting
can be configured with the absolute upper limit of 2000000, as defined
by the API

```sh
% oc explain ingresscontroller.spec.tuningOptions.maxConnections
KIND:     IngressController
VERSION:  operator.openshift.io/v1

FIELD:    maxConnections <integer>

DESCRIPTION:
     maxConnections defines the maximum number of simultaneous
     connections that can be established per HAProxy process.
     Increasing this value allows each ingress controller pod to
     handle more connections but at the cost of additional system
     resources being consumed. Permitted values are: empty, 0, -1, and
     the range 2000-2000000.
```

This change requires https://github.com/openshift/router/pull/527.

Fixes: https://issues.redhat.com/browse/OCPBUGS-21803.
