### PR TITLE
OCPBUGS-23999: Set owner for default ingress configmap

### DIFF
--- a/vendor/github.com/openshift/api/annotations/annotations.go
+++ b/vendor/github.com/openshift/api/annotations/annotations.go
@@ -1,0 +1,34 @@
+package annotations
+
+// annotation keys
+// NEVER ADD TO THIS LIST.  Annotations need to be owned in the API groups they are associated with, so these constants end
+// up nested in an API group, not top level in the OpenShift namespace.  The items located here are examples of annotations
+// claiming a global namespace key that have never achieved global reach.  In the future, names should be based on the
+// consuming component.
+const (
+	// OpenShiftDisplayName is a common, optional annotation that stores the name displayed by a UI when referencing a resource.
+	OpenShiftDisplayName = "openshift.io/display-name"
+
+	// OpenShiftProviderDisplayNameAnnotation is the name of a provider of a resource, e.g.
+	// "Red Hat, Inc."
+	OpenShiftProviderDisplayNameAnnotation = "openshift.io/provider-display-name"
+
+	// OpenShiftDocumentationURLAnnotation is the url where documentation associated with
+	// a resource can be found.
+	OpenShiftDocumentationURLAnnotation = "openshift.io/documentation-url"
+
+	// OpenShiftSupportURLAnnotation is the url where support for a template can be found.
+	OpenShiftSupportURLAnnotation = "openshift.io/support-url"
+
+	// OpenShiftDescription is a common, optional annotation that stores the description for a resource.
+	OpenShiftDescription = "openshift.io/description"
+
+	// OpenShiftLongDescriptionAnnotation is a resource's long description
+	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -385,6 +385,7 @@ github.com/oklog/ulid
 # github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible => github.com/openshift/api v0.0.0-20240405164942-0cc42a39da45
 ## explicit; go 1.21
 github.com/openshift/api
+github.com/openshift/api/annotations
 github.com/openshift/api/apiserver
 github.com/openshift/api/apiserver/v1
 github.com/openshift/api/apps


### PR DESCRIPTION
This adds annotation which identifies the component used to file issues with this certificate. The annotation is verified by [the test](https://github.com/openshift/origin/blob/master/test/extended/operators/certs.go?rgh-link-date=2023-11-21T09%3A53%3A38Z#L130), so that all certificates would be registered and have owners assigned. More metadata would be added later.

See https://github.com/openshift/enhancements/pull/1502 for proposed workflow with TLS registry