### PR TITLE
OCPBUGS-24531: Update CI and feature for LB scope change

### DIFF
--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -758,12 +758,12 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 			expectMessageContains: "delete",
 		},
 		{
-			name:                        "LoadBalancerService, inconsistent scope on Azure",
-			ic:                          &loadBalancerIngressControllerWithInternalScope,
-			service:                     lbService,
-			platformStatus:              azurePlatformStatus,
-			expectStatus:                operatorv1.ConditionTrue,
-			expectMessageDoesNotContain: "delete",
+			name:                  "LoadBalancerService, inconsistent scope on Azure",
+			ic:                    &loadBalancerIngressControllerWithInternalScope,
+			service:               lbService,
+			platformStatus:        azurePlatformStatus,
+			expectStatus:          operatorv1.ConditionTrue,
+			expectMessageContains: "delete",
 		},
 		{
 			name:           "LoadBalancerService, internal scope",


### PR DESCRIPTION
NOTE: this is only required if the scope change regression isn't fixed.  We do anticipate the resolution of https://issues.redhat.com/browse/OCPBUGS-24044

Update CI and feature surrounding LB scope change

pkg/operator/controller/ingress/load_balancer_service.go
    - Remove Azure and GCP as platforms with mutable scope.  There are no more platforms with mutable scope.
    - Change function loadBalancerServiceIsProgressing to write an error message about the requirement to manually
    delete the service after LB scope changed.  This marks the LB service as Progressing and subsequently, the
    Ingress Operator moves to Progressing until the service is re-created manually.
    
pkg/operator/controller/ingress/status_test.go
    - Change unit test for computeLoadBalancerProgressingStatus to reflect the change in loadBalancerServiceIsProgressing.
    
test/e2e/operator_test.go
    - Change TestScopeChange to perform a check for Progressing all platforms, not just Alibaba, AWS, IBMCloud, and PowerVSP
    - Remove the check for platforms that used to update the service themselves (Azure, GCP)

test/e2e/unmanaged_dns_test.go
    - In TestUnmanagedDNSToManagedDNSInternalIngressController, delete the service on all platforms, not just Alibaba, AWS, IBMCloud, and PowerVSP.
    -  - In TestManagedDNSToUnmanagedDNSIngressController, add a timed poll for updates to the wildcard DNS record.
