### PR TITLE
OCPBUGS-24531: Skip CI for scope change until OCPBUGS-24044 is resolved

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1435,6 +1435,9 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 // should delete and recreate the service automatically.
 func TestScopeChange(t *testing.T) {
 	t.Parallel()
+
+	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
+
 	if infraConfig.Status.PlatformStatus == nil {
 		t.Skip("test skipped on nil platform")
 	}

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -108,6 +108,8 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	t.Parallel()
 
+	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
+
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "managed-migrated"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
@@ -191,6 +193,8 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 // target changes and ensures the new updated target is published to the DNSZone.
 func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	t.Parallel()
+
+	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
 
 	if infraConfig.Status.PlatformStatus == nil {
 		t.Skip("test skipped on nil platform")


### PR DESCRIPTION
Skip CI for scope change until OCPBUGS-24044 is resolved.

test/e2e/unmanaged_dns_test.go
- TestUnmanagedDNSToManagedDNSInternalIngressController
- TestUnmanagedDNSToManagedDNSInternalIngressController

test/e2e/operator_test.go
- TestScopeChange
