### PR TITLE
OCPBUGS-24531: Revert "Merge pull request #1007 from candita/OCPBUGS-24531-SkipScopeChangeTest" and add changes to skip test only for Azure and GCP

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1435,9 +1435,6 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 // should delete and recreate the service automatically.
 func TestScopeChange(t *testing.T) {
 	t.Parallel()
-
-	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
-
 	if infraConfig.Status.PlatformStatus == nil {
 		t.Skip("test skipped on nil platform")
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1442,10 +1442,11 @@ func TestScopeChange(t *testing.T) {
 	supportedPlatforms := map[configv1.PlatformType]struct{}{
 		configv1.AlibabaCloudPlatformType: {},
 		configv1.AWSPlatformType:          {},
-		configv1.AzurePlatformType:        {},
-		configv1.GCPPlatformType:          {},
-		configv1.IBMCloudPlatformType:     {},
-		configv1.PowerVSPlatformType:      {},
+		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
+		//configv1.AzurePlatformType:        {},
+		//configv1.GCPPlatformType:          {},
+		configv1.IBMCloudPlatformType: {},
+		configv1.PowerVSPlatformType:  {},
 	}
 	if _, supported := supportedPlatforms[platform]; !supported {
 		t.Skipf("test skipped on platform %q", platform)

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -108,8 +108,6 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
-
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "managed-migrated"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
@@ -193,8 +191,6 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 // target changes and ensures the new updated target is published to the DNSZone.
 func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	t.Parallel()
-
-	t.Skip("test skipped until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044")
 
 	if infraConfig.Status.PlatformStatus == nil {
 		t.Skip("test skipped on nil platform")

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -108,6 +108,24 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	t.Parallel()
 
+	if infraConfig.Status.PlatformStatus == nil {
+		t.Skip("test skipped on nil platform")
+	}
+	platform := infraConfig.Status.PlatformStatus.Type
+
+	supportedPlatforms := map[configv1.PlatformType]struct{}{
+		configv1.AlibabaCloudPlatformType: {},
+		configv1.AWSPlatformType:          {},
+		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
+		//configv1.AzurePlatformType:    {},
+		//configv1.GCPPlatformType:      {},
+		configv1.IBMCloudPlatformType: {},
+		configv1.PowerVSPlatformType:  {},
+	}
+	if _, supported := supportedPlatforms[platform]; !supported {
+		t.Skipf("test skipped on platform %q", platform)
+	}
+
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "managed-migrated"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
@@ -200,10 +218,11 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	supportedPlatforms := map[configv1.PlatformType]struct{}{
 		configv1.AlibabaCloudPlatformType: {},
 		configv1.AWSPlatformType:          {},
-		configv1.AzurePlatformType:        {},
-		configv1.GCPPlatformType:          {},
-		configv1.IBMCloudPlatformType:     {},
-		configv1.PowerVSPlatformType:      {},
+		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
+		//configv1.AzurePlatformType:    {},
+		//configv1.GCPPlatformType:      {},
+		configv1.IBMCloudPlatformType: {},
+		configv1.PowerVSPlatformType:  {},
 	}
 	if _, supported := supportedPlatforms[platform]; !supported {
 		t.Skipf("test skipped on platform %q", platform)


### PR DESCRIPTION
This reverts commit 7a44e03198ea8efd27ee92ecc41aefa405ef2087, in PR #1007, reversing changes made to 9a872878deb0421105da88c9fe25b1079aa2f2ea, and adds changes to skip tests that will fail for Azure and GCP (only) until OCPBUGS-24044 is resolved.

