### PR TITLE
OCPBUGS-24531: Revert " OCPBUGS-24531 Skip CI for scope change until OCPBUGS-24044 is resolved"

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1442,11 +1442,10 @@ func TestScopeChange(t *testing.T) {
 	supportedPlatforms := map[configv1.PlatformType]struct{}{
 		configv1.AlibabaCloudPlatformType: {},
 		configv1.AWSPlatformType:          {},
-		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
-		//configv1.AzurePlatformType:        {},
-		//configv1.GCPPlatformType:          {},
-		configv1.IBMCloudPlatformType: {},
-		configv1.PowerVSPlatformType:  {},
+		configv1.AzurePlatformType:        {},
+		configv1.GCPPlatformType:          {},
+		configv1.IBMCloudPlatformType:     {},
+		configv1.PowerVSPlatformType:      {},
 	}
 	if _, supported := supportedPlatforms[platform]; !supported {
 		t.Skipf("test skipped on platform %q", platform)

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -108,24 +108,6 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	t.Parallel()
 
-	if infraConfig.Status.PlatformStatus == nil {
-		t.Skip("test skipped on nil platform")
-	}
-	platform := infraConfig.Status.PlatformStatus.Type
-
-	supportedPlatforms := map[configv1.PlatformType]struct{}{
-		configv1.AlibabaCloudPlatformType: {},
-		configv1.AWSPlatformType:          {},
-		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
-		//configv1.AzurePlatformType:    {},
-		//configv1.GCPPlatformType:      {},
-		configv1.IBMCloudPlatformType: {},
-		configv1.PowerVSPlatformType:  {},
-	}
-	if _, supported := supportedPlatforms[platform]; !supported {
-		t.Skipf("test skipped on platform %q", platform)
-	}
-
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "managed-migrated"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
@@ -218,11 +200,10 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	supportedPlatforms := map[configv1.PlatformType]struct{}{
 		configv1.AlibabaCloudPlatformType: {},
 		configv1.AWSPlatformType:          {},
-		// Test skipped on Azure/GCP until resolution in hand for https://issues.redhat.com/browse/OCPBUGS-24044
-		//configv1.AzurePlatformType:    {},
-		//configv1.GCPPlatformType:      {},
-		configv1.IBMCloudPlatformType: {},
-		configv1.PowerVSPlatformType:  {},
+		configv1.AzurePlatformType:        {},
+		configv1.GCPPlatformType:          {},
+		configv1.IBMCloudPlatformType:     {},
+		configv1.PowerVSPlatformType:      {},
 	}
 	if _, supported := supportedPlatforms[platform]; !supported {
 		t.Skipf("test skipped on platform %q", platform)


### PR DESCRIPTION
This reverts commit fe6809626569beeec32c561c9a5fe6a1f249b65d.