### PR TITLE
[release-4.15] OCPBUGS-28928: Prevent upgrades for SHA1 default cert and SHA1 route certs 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,6 @@ require (
 // github.com/operator-framework/operator-sdk.
 replace (
 	bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
-	github.com/openshift/api => github.com/openshift/api v0.0.0-20240131192415-e18b9cc8aa8b
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 	k8s.io/client-go => k8s.io/client-go v0.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -918,8 +918,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v0.1.2-0.20190618234442-a950415649c7/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/openshift/api v0.0.0-20240131192415-e18b9cc8aa8b h1:+oWnXf9QvOlVG4Y5NJ18iiWMbbwsp5CND+jjM3M/qRA=
-github.com/openshift/api v0.0.0-20240131192415-e18b9cc8aa8b/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341 h1:JQpzgk+p24rkgNbNsrNR0yLm63WTKapuT60INU5BqT8=
+github.com/openshift/api v0.0.0-20240522145529-93d6bda14341/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -292,3 +292,12 @@ func GatewayDNSRecordName(gateway *gatewayapiv1beta1.Gateway, host string) types
 		Name:      fmt.Sprintf("%s-%s-wildcard", gateway.Name, util.Hash(host)),
 	}
 }
+
+// AdminGatesConfigMapName returns the namespaced name for the
+// configmap that contains admin gates.
+func AdminGatesConfigMapName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      "admin-gates",
+		Namespace: GlobalMachineSpecifiedConfigNamespace,
+	}
+}

--- a/pkg/operator/controller/route-upgradeable/controller.go
+++ b/pkg/operator/controller/route-upgradeable/controller.go
@@ -1,0 +1,272 @@
+package routeupgradeable
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	controllerName = "route_upgradeable_controller"
+
+	// RouteConfigAdminGate415Key is the key of the admin-gate that will block upgrades from 4.15 to 4.16.
+	RouteConfigAdminGate415Key = "ack-4.15-route-config-not-supported-in-4.16"
+
+	// routeConfigAdminGate415Msg is the message that will be displayed in the admin-gates configmap.
+	routeConfigAdminGate415Msg = "A route in this cluster contains a configuration that isn't supported in 4.16. Please review each route's UnservableInFutureVersions status condition for more information."
+
+	// unservableInFutureVersionsIndexFieldName is the name of the index field that will list
+	// routes with UnservableInFutureVersions condition.
+	unservableInFutureVersionsIndexFieldName = "UnservableInFutureVersionsRoute"
+)
+
+var (
+	log = logf.Logger.WithName(controllerName)
+)
+
+// New creates the route upgradeable controller. This is the controller that handles
+// interpreting route status to determine if an admin gate is needed. The admin gate
+// will block upgrades until an admin acks it or resolves the unsupported configuration.
+func New(mgr manager.Manager, config Config) (controller.Controller, error) {
+	operatorCache := mgr.GetCache()
+	reconciler := &reconciler{
+		cache:  config.Cache,
+		client: mgr.GetClient(),
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler: reconciler,
+		RateLimiter: workqueue.NewMaxOfRateLimiter(
+			// Rate-limit to 1 update every 5 seconds per
+			// reconcile to avoid burning CPU if object
+			// updates are frequent.
+			workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, 30*time.Second),
+			// 10 qps, 100 bucket size, same as DefaultControllerRateLimiter().
+			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Index routes over the UnservableInFutureVersions condition so that we can
+	// efficiently find routes with UnservableInFutureVersions=true.
+	if err := reconciler.cache.IndexField(context.Background(), &routev1.Route{}, unservableInFutureVersionsIndexFieldName, client.IndexerFunc(func(o client.Object) []string {
+		if getRouteUnservableInFutureVersionsStatusCondition(o.(*routev1.Route)) != nil {
+			return []string{string(operatorv1.ConditionTrue)}
+		}
+		return nil
+	})); err != nil {
+		return nil, fmt.Errorf("failed to create index for routes: %w", err)
+	}
+
+	updatedUnservableInFutureVersionsConditionFilter := predicate.Funcs{
+		// Although this CreateFunc triggers for each route upon operator startup, we will rely on the
+		// configmap watch with the CreateFunc on adminGateFilter to trigger for the admin-gates
+		// configmap to ensure the initial state.
+		CreateFunc: func(createEvent event.CreateEvent) bool { return false },
+		// The only route deletions that matter are routes that have UnservableInFutureVersions.
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			route := deleteEvent.Object.(*routev1.Route)
+			return getRouteUnservableInFutureVersionsStatusCondition(route) != nil
+		},
+		// Only route updates for UnservableInFutureVersions changes matter.
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldRoute := e.ObjectOld.(*routev1.Route)
+			newRoute := e.ObjectNew.(*routev1.Route)
+			return routeIngressConditionStatusChanged(
+				getRouteUnservableInFutureVersionsStatusCondition(newRoute),
+				getRouteUnservableInFutureVersionsStatusCondition(oldRoute),
+			)
+		},
+		// Ignore all other events.
+		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+	}
+
+	adminGateFilter := predicate.Funcs{
+		// Filter for only when the admin-gates configmap is created.
+		// This runs on operator startup, and ensures initial state for the admin-gates configmap.
+		CreateFunc: func(e event.CreateEvent) bool {
+			configmap := e.Object.(*corev1.ConfigMap)
+			return configmap.Name == operatorcontroller.AdminGatesConfigMapName().Name && configmap.Namespace == operatorcontroller.AdminGatesConfigMapName().Namespace
+		},
+		// Ignore delete events because our reconcile can't do anything if
+		// the admin-gates configmap doesn't exist.
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool { return false },
+		// Filter for when our specific key is updated for admin-gates configmap.
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			configmapOld := e.ObjectOld.(*corev1.ConfigMap)
+			configmapNew := e.ObjectNew.(*corev1.ConfigMap)
+			if configmapOld.Name != operatorcontroller.AdminGatesConfigMapName().Name || configmapOld.Namespace != operatorcontroller.AdminGatesConfigMapName().Namespace {
+				return false
+			}
+			oldVal, oldExists := configmapOld.Data[RouteConfigAdminGate415Key]
+			newVal, newExists := configmapNew.Data[RouteConfigAdminGate415Key]
+			return oldExists != newExists || oldVal != newVal
+		},
+		// Ignore all other events.
+		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
+	}
+
+	toAdminGateConfigMap := func(_ context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			operatorcontroller.AdminGatesConfigMapName(),
+		}}
+	}
+
+	// Watch for routes using reconciler.cache because this cache
+	// includes all namespaces for watching routes.
+	if err := c.Watch(source.Kind(reconciler.cache, &routev1.Route{}),
+		handler.EnqueueRequestsFromMapFunc(toAdminGateConfigMap),
+		updatedUnservableInFutureVersionsConditionFilter); err != nil {
+		return nil, err
+	}
+	// Watch for configmap updates using the operatorCache because this cache includes
+	// the openshift-config-managed namespace in which our admin-gate configmap resides.
+	if err := c.Watch(source.Kind(operatorCache, &corev1.ConfigMap{}),
+		&handler.EnqueueRequestForObject{},
+		adminGateFilter); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// reconciler handles the actual configmap reconciliation logic in response to events.
+type reconciler struct {
+	client client.Client
+	cache  cache.Cache
+}
+
+// Config holds all the configuration that must be provided when creating the
+// controller.
+type Config struct {
+	// Cache should be a namespace global cache since routes
+	// are not restricted to any particular namespace.
+	Cache cache.Cache
+}
+
+// Reconcile expects request to refer to a configmap resource. It will add
+// an admin gate if any routes have the UnservableInFutureVersions status and remove the
+// admin gate if no routes have the UnservableInFutureVersions status.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log.Info("reconciling", "request", request)
+
+	unservableInFutureVersionsRoutesExists, err := r.unservableInFutureVersionsRouteExists(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to determine if UnservableInFutureVersionsRoute routes exist: %w", err)
+	}
+	if unservableInFutureVersionsRoutesExists {
+		if err := r.addAdminGate(ctx); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to add admin gate: %w", err)
+		}
+	} else {
+		if err := r.removeAdminGate(ctx); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to remove admin gate: %w", err)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// unservableInFutureVersionsRouteExists checks if there are any routes with
+// the UnservableInFutureVersions condition. It returns true if at least
+// one route is found with the UnservableInFutureVersions condition.
+func (r *reconciler) unservableInFutureVersionsRouteExists(ctx context.Context) (bool, error) {
+	// List routes using the "UnservableInFutureVersionsRoute" index which only lists UnservableInFutureVersions routes.
+	routeList := &routev1.RouteList{}
+	listOpts := client.MatchingFields(map[string]string{
+		unservableInFutureVersionsIndexFieldName: string(operatorv1.ConditionTrue),
+	})
+	if err := r.cache.List(ctx, routeList, listOpts); err != nil {
+		return false, fmt.Errorf("failed to list all routes: %w", err)
+	}
+
+	return len(routeList.Items) != 0, nil
+}
+
+// getRouteUnservableInFutureVersionsStatusCondition finds and returns a
+// RouteIngressCondition with UnservableInFutureVersions=true for any router.
+// If the UnservableInFutureVersions=true condition doesn't exist, nil is returned.
+func getRouteUnservableInFutureVersionsStatusCondition(route *routev1.Route) *routev1.RouteIngressCondition {
+	for i := range route.Status.Ingress {
+		for j := range route.Status.Ingress[i].Conditions {
+			condition := &route.Status.Ingress[i].Conditions[j]
+			if condition.Type == routev1.RouteUnservableInFutureVersions && condition.Status == corev1.ConditionTrue {
+				return condition
+			}
+		}
+	}
+	return nil
+}
+
+// addAdminGate adds an admin gate to block upgrades.
+func (r *reconciler) addAdminGate(ctx context.Context) error {
+	adminGateConfigMap := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, operatorcontroller.AdminGatesConfigMapName(), adminGateConfigMap); err != nil {
+		return fmt.Errorf("failed to get configmap %s: %w", operatorcontroller.AdminGatesConfigMapName(), err)
+	}
+
+	if adminGateConfigMap.Data == nil {
+		adminGateConfigMap.Data = map[string]string{}
+	}
+
+	if val, ok := adminGateConfigMap.Data[RouteConfigAdminGate415Key]; ok && val == routeConfigAdminGate415Msg {
+		return nil // Exists as expected.
+	}
+	adminGateConfigMap.Data[RouteConfigAdminGate415Key] = routeConfigAdminGate415Msg
+
+	log.Info("Adding admin gate for unservable in future versions route")
+	if err := r.client.Update(ctx, adminGateConfigMap); err != nil {
+		return fmt.Errorf("failed to update configmap %s: %w", operatorcontroller.AdminGatesConfigMapName(), err)
+	}
+	return nil
+}
+
+// removeAdminGate removes the admin gate to unblock upgrades.
+func (r *reconciler) removeAdminGate(ctx context.Context) error {
+	adminGateConfigMap := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, operatorcontroller.AdminGatesConfigMapName(), adminGateConfigMap); err != nil {
+		return fmt.Errorf("failed to get configmap %s: %w", operatorcontroller.AdminGatesConfigMapName(), err)
+	}
+
+	if _, ok := adminGateConfigMap.Data[RouteConfigAdminGate415Key]; !ok {
+		// Nothing needs to be done if key doesn't exist
+		return nil
+	}
+
+	log.Info("Removing admin gate for unservable in future versions route")
+
+	delete(adminGateConfigMap.Data, RouteConfigAdminGate415Key)
+	if err := r.client.Update(ctx, adminGateConfigMap); err != nil {
+		return fmt.Errorf("failed to update configmap %s: %w", operatorcontroller.AdminGatesConfigMapName(), err)
+	}
+	return nil
+}
+
+// routeIngressConditionStatusChanged detects if a RouteIngressCondition's status changed.
+func routeIngressConditionStatusChanged(a, b *routev1.RouteIngressCondition) bool {
+	// If one is nil, then must both be nil to be unchanged.
+	if a == nil || b == nil {
+		return a != b
+	}
+	return a.Status != b.Status
+}

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -114,5 +114,6 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)
 		t.Run("TestHostNetworkPortBinding", TestHostNetworkPortBinding)
 		t.Run("TestDashboardCreation", TestDashboardCreation)
+		t.Run("TestRouteNotUpgradeableWithSha1", TestRouteNotUpgradeableWithSha1)
 	})
 }

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -61,11 +61,11 @@ func TestClientTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate client CA certificate: %v", err)
 	}
-	validMatchingCert, validMatchingKey, err := generateCertificate(ca, caKey, "allowed")
+	validMatchingCert, validMatchingKey, err := generateCertificate(ca, caKey, "allowed", x509.SHA256WithRSA)
 	if err != nil {
 		t.Fatalf("failed to generate first client certificate: %v", err)
 	}
-	validMismatchingCert, validMismatchingKey, err := generateCertificate(ca, caKey, "disallowed")
+	validMismatchingCert, validMismatchingKey, err := generateCertificate(ca, caKey, "disallowed", x509.SHA256WithRSA)
 	if err != nil {
 		t.Fatalf("failed to generate second client certificate: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestClientTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate other CA certificate: %v", err)
 	}
-	invalidMatchingCert, invalidMatchingKey, err := generateCertificate(otherCA, otherCAKey, "allowed")
+	invalidMatchingCert, invalidMatchingKey, err := generateCertificate(otherCA, otherCAKey, "allowed", x509.SHA256WithRSA)
 	if err != nil {
 		t.Fatalf("failed to generate third client certificate: %v", err)
 	}
@@ -1477,7 +1477,7 @@ func generateCA() (*x509.Certificate, *rsa.PrivateKey, error) {
 
 // generateCertificate generates and returns a certificate and key
 // where the certificate is signed by the provided CA certificate.
-func generateCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string) (*x509.Certificate, *rsa.PrivateKey, error) {
+func generateCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string, signatureAlgorithm x509.SignatureAlgorithm) (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
@@ -1488,7 +1488,7 @@ func generateCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn str
 			CommonName:   cn,
 			Organization: []string{"OpenShift"},
 		},
-		SignatureAlgorithm:    x509.SHA256WithRSA,
+		SignatureAlgorithm:    signatureAlgorithm,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		SerialNumber:          big.NewInt(1),

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -57,25 +57,25 @@ func TestClientTLS(t *testing.T) {
 	t.Parallel()
 	// We will configure the ingresscontroller to recognize certificates
 	// signed by this CA.
-	ca, caKey, err := generateClientCA()
+	ca, caKey, err := generateCA()
 	if err != nil {
 		t.Fatalf("failed to generate client CA certificate: %v", err)
 	}
-	validMatchingCert, validMatchingKey, err := generateClientCertificate(ca, caKey, "allowed")
+	validMatchingCert, validMatchingKey, err := generateCertificate(ca, caKey, "allowed")
 	if err != nil {
 		t.Fatalf("failed to generate first client certificate: %v", err)
 	}
-	validMismatchingCert, validMismatchingKey, err := generateClientCertificate(ca, caKey, "disallowed")
+	validMismatchingCert, validMismatchingKey, err := generateCertificate(ca, caKey, "disallowed")
 	if err != nil {
 		t.Fatalf("failed to generate second client certificate: %v", err)
 	}
 	// The ingresscontroller will not recognize certificates signed by this
 	// other CA.
-	otherCA, otherCAKey, err := generateClientCA()
+	otherCA, otherCAKey, err := generateCA()
 	if err != nil {
 		t.Fatalf("failed to generate other CA certificate: %v", err)
 	}
-	invalidMatchingCert, invalidMatchingKey, err := generateClientCertificate(otherCA, otherCAKey, "allowed")
+	invalidMatchingCert, invalidMatchingKey, err := generateCertificate(otherCA, otherCAKey, "allowed")
 	if err != nil {
 		t.Fatalf("failed to generate third client certificate: %v", err)
 	}
@@ -1439,8 +1439,8 @@ func getActiveCRLs(t *testing.T, clientPod *corev1.Pod) ([]*x509.RevocationList,
 	return crls, nil
 }
 
-// generateClientCA generates and returns a CA certificate and key.
-func generateClientCA() (*x509.Certificate, *rsa.PrivateKey, error) {
+// generateCA generates and returns a CA certificate and key.
+func generateCA() (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
@@ -1475,9 +1475,9 @@ func generateClientCA() (*x509.Certificate, *rsa.PrivateKey, error) {
 	return certs[0], key, nil
 }
 
-// generateClientCertificate generates and returns a client certificate and key
+// generateCertificate generates and returns a certificate and key
 // where the certificate is signed by the provided CA certificate.
-func generateClientCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string) (*x509.Certificate, *rsa.PrivateKey, error) {
+func generateCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string) (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/test/e2e/route_upgradeable_test.go
+++ b/test/e2e/route_upgradeable_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	routeupgradeable "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/route-upgradeable"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	waitForAdminGateInterval = 3 * time.Second
+	waitForAdminGateTimeout  = 3 * time.Minute
+)
+
+// TestRouteNotUpgradeableWithSha1 tests the route-upgradeable control loop by creating a route with a SHA1 certificate,
+// expecting the Ingress Operator to create an admin gate, and update the route to SHA256 certificate to resolve the
+// issue.
+//
+// This is a serial test because adding an admin gate could potentially interfere with other upgrade-related tests.
+// Also, other tests create and delete router deployments, which would interfere with the status of the route that
+// this test creates and updates.
+func TestRouteNotUpgradeableWithSha1(t *testing.T) {
+	// Make sure admin gate doesn't exist before starting test.
+	if err := waitForAdminGate(t, routeupgradeable.RouteConfigAdminGate415Key, false, waitForAdminGateInterval, waitForAdminGateTimeout); err != nil {
+		t.Fatalf("failed to observe initial admin gate value: %v", err)
+	}
+
+	// Generate SHA1 certificates
+	ca, caKey, err := generateCA()
+	if err != nil {
+		t.Fatalf("failed to generate client CA certificate: %v", err)
+	}
+	certSha1, keySha1, err := generateCertificate(ca, caKey, "test", x509.SHA1WithRSA)
+	if err != nil {
+		t.Fatalf("failed to generate SHA1 certificate: %v", err)
+	}
+
+	t.Log("creating SHA1 route to add admin gate")
+	routeSha1Name := types.NamespacedName{Name: "route-sha1", Namespace: operatorcontroller.DefaultOperandNamespace}
+	routeSha1 := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeSha1Name.Name,
+			Namespace: routeSha1Name.Namespace,
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "foo",
+			},
+			TLS: &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationEdge,
+				Certificate: encodeCert(certSha1),
+				Key:         encodeKey(keySha1),
+			},
+		},
+	}
+	if err := kclient.Create(context.Background(), routeSha1); err != nil {
+		t.Fatalf("failed to create route %s: %v", routeSha1Name, err)
+	}
+	t.Cleanup(func() {
+		if err := kclient.Delete(context.Background(), routeSha1); err != nil {
+			t.Fatalf("failed to delete route %s: %v", routeSha1Name, err)
+		}
+	})
+
+	// Poll for the admin gate, and wait until it is True.
+	if err := waitForAdminGate(t, routeupgradeable.RouteConfigAdminGate415Key, true, waitForAdminGateInterval, waitForAdminGateTimeout); err != nil {
+		t.Fatalf("admin gate observation error: %v", err)
+	}
+
+	// Now, resolve the route's certificate problem by replacing with supported SHA256 certs.
+	t.Log("resolving SHA1 route issue to remove admin gate")
+	certSha256, keySha256, err := generateCertificate(ca, caKey, "test", x509.SHA256WithRSA)
+	if err != nil {
+		t.Fatalf("failed to generate SHA256 certificate: %v", err)
+	}
+
+	if err := kclient.Get(context.Background(), routeSha1Name, routeSha1); err != nil {
+		t.Fatalf("failed to get route %s: %v", routeSha1Name, err)
+	}
+	routeSha1.Spec.TLS.Certificate = encodeCert(certSha256)
+	routeSha1.Spec.TLS.Key = encodeKey(keySha256)
+	if err := kclient.Update(context.Background(), routeSha1); err != nil {
+		t.Fatalf("failed to update route %s: %v", routeSha1Name, err)
+	}
+	if err := waitForAdminGate(t, routeupgradeable.RouteConfigAdminGate415Key, false, waitForAdminGateInterval, waitForAdminGateTimeout); err != nil {
+		t.Fatalf("admin gate observation error: %v", err)
+	}
+}

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -29,7 +29,7 @@ spec:
                 name:
                   anyOf:
                     - format: ipv4
-                    - format: ipv6
+                    - pattern: ^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$
                   type: string
               type: object
             spec:

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
@@ -7,4 +7,4 @@
         type: string
         anyOf:
         - format: ipv4
-        - format: ipv6
+        - pattern: '^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$'

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -141,7 +141,8 @@ spec:
                           audiences:
                             description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
                             type: array
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             items:
                               type: string
                               minLength: 1

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -123,7 +123,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
@@ -91,7 +91,8 @@
             audiences:
               description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
               type: array
-              maxItems: 1
+              maxItems: 10
+              minItems: 1
               items:
                 type: string
                 minLength: 1

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -126,7 +126,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
@@ -110,6 +110,53 @@ spec:
                 clusterNetworkMTU:
                   description: ClusterNetworkMTU is the MTU for inter-pod networking.
                   type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 migration:
                   description: Migration contains the cluster network migration configuration.
                   type: object

--- a/vendor/github.com/openshift/api/config/v1/stable.network.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.network.testsuite.yaml
@@ -12,7 +12,7 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Network
       spec: {}
-  - name: Should not be able to set status conditions
+  - name: Should be able to set status conditions
     initial: |
       apiVersion: config.openshift.io/v1
       kind: Network
@@ -28,4 +28,10 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Network
       spec: {}
-      status: {}
+      status:
+        conditions:
+          - type: NetworkTypeMigrationInProgress
+            status: "False"
+            reason: "Reason"
+            message: "Message"
+            lastTransitionTime: "2023-10-25T12:00:00Z"

--- a/vendor/github.com/openshift/api/config/v1/types_authentication.go
+++ b/vendor/github.com/openshift/api/config/v1/types_authentication.go
@@ -240,7 +240,8 @@ type TokenIssuer struct {
 	//
 	// +listType=set
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=10
 	// +required
 	Audiences []TokenAudience `json:"audiences"`
 

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -188,7 +188,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(metricsServer).
 		with(installAlternateInfrastructureAWS).
 		without(clusterAPIInstall).
-		with(sdnLiveMigration).
 		with(mixedCPUsAllocation).
 		with(managedBootImages).
 		without(disableKubeletCloudCredentialProviders).
@@ -211,6 +210,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		externalCloudProviderExternal,
 		privateHostedZoneAWS,
 		buildCSIVolumes,
+		sdnLiveMigration,
 	},
 	Disabled: []FeatureGateDescription{
 		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.

--- a/vendor/github.com/openshift/api/config/v1/types_network.go
+++ b/vendor/github.com/openshift/api/config/v1/types_network.go
@@ -95,7 +95,6 @@ type NetworkStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 

--- a/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -428,6 +428,13 @@ spec:
                           description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
                           type: boolean
                           default: true
+                    mode:
+                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
+                      type: string
+                      enum:
+                        - Live
+                        - Offline
+                        - ""
                     mtu:
                       description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
                       type: object

--- a/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -59,7 +59,7 @@ spec:
                       properties:
                         kmsKeyARN:
                           description: kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key, rather than the default KMS key used by AWS. The value may be either the ARN or Alias ARN of a KMS key.
-                          pattern: ^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
+                          pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
                           type: string
                       type: object
                     azure:

--- a/vendor/github.com/openshift/api/operator/v1/stable.network.testsuite.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/stable.network.testsuite.yaml
@@ -255,11 +255,11 @@ tests:
               ipv6:
                 internalMasqueradeSubnet: "abcd:eff01:2345:6789::2345:6789/20"
     expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
-  - name: Should not be able to create migration mode
+  - name: Should be able to create migration mode
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         migration:
           mode: Live
     expected: |
@@ -269,7 +269,8 @@ tests:
         disableNetworkDiagnostics: false
         logLevel: Normal
         operatorLogLevel: Normal
-        migration: {}
+        migration:
+          mode: Live
   - name: "IPsec - Empty ipsecConfig is allowed in initial state"
     initial: |
       apiVersion: operator.openshift.io/v1

--- a/vendor/github.com/openshift/api/operator/v1/types_csi_cluster_driver.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_csi_cluster_driver.go
@@ -159,7 +159,7 @@ type AWSCSIDriverConfigSpec struct {
 	// kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key,
 	// rather than the default KMS key used by AWS.
 	// The value may be either the ARN or Alias ARN of a KMS key.
-	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
+	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
 	// +optional
 	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }

--- a/vendor/github.com/openshift/api/operator/v1/types_network.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_network.go
@@ -157,7 +157,6 @@ type NetworkMigration struct {
 	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
 	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
 	// The current default value is "Offline".
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	Mode NetworkMigrationMode `json:"mode"`
 }

--- a/vendor/github.com/openshift/api/route/v1/generated.proto
+++ b/vendor/github.com/openshift/api/route/v1/generated.proto
@@ -213,7 +213,7 @@ message RouteIngress {
 // router.
 message RouteIngressCondition {
   // Type is the type of the condition.
-  // Currently only Admitted.
+  // Currently only Admitted or UnservableInFutureVersions.
   optional string type = 1;
 
   // Status is the status of the condition.

--- a/vendor/github.com/openshift/api/route/v1/route-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route-CustomNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/vendor/github.com/openshift/api/route/v1/route-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route-TechPreviewNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/vendor/github.com/openshift/api/route/v1/route.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route.crd.yaml
@@ -376,7 +376,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                           required:
                             - status

--- a/vendor/github.com/openshift/api/route/v1/types.go
+++ b/vendor/github.com/openshift/api/route/v1/types.go
@@ -369,14 +369,16 @@ type RouteIngressConditionType string
 const (
 	// RouteAdmitted means the route is able to service requests for the provided Host
 	RouteAdmitted RouteIngressConditionType = "Admitted"
-	// TODO: add other route condition types
+	// RouteUnservableInFutureVersions indicates that the route is using an unsupported
+	// configuration that may be incompatible with a future version of OpenShift.
+	RouteUnservableInFutureVersions RouteIngressConditionType = "UnservableInFutureVersions"
 )
 
 // RouteIngressCondition contains details for the current condition of this route on a particular
 // router.
 type RouteIngressCondition struct {
 	// Type is the type of the condition.
-	// Currently only Admitted.
+	// Currently only Admitted or UnservableInFutureVersions.
 	Type RouteIngressConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RouteIngressConditionType"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.

--- a/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
@@ -85,7 +85,7 @@ func (RouteIngress) SwaggerDoc() map[string]string {
 
 var map_RouteIngressCondition = map[string]string{
 	"":                   "RouteIngressCondition contains details for the current condition of this route on a particular router.",
-	"type":               "Type is the type of the condition. Currently only Admitted.",
+	"type":               "Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.",
 	"status":             "Status is the status of the condition. Can be True, False, Unknown.",
 	"reason":             "(brief) reason for the condition's last transition, and is usually a machine and human readable constant",
 	"message":            "Human readable message indicating details about last transition.",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -345,7 +345,7 @@ github.com/munnerz/goautoneg
 github.com/oklog/ulid
 # github.com/onsi/ginkgo v1.16.5
 ## explicit; go 1.16
-# github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible => github.com/openshift/api v0.0.0-20240131192415-e18b9cc8aa8b
+# github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible => github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 ## explicit; go 1.20
 github.com/openshift/api
 github.com/openshift/api/apiserver
@@ -1262,5 +1262,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
-# github.com/openshift/api => github.com/openshift/api v0.0.0-20240131192415-e18b9cc8aa8b
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
 # k8s.io/client-go => k8s.io/client-go v0.28.0


### PR DESCRIPTION
_**Note: This is NOT a backport or cherry-pick of any commits, but instead a discrete PR targeting 4.15.**_

This PR handles SHA1 certificate upgradeable scenarios for 4.15. With OpenSSL3.0 provided by RHEL9 in 4.16, the router will fail to start if any cert provided is SHA1.

First, if the default certificate on the Ingress Controller object is using SHA1, then set `Upgradeable` to be False.

Secondly, add a new control loop, route deprecated, that determines upgradeablity by searching for the `UnservableInFutureVersions` condition in the routes. The `UnservableInFutureVersions` will be added to the route by https://github.com/openshift/router/pull/555 when a SHA1 certificate exists on the route. It creates an [admin-gate](https://github.com/openshift/enhancements/blob/master/enhancements/update/upgrades-blocking-on-ack.md) if a `UnservableInFutureVersions` condition is found. This logic assumes any `UnservableInFutureVersions` route status condition is an upgrade blocker.

This implementation targets 4.15 to 4.16 updates specifically, so it is only targeting the `release-4.15` branch and we will be merged in the backport of https://issues.redhat.com/browse/OCPBUGS-26498. The code should not be merged into 4.16.

This PR leveraged logic from https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/171.

This PR depends on https://github.com/openshift/router/pull/585 for E2E test to succeed.