### PR TITLE
CFE-987: Use RouterExternalCertificate feature gate for adding ROUTER_ENABLE_EXTERNAL_CERTIFICATE env var to the router pods

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -187,8 +187,9 @@ func enqueueRequestForOwningIngressController(namespace string) handler.EventHan
 
 // Config holds all the things necessary for the controller to run.
 type Config struct {
-	Namespace              string
-	IngressControllerImage string
+	Namespace                       string
+	IngressControllerImage          string
+	RouteExternalCertificateEnabled bool
 }
 
 // reconciler handles the actual ingress reconciliation logic in response to

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -170,7 +170,7 @@ func TestTuningOptions(t *testing.T) {
 	ic.Spec.TuningOptions.HealthCheckInterval = &metav1.Duration{Duration: 15 * time.Second}
 	ic.Spec.TuningOptions.ReloadInterval = metav1.Duration{Duration: 30 * time.Second}
 
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestTuningOptions(t *testing.T) {
 func TestClusterProxy(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestClusterProxy(t *testing.T) {
 	clusterProxyConfig.Status.HTTPSProxy = "bar"
 	clusterProxyConfig.Status.NoProxy = "baz"
 
-	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -387,7 +387,7 @@ func getRouterDeploymentComponents(t *testing.T) (*operatorv1.IngressController,
 func Test_desiredRouterDeployment(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -468,7 +468,7 @@ func Test_desiredRouterDeployment(t *testing.T) {
 func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -597,7 +597,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -684,7 +684,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -799,7 +799,7 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -913,7 +913,7 @@ func TestDesiredRouterDeploymentHostNetworkNil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -944,7 +944,7 @@ func TestDesiredRouterDeploymentSingleReplica(t *testing.T) {
 		},
 	}
 
-	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, false)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -2248,7 +2248,7 @@ func TestDesiredRouterDeploymentDefaultPlacement(t *testing.T) {
 			// This value does not matter in the context of this test, just use a dummy value
 			dummyProxyNeeded := true
 
-			deployment, err := desiredRouterDeployment(ic, ingressControllerImage, tc.ingressConfig, tc.infraConfig, apiConfig, networkConfig, dummyProxyNeeded, false, nil, &configv1.Proxy{})
+			deployment, err := desiredRouterDeployment(ic, ingressControllerImage, tc.ingressConfig, tc.infraConfig, apiConfig, networkConfig, dummyProxyNeeded, false, nil, &configv1.Proxy{}, false)
 			if err != nil {
 				t.Error(err)
 			}
@@ -2264,4 +2264,38 @@ func TestDesiredRouterDeploymentDefaultPlacement(t *testing.T) {
 		})
 	}
 
+}
+
+func TestDesiredRouterDeploymentRouterExternalCertificate(t *testing.T) {
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
+
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, false)
+	if err != nil {
+		t.Fatalf("invalid router Deployment: %v", err)
+	}
+
+	// Verify that router external certificate env var is not added.
+	expectedEnv := []envData{
+		{"ROUTER_ENABLE_EXTERNAL_CERTIFICATE", false, ""},
+	}
+
+	if err := checkDeploymentEnvironment(t, deployment, expectedEnv); err != nil {
+		t.Error(err)
+	}
+
+	deployment, err = desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig, true)
+	if err != nil {
+		t.Fatalf("invalid router Deployment: %v", err)
+	}
+
+	// Verify that router external certificate env var is set to true.
+	expectedEnv = []envData{
+		{"ROUTER_ENABLE_EXTERNAL_CERTIFICATE", true, "true"},
+	}
+
+	if err := checkDeploymentEnvironment(t, deployment, expectedEnv); err != nil {
+		t.Error(err)
+	}
+
+	checkDeploymentHasEnvSorted(t, deployment)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,6 +131,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	azureWorkloadIdentityEnabled := featureGates.Enabled(configv1.FeatureGateAzureWorkloadIdentity)
 	sharedVPCEnabled := featureGates.Enabled(configv1.FeatureGatePrivateHostedZoneAWS)
 	gatewayAPIEnabled := featureGates.Enabled(configv1.FeatureGateGatewayAPI)
+	routeExternalCertificateEnabled := featureGates.Enabled(configv1.FeatureGateRouteExternalCertificate)
 
 	// Set up an operator manager for the operator namespace.
 	mgr, err := manager.New(kubeConfig, manager.Options{
@@ -163,8 +164,9 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 
 	// Create and register the ingress controller with the operator manager.
 	if _, err := ingresscontroller.New(mgr, ingresscontroller.Config{
-		Namespace:              config.Namespace,
-		IngressControllerImage: config.IngressControllerImage,
+		Namespace:                       config.Namespace,
+		IngressControllerImage:          config.IngressControllerImage,
+		RouteExternalCertificateEnabled: routeExternalCertificateEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create ingress controller: %v", err)
 	}


### PR DESCRIPTION
Use `RouterExternalCertificate` feature gate and add `ROUTER_ENABLE_EXTERNAL_CERTIFICATE` env var to the router pod based on the feature gate according to the EP https://github.com/openshift/enhancements/pull/1307.