### PR TITLE
NE-1400: Bump to OSSM 2.5 and Gateway API v0.6.2 CRDs

### DIFF
--- a/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
-    gateway.networking.k8s.io/channel: experimental
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.2
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -34,6 +34,9 @@ spec:
       name: Description
       priority: 1
       type: string
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of GatewayClass has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -87,7 +90,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.
@@ -135,7 +138,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller
@@ -145,13 +148,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -217,7 +221,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -288,7 +292,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.
@@ -336,7 +340,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller
@@ -346,13 +350,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_gateways.yaml
+++ b/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_gateways.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
-    gateway.networking.k8s.io/channel: experimental
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.2
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -27,12 +27,15 @@ spec:
     - jsonPath: .status.addresses[*].value
       name: Address
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of Gateway has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -334,9 +337,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
@@ -356,8 +359,8 @@ spec:
                               group:
                                 default: ""
                                 description: Group is the group of the referent. For
-                                  example, "networking.k8s.io". When unspecified (empty
-                                  string), core API group is inferred.
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
@@ -451,7 +454,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -486,26 +489,32 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -585,14 +594,15 @@ spec:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct
                           is intended for direct use as an array at the field path
-                          .status.conditions.  For example, type FooStatus struct{
-                          \    // Represents the observations of a foo's current state.
-                          \    // Known .status.conditions.type are: \"Available\",
-                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                          \    // +patchStrategy=merge     // +listType=map     //
-                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                          \n     // other fields }"
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
                         properties:
                           lastTransitionTime:
                             description: lastTransitionTime is the last time the condition
@@ -710,7 +720,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -721,8 +731,8 @@ spec:
     - jsonPath: .status.addresses[*].value
       name: Address
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -1028,9 +1038,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
@@ -1050,8 +1060,8 @@ spec:
                               group:
                                 default: ""
                                 description: Group is the group of the referent. For
-                                  example, "networking.k8s.io". When unspecified (empty
-                                  string), core API group is inferred.
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
@@ -1145,7 +1155,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -1180,26 +1190,32 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -1279,14 +1295,15 @@ spec:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct
                           is intended for direct use as an array at the field path
-                          .status.conditions.  For example, type FooStatus struct{
-                          \    // Represents the observations of a foo's current state.
-                          \    // Known .status.conditions.type are: \"Available\",
-                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                          \    // +patchStrategy=merge     // +listType=map     //
-                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                          \n     // other fields }"
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
                         properties:
                           lastTransitionTime:
                             description: lastTransitionTime is the last time the condition

--- a/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_httproutes.yaml
+++ b/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_httproutes.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
-    gateway.networking.k8s.io/channel: experimental
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.2
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -25,6 +25,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of HTTPRoute has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -77,12 +80,18 @@ spec:
                   have specified hostnames, and none match with the criteria above,
                   then the HTTPRoute is not accepted. The implementation must raise
                   an 'Accepted' Condition with a status of `False` in the corresponding
-                  RouteParentStatus. \n Support: Core"
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -111,7 +120,12 @@ spec:
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
-                  also be merged."
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable any other
+                  kind of cross-namespace reference."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -123,7 +137,10 @@ spec:
                   properties:
                     group:
                       default: gateway.networking.k8s.io
-                      description: "Group is the group of the referent. \n Support:
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
                         Core"
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -131,7 +148,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -145,37 +162,17 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
                         \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
-                    port:
-                      description: "Port is the network port this Route targets. It
-                        can be interpreted differently based on the type of parent
-                        resource. \n When the parent resource is a Gateway, this targets
-                        all listeners listening on the specified port that also support
-                        this kind of Route(and select this Route). It's not recommended
-                        to set `Port` unless the networking behaviors specified in
-                        a Route must apply to a specific port as opposed to a listener(s)
-                        whose port(s) may be changed. When both Port and SectionName
-                        are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
                     sectionName:
                       description: "SectionName is the name of a section within the
                         target resource. In the following resources, SectionName is
@@ -233,7 +230,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -242,9 +239,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -265,8 +262,9 @@ spec:
                                   properties:
                                     group:
                                       description: Group is the group of the referent.
-                                        For example, "networking.k8s.io". When unspecified
-                                        (empty string), core API group is inferred.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
@@ -298,9 +296,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -421,14 +419,15 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
                                           description: Group is the group of the referent.
-                                            For example, "networking.k8s.io". When
-                                            unspecified (empty string), core API group
-                                            is inferred.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
@@ -493,57 +492,6 @@ spec:
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
-                                    path:
-                                      description: "Path defines parameters used to
-                                        modify the path of the incoming request. The
-                                        modified path is then used to construct the
-                                        `Location` header. When empty, the request
-                                        path is used as-is. \n Support: Extended \n
-                                        <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
@@ -557,13 +505,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended \n Note that
-                                        values may be added to this enum, implementations
-                                        must ensure that unknown values will not cause
-                                        a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
-                                        Condition for the Route to `status: False`,
-                                        with a Reason of `UnsupportedValue`."
+                                        is used. \n Note that values may be added
+                                        to this enum, implementations must ensure
+                                        that unknown values will not cause a crash.
+                                        \n Unknown values here must result in the
+                                        implementation setting the Accepted Condition
+                                        for the Route to `status: False`, with a Reason
+                                        of `UnsupportedValue`. \n Support: Extended"
                                       enum:
                                       - http
                                       - https
@@ -571,13 +519,14 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core
-                                        \n Note that values may be added to this enum,
-                                        implementations must ensure that unknown values
-                                        will not cause a crash. \n Unknown values
-                                        here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `UnsupportedValue`."
+                                        code to be used in response. \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Accepted
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `UnsupportedValue`. \n Support:
+                                        Core"
                                       enum:
                                       - 301
                                       - 302
@@ -594,9 +543,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -612,77 +561,15 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
                                   - RequestRedirect
-                                  - URLRewrite
                                   - ExtensionRef
                                   type: string
-                                urlRewrite:
-                                  description: "URLRewrite defines a schema for a
-                                    filter that modifies a request during forwarding.
-                                    \n Support: Extended \n <gateway:experimental>"
-                                  properties:
-                                    hostname:
-                                      description: "Hostname is the value to be used
-                                        to replace the Host header value during forwarding.
-                                        \n Support: Extended \n <gateway:experimental>"
-                                      maxLength: 253
-                                      minLength: 1
-                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                      type: string
-                                    path:
-                                      description: "Path defines a path rewrite. \n
-                                        Support: Extended \n <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  type: object
                               required:
                               - type
                               type: object
@@ -691,8 +578,8 @@ spec:
                           group:
                             default: ""
                             description: Group is the group of the referent. For example,
-                              "networking.k8s.io". When unspecified (empty string),
-                              core API group is inferred.
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -767,14 +654,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -794,8 +681,8 @@ spec:
                             properties:
                               group:
                                 description: Group is the group of the referent. For
-                                  example, "networking.k8s.io". When unspecified (empty
-                                  string), core API group is inferred.
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
@@ -827,8 +714,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -940,13 +827,15 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
                                     description: Group is the group of the referent.
-                                      For example, "networking.k8s.io". When unspecified
-                                      (empty string), core API group is inferred.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -1008,52 +897,6 @@ spec:
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
-                              path:
-                                description: "Path defines parameters used to modify
-                                  the path of the incoming request. The modified path
-                                  is then used to construct the `Location` header.
-                                  When empty, the request path is used as-is. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
@@ -1067,12 +910,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended \n Note that values may be added
-                                  to this enum, implementations must ensure that unknown
-                                  values will not cause a crash. \n Unknown values
-                                  here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
-                                  with a Reason of `UnsupportedValue`."
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Accepted Condition for
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`.
+                                  \n Support: Extended"
                                 enum:
                                 - http
                                 - https
@@ -1080,12 +923,13 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core \n Note that
-                                  values may be added to this enum, implementations
-                                  must ensure that unknown values will not cause a
-                                  crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
+                                  be used in response. \n Note that values may be
+                                  added to this enum, implementations must ensure
+                                  that unknown values will not cause a crash. \n Unknown
+                                  values here must result in the implementation setting
+                                  the Accepted Condition for the Route to `status:
+                                  False`, with a Reason of `UnsupportedValue`. \n
+                                  Support: Core"
                                 enum:
                                 - 301
                                 - 302
@@ -1101,15 +945,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -1118,72 +962,14 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
                             - RequestRedirect
-                            - URLRewrite
                             - ExtensionRef
                             type: string
-                          urlRewrite:
-                            description: "URLRewrite defines a schema for a filter
-                              that modifies a request during forwarding. \n Support:
-                              Extended \n <gateway:experimental>"
-                            properties:
-                              hostname:
-                                description: "Hostname is the value to be used to
-                                  replace the Host header value during forwarding.
-                                  \n Support: Extended \n <gateway:experimental>"
-                                maxLength: 253
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              path:
-                                description: "Path defines a path rewrite. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            type: object
                         required:
                         - type
                         type: object
@@ -1208,22 +994,21 @@ spec:
                         together. \n If no matches are specified, the default is a
                         prefix path match on \"/\", which has the effect of matching
                         every HTTP request. \n Proxy or Load Balancer routing configuration
-                        generated from HTTPRoutes MUST prioritize rules based on the
-                        following criteria, continuing on ties. Precedence must be
-                        given to the Rule with the largest number of: \n * Characters
-                        in a matching non-wildcard hostname. * Characters in a matching
-                        hostname. * Characters in a matching path. * Header matches.
-                        * Query param matches. \n If ties still exist across multiple
-                        Routes, matching precedence MUST be determined in order of
-                        the following criteria, continuing on ties: \n * The oldest
-                        Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
-                        still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the FIRST matching
-                        rule (in list order) meeting the above criteria. \n When no
-                        rules matching a request have been successfully attached to
-                        the parent a request is coming from, a HTTP 404 status code
-                        MUST be returned."
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -1231,8 +1016,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.
@@ -1267,12 +1052,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -1319,7 +1104,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -1332,10 +1117,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.
@@ -1351,12 +1136,12 @@ spec:
                                     be ignored. \n If a query param is repeated in
                                     an HTTP request, the behavior is purposely left
                                     undefined, since different data planes have different
-                                    capabilities. However, it's *recommended* that
+                                    capabilities. However, it is *recommended* that
                                     implementations should match against the first
                                     value of the param if the data plane supports
                                     it, as this behavior is expected in other load
                                     balancing contexts outside of the Gateway API.
-                                    Users should not route traffic based on repeated
+                                    \n Users SHOULD NOT route traffic based on repeated
                                     query params to guard themselves against potential
                                     differences in the implementations."
                                   maxLength: 256
@@ -1366,10 +1151,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -1439,14 +1225,15 @@ spec:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct
                           is intended for direct use as an array at the field path
-                          .status.conditions.  For example, type FooStatus struct{
-                          \    // Represents the observations of a foo's current state.
-                          \    // Known .status.conditions.type are: \"Available\",
-                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                          \    // +patchStrategy=merge     // +listType=map     //
-                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                          \n     // other fields }"
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
                         properties:
                           lastTransitionTime:
                             description: lastTransitionTime is the last time the condition
@@ -1533,15 +1320,19 @@ spec:
                       properties:
                         group:
                           default: gateway.networking.k8s.io
-                          description: "Group is the group of the referent. \n Support:
-                            Core"
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1555,39 +1346,17 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified, this refers to the local namespace of
-                            the Route. \n Support: Core"
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
-                        port:
-                          description: "Port is the network port this Route targets.
-                            It can be interpreted differently based on the type of
-                            parent resource. \n When the parent resource is a Gateway,
-                            this targets all listeners listening on the specified
-                            port that also support this kind of Route(and select this
-                            Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to
-                            a specific port as opposed to a listener(s) whose port(s)
-                            may be changed. When both Port and SectionName are specified,
-                            the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
-                            other types of parent resources MUST clearly document
-                            how/if Port is interpreted. \n For the purpose of status,
-                            an attachment is considered successful as long as the
-                            parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them
-                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
-                            listeners accept attachment from the referencing Route,
-                            the Route MUST be considered successfully attached. If
-                            no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-                            \n Support: Extended \n <gateway:experimental>"
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
                         sectionName:
                           description: "SectionName is the name of a section within
                             the target resource. In the following resources, SectionName
@@ -1627,7 +1396,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}
@@ -1690,12 +1459,18 @@ spec:
                   have specified hostnames, and none match with the criteria above,
                   then the HTTPRoute is not accepted. The implementation must raise
                   an 'Accepted' Condition with a status of `False` in the corresponding
-                  RouteParentStatus. \n Support: Core"
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -1724,7 +1499,12 @@ spec:
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
-                  also be merged."
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable any other
+                  kind of cross-namespace reference."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -1736,7 +1516,10 @@ spec:
                   properties:
                     group:
                       default: gateway.networking.k8s.io
-                      description: "Group is the group of the referent. \n Support:
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
                         Core"
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1744,7 +1527,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1758,37 +1541,17 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
                         \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
-                    port:
-                      description: "Port is the network port this Route targets. It
-                        can be interpreted differently based on the type of parent
-                        resource. \n When the parent resource is a Gateway, this targets
-                        all listeners listening on the specified port that also support
-                        this kind of Route(and select this Route). It's not recommended
-                        to set `Port` unless the networking behaviors specified in
-                        a Route must apply to a specific port as opposed to a listener(s)
-                        whose port(s) may be changed. When both Port and SectionName
-                        are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
                     sectionName:
                       description: "SectionName is the name of a section within the
                         target resource. In the following resources, SectionName is
@@ -1846,7 +1609,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -1855,9 +1618,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -1878,8 +1641,9 @@ spec:
                                   properties:
                                     group:
                                       description: Group is the group of the referent.
-                                        For example, "networking.k8s.io". When unspecified
-                                        (empty string), core API group is inferred.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
@@ -1911,9 +1675,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -2034,14 +1798,15 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
                                           description: Group is the group of the referent.
-                                            For example, "networking.k8s.io". When
-                                            unspecified (empty string), core API group
-                                            is inferred.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
@@ -2106,57 +1871,6 @@ spec:
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
-                                    path:
-                                      description: "Path defines parameters used to
-                                        modify the path of the incoming request. The
-                                        modified path is then used to construct the
-                                        `Location` header. When empty, the request
-                                        path is used as-is. \n Support: Extended \n
-                                        <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
@@ -2170,13 +1884,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended \n Note that
-                                        values may be added to this enum, implementations
-                                        must ensure that unknown values will not cause
-                                        a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
-                                        Condition for the Route to `status: False`,
-                                        with a Reason of `UnsupportedValue`."
+                                        is used. \n Note that values may be added
+                                        to this enum, implementations must ensure
+                                        that unknown values will not cause a crash.
+                                        \n Unknown values here must result in the
+                                        implementation setting the Accepted Condition
+                                        for the Route to `status: False`, with a Reason
+                                        of `UnsupportedValue`. \n Support: Extended"
                                       enum:
                                       - http
                                       - https
@@ -2184,13 +1898,14 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core
-                                        \n Note that values may be added to this enum,
-                                        implementations must ensure that unknown values
-                                        will not cause a crash. \n Unknown values
-                                        here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `UnsupportedValue`."
+                                        code to be used in response. \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Accepted
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `UnsupportedValue`. \n Support:
+                                        Core"
                                       enum:
                                       - 301
                                       - 302
@@ -2207,9 +1922,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -2225,77 +1940,15 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
                                   - RequestRedirect
-                                  - URLRewrite
                                   - ExtensionRef
                                   type: string
-                                urlRewrite:
-                                  description: "URLRewrite defines a schema for a
-                                    filter that modifies a request during forwarding.
-                                    \n Support: Extended \n <gateway:experimental>"
-                                  properties:
-                                    hostname:
-                                      description: "Hostname is the value to be used
-                                        to replace the Host header value during forwarding.
-                                        \n Support: Extended \n <gateway:experimental>"
-                                      maxLength: 253
-                                      minLength: 1
-                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                      type: string
-                                    path:
-                                      description: "Path defines a path rewrite. \n
-                                        Support: Extended \n <gateway:experimental>"
-                                      properties:
-                                        replaceFullPath:
-                                          description: "ReplaceFullPath specifies
-                                            the value with which to replace the full
-                                            path of a request during a rewrite or
-                                            redirect. \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        replacePrefixMatch:
-                                          description: "ReplacePrefixMatch specifies
-                                            the value with which to replace the prefix
-                                            match of a request during a rewrite or
-                                            redirect. For example, a request to \"/foo/bar\"
-                                            with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n Note that
-                                            this matches the behavior of the PathPrefix
-                                            match type. This matches full path elements.
-                                            A path element refers to the list of labels
-                                            in the path split by the `/` separator.
-                                            When specified, a trailing `/` is ignored.
-                                            For example, the paths `/abc`, `/abc/`,
-                                            and `/abc/def` would all match the prefix
-                                            `/abc`, but the path `/abcd` would not.
-                                            \n <gateway:experimental>"
-                                          maxLength: 1024
-                                          type: string
-                                        type:
-                                          description: "Type defines the type of path
-                                            modifier. Additional types may be added
-                                            in a future release of the API. \n Note
-                                            that values may be added to this enum,
-                                            implementations must ensure that unknown
-                                            values will not cause a crash. \n Unknown
-                                            values here must result in the implementation
-                                            setting the Attached Condition for the
-                                            Route to `status: False`, with a Reason
-                                            of `UnsupportedValue`. \n <gateway:experimental>"
-                                          enum:
-                                          - ReplaceFullPath
-                                          - ReplacePrefixMatch
-                                          type: string
-                                      required:
-                                      - type
-                                      type: object
-                                  type: object
                               required:
                               - type
                               type: object
@@ -2304,8 +1957,8 @@ spec:
                           group:
                             default: ""
                             description: Group is the group of the referent. For example,
-                              "networking.k8s.io". When unspecified (empty string),
-                              core API group is inferred.
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
@@ -2380,14 +2033,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2407,8 +2060,8 @@ spec:
                             properties:
                               group:
                                 description: Group is the group of the referent. For
-                                  example, "networking.k8s.io". When unspecified (empty
-                                  string), core API group is inferred.
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
@@ -2440,8 +2093,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -2553,13 +2206,15 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
                                     description: Group is the group of the referent.
-                                      For example, "networking.k8s.io". When unspecified
-                                      (empty string), core API group is inferred.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
@@ -2621,52 +2276,6 @@ spec:
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
-                              path:
-                                description: "Path defines parameters used to modify
-                                  the path of the incoming request. The modified path
-                                  is then used to construct the `Location` header.
-                                  When empty, the request path is used as-is. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
@@ -2680,12 +2289,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended \n Note that values may be added
-                                  to this enum, implementations must ensure that unknown
-                                  values will not cause a crash. \n Unknown values
-                                  here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
-                                  with a Reason of `UnsupportedValue`."
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Accepted Condition for
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`.
+                                  \n Support: Extended"
                                 enum:
                                 - http
                                 - https
@@ -2693,12 +2302,13 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core \n Note that
-                                  values may be added to this enum, implementations
-                                  must ensure that unknown values will not cause a
-                                  crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
+                                  be used in response. \n Note that values may be
+                                  added to this enum, implementations must ensure
+                                  that unknown values will not cause a crash. \n Unknown
+                                  values here must result in the implementation setting
+                                  the Accepted Condition for the Route to `status:
+                                  False`, with a Reason of `UnsupportedValue`. \n
+                                  Support: Core"
                                 enum:
                                 - 301
                                 - 302
@@ -2714,15 +2324,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -2731,72 +2341,14 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
                             - RequestRedirect
-                            - URLRewrite
                             - ExtensionRef
                             type: string
-                          urlRewrite:
-                            description: "URLRewrite defines a schema for a filter
-                              that modifies a request during forwarding. \n Support:
-                              Extended \n <gateway:experimental>"
-                            properties:
-                              hostname:
-                                description: "Hostname is the value to be used to
-                                  replace the Host header value during forwarding.
-                                  \n Support: Extended \n <gateway:experimental>"
-                                maxLength: 253
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                              path:
-                                description: "Path defines a path rewrite. \n Support:
-                                  Extended \n <gateway:experimental>"
-                                properties:
-                                  replaceFullPath:
-                                    description: "ReplaceFullPath specifies the value
-                                      with which to replace the full path of a request
-                                      during a rewrite or redirect. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  replacePrefixMatch:
-                                    description: "ReplacePrefixMatch specifies the
-                                      value with which to replace the prefix match
-                                      of a request during a rewrite or redirect. For
-                                      example, a request to \"/foo/bar\" with a prefix
-                                      match of \"/foo\" would be modified to \"/bar\".
-                                      \n Note that this matches the behavior of the
-                                      PathPrefix match type. This matches full path
-                                      elements. A path element refers to the list
-                                      of labels in the path split by the `/` separator.
-                                      When specified, a trailing `/` is ignored. For
-                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
-                                      would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n <gateway:experimental>"
-                                    maxLength: 1024
-                                    type: string
-                                  type:
-                                    description: "Type defines the type of path modifier.
-                                      Additional types may be added in a future release
-                                      of the API. \n Note that values may be added
-                                      to this enum, implementations must ensure that
-                                      unknown values will not cause a crash. \n Unknown
-                                      values here must result in the implementation
-                                      setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `UnsupportedValue`.
-                                      \n <gateway:experimental>"
-                                    enum:
-                                    - ReplaceFullPath
-                                    - ReplacePrefixMatch
-                                    type: string
-                                required:
-                                - type
-                                type: object
-                            type: object
                         required:
                         - type
                         type: object
@@ -2821,22 +2373,21 @@ spec:
                         together. \n If no matches are specified, the default is a
                         prefix path match on \"/\", which has the effect of matching
                         every HTTP request. \n Proxy or Load Balancer routing configuration
-                        generated from HTTPRoutes MUST prioritize rules based on the
-                        following criteria, continuing on ties. Precedence must be
-                        given to the Rule with the largest number of: \n * Characters
-                        in a matching non-wildcard hostname. * Characters in a matching
-                        hostname. * Characters in a matching path. * Header matches.
-                        * Query param matches. \n If ties still exist across multiple
-                        Routes, matching precedence MUST be determined in order of
-                        the following criteria, continuing on ties: \n * The oldest
-                        Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
-                        still exist within the Route that has been given precedence,
-                        matching precedence MUST be granted to the FIRST matching
-                        rule (in list order) meeting the above criteria. \n When no
-                        rules matching a request have been successfully attached to
-                        the parent a request is coming from, a HTTP 404 status code
-                        MUST be returned."
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -2844,8 +2395,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.
@@ -2880,12 +2431,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -2932,7 +2483,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -2945,10 +2496,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.
@@ -2964,12 +2515,12 @@ spec:
                                     be ignored. \n If a query param is repeated in
                                     an HTTP request, the behavior is purposely left
                                     undefined, since different data planes have different
-                                    capabilities. However, it's *recommended* that
+                                    capabilities. However, it is *recommended* that
                                     implementations should match against the first
                                     value of the param if the data plane supports
                                     it, as this behavior is expected in other load
                                     balancing contexts outside of the Gateway API.
-                                    Users should not route traffic based on repeated
+                                    \n Users SHOULD NOT route traffic based on repeated
                                     query params to guard themselves against potential
                                     differences in the implementations."
                                   maxLength: 256
@@ -2979,10 +2530,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -3052,14 +2604,15 @@ spec:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct
                           is intended for direct use as an array at the field path
-                          .status.conditions.  For example, type FooStatus struct{
-                          \    // Represents the observations of a foo's current state.
-                          \    // Known .status.conditions.type are: \"Available\",
-                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                          \    // +patchStrategy=merge     // +listType=map     //
-                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                          \n     // other fields }"
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
                         properties:
                           lastTransitionTime:
                             description: lastTransitionTime is the last time the condition
@@ -3146,15 +2699,19 @@ spec:
                       properties:
                         group:
                           default: gateway.networking.k8s.io
-                          description: "Group is the group of the referent. \n Support:
-                            Core"
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3168,39 +2725,17 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified, this refers to the local namespace of
-                            the Route. \n Support: Core"
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
-                        port:
-                          description: "Port is the network port this Route targets.
-                            It can be interpreted differently based on the type of
-                            parent resource. \n When the parent resource is a Gateway,
-                            this targets all listeners listening on the specified
-                            port that also support this kind of Route(and select this
-                            Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to
-                            a specific port as opposed to a listener(s) whose port(s)
-                            may be changed. When both Port and SectionName are specified,
-                            the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
-                            other types of parent resources MUST clearly document
-                            how/if Port is interpreted. \n For the purpose of status,
-                            an attachment is considered successful as long as the
-                            parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them
-                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
-                            listeners accept attachment from the referencing Route,
-                            the Route MUST be considered successfully attached. If
-                            no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-                            \n Support: Extended \n <gateway:experimental>"
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
                         sectionName:
                           description: "SectionName is the name of a section within
                             the target resource. In the following resources, SectionName

--- a/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_referencegrants.yaml
+++ b/pkg/manifests/assets/gateway-api/gateway.networking.k8s.io_referencegrants.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
-    gateway.networking.k8s.io/channel: experimental
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.2
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -34,7 +34,11 @@ spec:
           add to the set of trusted sources of inbound references for the namespace
           they are defined within. \n All cross-namespace references in Gateway API
           (with the exception of cross-namespace Gateway-route attachment) require
-          a ReferenceGrant. \n Support: Core"
+          a ReferenceGrant. \n ReferenceGrant is a form of runtime verification allowing
+          users to assert which cross-namespace object references are permitted. Implementations
+          that support ReferenceGrant MUST NOT permit cross-namespace references which
+          have no grant, and MUST respond to the removal of a grant by revoking the
+          access that the grant allowed. \n Support: Core"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -54,8 +58,8 @@ spec:
               from:
                 description: "From describes the trusted namespaces and kinds that
                   can reference the resources described in \"To\". Each entry in this
-                  list must be considered to be an additional place that references
-                  can be valid from, or to put this another way, entries must be combined
+                  list MUST be considered to be an additional place that references
+                  can be valid from, or to put this another way, entries MUST be combined
                   using OR. \n Support: Core"
                 items:
                   description: ReferenceGrantFrom describes trusted namespaces and
@@ -72,8 +76,8 @@ spec:
                         may support additional resources, the following types are
                         part of the \"Core\" support level for this field. \n When
                         used to permit a SecretObjectReference: \n * Gateway \n When
-                        used to permit a BackendObjectReference: \n * HTTPRoute *
-                        TCPRoute * TLSRoute * UDPRoute"
+                        used to permit a BackendObjectReference: \n * GRPCRoute *
+                        HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -95,9 +99,9 @@ spec:
                 type: array
               to:
                 description: "To describes the resources that may be referenced by
-                  the resources described in \"From\". Each entry in this list must
+                  the resources described in \"From\". Each entry in this list MUST
                   be considered to be an additional place that references can be valid
-                  to, or to put this another way, entries must be combined using OR.
+                  to, or to put this another way, entries MUST be combined using OR.
                   \n Support: Core"
                 items:
                   description: ReferenceGrantTo describes what Kinds are allowed as
@@ -140,6 +144,131 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: "ReferenceGrant identifies kinds of resources in other namespaces
+          that are trusted to reference the specified kinds of resources in the same
+          namespace as the policy. \n Each ReferenceGrant can be used to represent
+          a unique trust relationship. Additional Reference Grants can be used to
+          add to the set of trusted sources of inbound references for the namespace
+          they are defined within. \n All cross-namespace references in Gateway API
+          (with the exception of cross-namespace Gateway-route attachment) require
+          a ReferenceGrant. \n ReferenceGrant is a form of runtime verification allowing
+          users to assert which cross-namespace object references are permitted. Implementations
+          that support ReferenceGrant MUST NOT permit cross-namespace references which
+          have no grant, and MUST respond to the removal of a grant by revoking the
+          access that the grant allowed. \n Support: Core"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: "From describes the trusted namespaces and kinds that
+                  can reference the resources described in \"To\". Each entry in this
+                  list MUST be considered to be an additional place that references
+                  can be valid from, or to put this another way, entries MUST be combined
+                  using OR. \n Support: Core"
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: "Group is the group of the referent. When empty,
+                        the Kubernetes core API group is inferred. \n Support: Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: "Kind is the kind of the referent. Although implementations
+                        may support additional resources, the following types are
+                        part of the \"Core\" support level for this field. \n When
+                        used to permit a SecretObjectReference: \n * Gateway \n When
+                        used to permit a BackendObjectReference: \n * GRPCRoute *
+                        HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. \n
+                        Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              to:
+                description: "To describes the resources that may be referenced by
+                  the resources described in \"From\". Each entry in this list MUST
+                  be considered to be an additional place that references can be valid
+                  to, or to put this another way, entries MUST be combined using OR.
+                  \n Support: Core"
+                items:
+                  description: ReferenceGrantTo describes what Kinds are allowed as
+                    targets of the references.
+                  properties:
+                    group:
+                      description: "Group is the group of the referent. When empty,
+                        the Kubernetes core API group is inferred. \n Support: Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: "Kind is the kind of the referent. Although implementations
+                        may support additional resources, the following types are
+                        part of the \"Core\" support level for this field: \n * Secret
+                        when used to permit a SecretObjectReference * Service when
+                        used to permit a BackendObjectReference"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent. When unspecified,
+                        this policy refers to all resources of the specified Group
+                        and Kind in the local namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: false
     subresources: {}
 status:
   acceptedNames:

--- a/pkg/operator/controller/gatewayclass/servicemeshcontrolplane.go
+++ b/pkg/operator/controller/gatewayclass/servicemeshcontrolplane.go
@@ -6,15 +6,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	maistrav1 "github.com/maistra/istio-operator/pkg/apis/maistra/v1"
 	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
-
-	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,12 +60,11 @@ func (r *reconciler) ensureServiceMeshControlPlane(ctx context.Context, gatewayc
 // desiredServiceMeshControlPlane returns the desired servicemeshcontrolplane.
 func desiredServiceMeshControlPlane(name types.NamespacedName, ownerRef metav1.OwnerReference) (*maistrav2.ServiceMeshControlPlane, error) {
 	pilotContainerEnv := map[string]string{
-		"PILOT_ENABLE_GATEWAY_API":                         "true",
-		"PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER":   "true",
-		"PILOT_ENABLE_GATEWAY_API_STATUS":                  "true",
-		"PILOT_GATEWAY_API_CONTROLLER_NAME":                OpenShiftGatewayClassControllerName,
-		"PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS":           OpenShiftDefaultGatewayClassName,
-		"PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER": "false",
+		"PILOT_ENABLE_GATEWAY_CONTROLLER_MODE":   "true",
+		"PILOT_GATEWAY_API_CONTROLLER_NAME":      OpenShiftGatewayClassControllerName,
+		"PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS": OpenShiftDefaultGatewayClassName,
+		// OSSM will only reconcile the default gateway class if this is true.
+		"PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER": "true",
 	}
 	f := false
 	t := true
@@ -97,18 +93,15 @@ func desiredServiceMeshControlPlane(name types.NamespacedName, ownerRef metav1.O
 					Enablement: maistrav2.Enablement{Enabled: &f},
 				},
 			},
+			// Both ingress and egress gateways are enabled by default in OSSM.
+			// We don't need them, so we have to explicitly disable them.
 			Gateways: &maistrav2.GatewaysConfig{
 				ClusterIngress: &maistrav2.ClusterIngressGatewayConfig{
-					IngressEnabled: &t,
+					IngressEnabled: &f,
 					IngressGatewayConfig: maistrav2.IngressGatewayConfig{
 						GatewayConfig: maistrav2.GatewayConfig{
 							Enablement: maistrav2.Enablement{
-								Enabled: &t,
-							},
-							Service: maistrav2.GatewayServiceConfig{
-								ServiceSpec: corev1.ServiceSpec{
-									Type: corev1.ServiceTypeLoadBalancer,
-								},
+								Enabled: &f,
 							},
 						},
 					},
@@ -153,7 +146,12 @@ func desiredServiceMeshControlPlane(name types.NamespacedName, ownerRef metav1.O
 			Tracing: &maistrav2.TracingConfig{
 				Type: maistrav2.TracerTypeNone,
 			},
-			Version: "v2.4",
+			Version: "v2.5",
+			TechPreview: maistrav1.NewHelmValues(map[string]interface{}{
+				"gatewayAPI": map[string]interface{}{
+					"enabled": &t,
+				},
+			}),
 		},
 	}
 	return &smcp, nil


### PR DESCRIPTION
OSSM 2.5 supports Istio 1.18 and therefore only Gateway API v0.6.2 CRDS. 

 - Pull the new CRD yaml from upstream and update pkg/manifests/assets/gateway-api
- Update the pkg/operator/controller/gatewayclass/servicemeshcontrolplane.go to reflect changes required by OSSM 2.5.
