### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -85,6 +85,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: metrics-tls

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -104,6 +104,7 @@ spec:
             requests:
               cpu: 10m
               memory: 40Mi
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /etc/tls/private
             name: metrics-tls


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.