### PR TITLE
OCPBUGS-25193: Add vnet subnet read and join permission for azure

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -56,6 +56,8 @@ spec:
     - Microsoft.Network/dnsZones/A/write
     - Microsoft.Network/privateDnsZones/A/delete
     - Microsoft.Network/privateDnsZones/A/write
+    - Microsoft.Network/virtualNetworks/subnets/read
+    - Microsoft.Network/virtualNetworks/subnets/join/action
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
xref: OCPBUGS-25193

When installing a private cluster on azure, the customer supplies a
custom resource group for their existing vnet to which the ingress
operator (among others) must have access to. From within this custom
vnet, the operator must be able to read and join the various existing
subnets that the customer has supplied.

see also: https://github.com/openshift/cloud-credential-operator/pull/682 