### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: ingress-operator
     spec:

--- a/pkg/manifests/assets/canary/daemonset.yaml
+++ b/pkg/manifests/assets/canary/daemonset.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
     spec:
       securityContext:
         runAsNonRoot: true

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	configv1 "github.com/openshift/api/config/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 )
 
 const (
@@ -1136,6 +1137,14 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		deployment.Spec.Template.Spec.Containers[0].Ports,
 		httpPort, httpsPort, statsPort,
 	)
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.Annotations[securityv1.RequiredSCCAnnotation] = "restricted"
+	if ci.Status.EndpointPublishingStrategy.Type == operatorv1.HostNetworkStrategyType {
+		deployment.Spec.Template.Annotations[securityv1.RequiredSCCAnnotation] = "hostnetwork"
+	}
 
 	// Compute the hash for topology spread constraints and possibly
 	// affinity policy now, after all the other fields have been computed,

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -11,6 +11,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
@@ -488,7 +489,7 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		}
 	}
 
-	if expected, got := 1, len(deployment.Spec.Template.Annotations); expected != got {
+	if expected, got := 2, len(deployment.Spec.Template.Annotations); expected != got {
 		t.Errorf("expected len(annotations)=%v, got %v", expected, got)
 	}
 
@@ -500,6 +501,16 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		t.Errorf("missing annotation %q", WorkloadPartitioningManagement)
 	} else if expected := "{\"effect\": \"PreferredDuringScheduling\"}"; expected != val {
 		t.Errorf("expected annotation %q to be %q, got %q", WorkloadPartitioningManagement, expected, val)
+	}
+
+	expected := "restricted"
+	if ic.Status.EndpointPublishingStrategy.Type == operatorv1.HostNetworkStrategyType {
+		expected = "hostnetwork"
+	}
+	if val, ok := deployment.Spec.Template.Annotations[securityv1.RequiredSCCAnnotation]; !ok {
+		t.Errorf("missing annotation %q", securityv1.RequiredSCCAnnotation)
+	} else if expected != val {
+		t.Errorf("expected annotation %q to be %q, got %q", securityv1.RequiredSCCAnnotation, expected, val)
 	}
 
 	if deployment.Spec.Template.Spec.HostNetwork != false {


### PR DESCRIPTION
Workloads affected:
- `openshift-ingress/router-default` deployment
- `openshift-ingress-canary/ingress-canary` daemonset
- `openshift-ingress-operator/ingress-operator` deployment