### PR TITLE
OCPBUGS-30091: TestHostNetworkPortBinding: Delete t.Parallel()

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -970,7 +970,6 @@ func TestHostNetworkEndpointPublishingStrategy(t *testing.T) {
 // TestHostNetworkPortBinding creates two ingresscontrollers on the same node
 // with different port bindings and verifies that both routers are available.
 func TestHostNetworkPortBinding(t *testing.T) {
-	t.Parallel()
 	// deploy first ingresscontroller with the default port bindings
 	name1 := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkportbinding"}
 	ing1 := newHostNetworkController(name1, name1.Name+"."+dnsConfig.Spec.BaseDomain)


### PR DESCRIPTION
Remove the `t.Parallel()` call inside `TestHostNetworkPortBinding`.  The test is listed in `TestAll` as a serial test, but the test itself calls `t.Parallel()`, which causes it to run in parallel with other serial tests.  This likely causes occasional failures of the test in CI.