### PR TITLE
OCPBUGS-31722: Use centos7 tag for quay.io/centos7/httpd-24-centos7 image

### DIFF
--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -757,7 +757,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "httpd",
-						Image: "quay.io/centos7/httpd-24-centos7",
+						Image: "quay.io/centos7/httpd-24-centos7:centos7",
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
 							Name:          "http-svc",
@@ -1186,7 +1186,7 @@ func TestCRLUpdate(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "httpd",
-						Image: "quay.io/centos7/httpd-24-centos7",
+						Image: "quay.io/centos7/httpd-24-centos7:centos7",
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
 							Name:          "http-svc",


### PR DESCRIPTION
The latest tag for `quay.io/centos7/httpd-24-centos7` is no longer available, but the same image is accessible with the centos7 tag. In the long term, a different httpd image should probably be used, but this change should get tests passing.