### PR TITLE
OCPBUGS-29862: Bump golang to 1.20 net/http for CVE-2022-41723

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-ingress-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go v46.0.0+incompatible


### PR DESCRIPTION
Since 4.13 was go v1.19, the net/http package should be updated to  go v1.20 to eliminate vulnerability.
