### PR TITLE
[release-4.12] OCPBUGS-29861: Bump golang to 1.19 net/http for CVE-2022-41723

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-ingress-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v30.0.0+incompatible


### PR DESCRIPTION
Since 4.12 was go v1.18, the net/http package should be updated to go v1.19 to eliminate the vulnerability.  Per art-bot application, we are at 1.19.13.