### PR TITLE
OCPBUGS-32887: Allow operator to update Route spec.subdomain

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -218,6 +218,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - '*'
 


### PR DESCRIPTION
Before this change, cluster-ingress-operator did not have permission to update `spec.host` or `spec.subdomain` on an existing route as the operator's serviceaccount did not have the necessary "routes/custom-host" permission.  #965 added logic to the operator to clear `spec.host` and instead set `spec.subdomain`, but without the required permission, the update would fail with the following error message:

    ERROR   operator.init   controller/controller.go:265    Reconciler error {"controller": "canary_controller", "object": {"name":"default","namespace":"openshift-ingress-operator"}, "namespace": "openshift-ingress-operator", "name": "default", "reconcileID": "463061e3-93a1-4067-802e-03e3f1f8cdd0", "error": "failed to ensure canary route: failed to update canary route openshift-ingress-canary/canary: Route.route.openshift.io \"canary\" is invalid: spec.subdomain: Invalid value: \"canary-openshift-ingress-canary\": field is immutable"}

This PR adds the needed permission to the clusterrole for the operator's serviceaccount so that the update can succeed.