### PR TITLE
OCPBUGS-29894: Add test verifying that routers without the required CRLs are marked not ready

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -24,6 +24,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestClientTLS", TestClientTLS)
 		t.Run("TestMTLSWithCRLs", TestMTLSWithCRLs)
 		t.Run("TestCRLUpdate", TestCRLUpdate)
+		t.Run("TestRouterWaitsForCRLs", TestRouterWaitsForCRLs)
 		t.Run("TestContainerLogging", TestContainerLogging)
 		t.Run("TestContainerLoggingMaxLength", TestContainerLoggingMaxLength)
 		t.Run("TestContainerLoggingMinLength", TestContainerLoggingMinLength)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -796,6 +796,12 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 }
 
+func assertCreated(t *testing.T, cl client.Client, thing client.Object) {
+	if err := cl.Create(context.TODO(), thing); err != nil {
+		t.Fatalf("Failed to create %s: %v", thing.GetName(), err)
+	}
+}
+
 // assertDeleted tries to delete a cluster resource, and causes test failure if the delete fails.
 func assertDeleted(t *testing.T, cl client.Client, thing client.Object) {
 	t.Helper()


### PR DESCRIPTION
The new test should fail until https://github.com/openshift/router/pull/595 is merged.
This is part of the fix for OCPBUGS-29894