### PR TITLE
WIP: NE-906: release-4.15: test dynamic config manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ release-local:
 
 .PHONY: test-e2e
 test-e2e: generate
-	CGO_ENABLED=1 $(GO) test -timeout 1h -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
+	echo CGO_ENABLED=1 $(GO) test -timeout 1h -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
 
 .PHONY: test-e2e-list
 test-e2e-list: generate

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -555,7 +555,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 	}
 
 	dynamicConfigOverride := unsupportedConfigOverrides.DynamicConfigManager
-	if v, err := strconv.ParseBool(dynamicConfigOverride); err == nil && v {
+	if v, err := strconv.ParseBool(dynamicConfigOverride); err != nil || v {
 		env = append(env, corev1.EnvVar{
 			Name:  RouterHAProxyConfigManager,
 			Value: "true",

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -563,12 +563,10 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 			Name:  RouterHAProxyConfigManager,
 			Value: "true",
 		})
-		if isSet, value := MaxDynamicServersIsSet(ci, ingressConfig); isSet {
-			env = append(env, corev1.EnvVar{
-				Name:  RouterMaxDynamicServersEnvName,
-				Value: value,
-			})
-		}
+		env = append(env, corev1.EnvVar{
+			Name:  RouterMaxDynamicServersEnvName,
+			Value: "100", // for testing in CI
+		})
 	}
 	contStats := unsupportedConfigOverrides.ContStats
 	if v, err := strconv.ParseBool(contStats); err == nil && v {

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -106,6 +106,9 @@ const (
 	StatsPortName = "metrics"
 
 	haproxyMaxTimeoutMilliseconds = 2147483647 * time.Millisecond
+
+	RouterMaxDynamicServersEnvName    = "ROUTER_MAX_DYNAMIC_SERVERS"
+	RouterMaxDynamicServersAnnotation = "ingress.operator.openshift.io/max-dynamic-servers"
 )
 
 // ensureRouterDeployment ensures the router deployment exists for a given
@@ -560,6 +563,12 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 			Name:  RouterHAProxyConfigManager,
 			Value: "true",
 		})
+		if isSet, value := MaxDynamicServersIsSet(ci, ingressConfig); isSet {
+			env = append(env, corev1.EnvVar{
+				Name:  RouterMaxDynamicServersEnvName,
+				Value: value,
+			})
+		}
 	}
 	contStats := unsupportedConfigOverrides.ContStats
 	if v, err := strconv.ParseBool(contStats); err == nil && v {
@@ -1782,4 +1791,33 @@ func singleReplica(ingressConfig *configv1.Ingress, infraConfig *configv1.Infras
 	}
 
 	return topology == configv1.SingleReplicaTopologyMode
+}
+
+// MaxDynamicServersIsEnabledByAnnotation returns true if the map m
+// has the key RouterMaxDynamicServersAnnotation and it is an integer
+// value > 0.
+func MaxDynamicServersIsEnabledByAnnotation(m map[string]string) (bool, string) {
+	if val, ok := m[RouterMaxDynamicServersAnnotation]; ok && len(val) > 0 {
+		value, err := strconv.Atoi(val)
+		if err != nil || value < 0 {
+			log.Error(err, "invalid value", "annotation", RouterMaxDynamicServersAnnotation, "value", val)
+			return false, ""
+		} else {
+			return true, val
+		}
+	}
+
+	return false, ""
+}
+
+// MaxDynamicServersIsSet returns true if either the ingress
+// controller or the ingress config has the "max-dynamic-servers"
+// annotation. The presence of the annotation on the ingress
+// controller, irrespective of its value, always overrides any setting
+// on the ingress config.
+func MaxDynamicServersIsSet(ic *operatorv1.IngressController, ingressConfig *configv1.Ingress) (bool, string) {
+	if controllerAnnotation, controllerValue := MaxDynamicServersIsEnabledByAnnotation(ic.Annotations); controllerAnnotation {
+		return controllerAnnotation, controllerValue
+	}
+	return MaxDynamicServersIsEnabledByAnnotation(ingressConfig.Annotations)
 }

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -887,6 +887,7 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		{"STATS_PORT", true, "9146"},
 		{"ROUTER_SERVICE_HTTP_PORT", true, "8080"},
 		{"ROUTER_SERVICE_HTTPS_PORT", true, "8443"},
+		{RouterMaxDynamicServersEnvName, false, ""},
 	}
 	if err := checkDeploymentEnvironment(t, deployment, tests); err != nil {
 		t.Error(err)

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -887,7 +887,7 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		{"STATS_PORT", true, "9146"},
 		{"ROUTER_SERVICE_HTTP_PORT", true, "8080"},
 		{"ROUTER_SERVICE_HTTPS_PORT", true, "8443"},
-		{RouterMaxDynamicServersEnvName, false, ""},
+		{RouterMaxDynamicServersEnvName, true, "100"},
 	}
 	if err := checkDeploymentEnvironment(t, deployment, tests); err != nil {
 		t.Error(err)

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -434,7 +434,7 @@ func Test_desiredRouterDeployment(t *testing.T) {
 		{"ROUTER_DEFAULT_TUNNEL_TIMEOUT", false, ""},
 		{"ROUTER_ERRORFILE_503", false, ""},
 		{"ROUTER_ERRORFILE_404", false, ""},
-		{"ROUTER_HAPROXY_CONFIG_MANAGER", false, ""},
+		{"ROUTER_HAPROXY_CONFIG_MANAGER", true, "true"},
 		{"ROUTER_H1_CASE_ADJUST", false, ""},
 		{"ROUTER_INSPECT_DELAY", false, ""},
 		{"ROUTER_IP_V4_V6_MODE", false, ""},

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3284,6 +3284,9 @@ func TestUnsupportedConfigOverride(t *testing.T) {
 			icName := types.NamespacedName{Namespace: operatorNamespace, Name: tt.name}
 			domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 			ic := newPrivateController(icName, domain)
+			ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(`{"%s":"false"}`, tt.unsupportedConfigOverride)),
+			}
 			if err := kclient.Create(context.TODO(), ic); err != nil {
 				t.Fatalf("failed to create ingresscontroller: %v", err)
 			}


### PR DESCRIPTION
- Add "ingress.operator.openshift.io/max-dynamic-servers" annotation
- HACK: hard-code MAX_DYNAMIC_SERVERS to 100
- Enable config manager by default