### PR TITLE
OCPBUGS-34418: Allow router pods to use the "restricted" SCC

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -239,6 +239,7 @@ rules:
   - use
   resourceNames:
   - hostnetwork
+  - restricted
 
 # Mirrored from assets/router/cluster-role.yaml
 - apiGroups:

--- a/pkg/manifests/assets/router/cluster-role.yaml
+++ b/pkg/manifests/assets/router/cluster-role.yaml
@@ -51,6 +51,7 @@ rules:
   - use
   resourceNames:
   - hostnetwork
+  - restricted
 
 - apiGroups:
   - discovery.k8s.io


### PR DESCRIPTION
Give router pods permission to use the "restricted" securitycontextconstraint.  This permission is required since OpenShift 4.11 in order to use the "restricted" SCC.

[The OCP 4.11 release notes mention](https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission) that explicit permission is now required to use the "restricted" SCC:

    The restricted SCC is no longer available to users of new clusters, unless the access is explicitly granted. In clusters originally installed in OpenShift Container Platform 4.10 or earlier, all authenticated users can use the restricted SCC when upgrading to OpenShift Container Platform 4.11 and later.

Router pods already have permission to use the "hostnetwork" SCC as they need this SCC when they use the host network.  Because we did not give router pods permission to use the "restricted" SCC, the pods always used the "hostnetwork" SCC, even when they did not use the host network.  After this commit, router pods use the "hostnetwork" SCC if they use the host network, and router pods use the "restricted" SCC otherwise.
