### PR TITLE
[release-4.15] OCPBUGS-35028: internalServiceChanged: Fix target port logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/apiserver v0.28.3
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
+	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/gateway-api v0.5.1-0.20220921185115-ee7a83814203
 )

--- a/go.sum
+++ b/go.sum
@@ -1835,8 +1835,9 @@ k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 h1:jgGTlFYnhF1PM1Ax/lAlxUPE+KfCIXHaathvJg1C3ak=
+k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 maistra.io/api v0.0.0-20210601141927-1cbee4cb8ce8/go.mod h1:Os/zrIv6nsjgC43UAo17FFv+fvYlzANUWIpNNZEZ/KE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=

--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -31,20 +31,33 @@ spec:
           - name: DEFAULT_DESTINATION_CA_PATH
             value: /var/run/configmaps/service-ca/service-ca.crt
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: /healthz
               port: 1936
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
             terminationGracePeriodSeconds: 10
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /healthz/ready
               port: 1936
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           startupProbe:
             failureThreshold: 120
             httpGet:
               path: /healthz/ready
               port: 1936
+              scheme: HTTP
             periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
             requests:
               cpu: 100m

--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -63,9 +63,9 @@ spec:
           # SecretName is set at run-time.
       - name: service-ca-bundle
         configMap:
+          defaultMode: 420
           items:
           - key: service-ca.crt
             path: service-ca.crt
           name: service-ca-bundle
           optional: false
-        defaultMode: 420

--- a/pkg/manifests/assets/router/service-cloud.yaml
+++ b/pkg/manifests/assets/router/service-cloud.yaml
@@ -24,3 +24,4 @@ spec:
     protocol: TCP
     port: 443
     targetPort: https
+  sessionAffinity: None

--- a/pkg/manifests/assets/router/service-internal.yaml
+++ b/pkg/manifests/assets/router/service-internal.yaml
@@ -19,3 +19,4 @@ spec:
     port: 1936
     protocol: TCP
     targetPort: metrics
+  sessionAffinity: None

--- a/pkg/operator/controller/canary/daemonset_test.go
+++ b/pkg/operator/controller/canary/daemonset_test.go
@@ -200,6 +200,9 @@ func Test_canaryDaemonsetChanged(t *testing.T) {
 			if changed, updated := canaryDaemonSetChanged(original, mutated); changed != tc.expect {
 				t.Errorf("expect canaryDaemonSetChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := canaryDaemonSetChanged(original, updated); !updatedChanged {
+					t.Error("canaryDaemonSetChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := canaryDaemonSetChanged(mutated, updated); changedAgain {
 					t.Error("canaryDaemonSetChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/canary/namespace_test.go
+++ b/pkg/operator/controller/canary/namespace_test.go
@@ -38,6 +38,9 @@ func Test_canaryNamespaceChanged(t *testing.T) {
 			if changed, updated := canaryNamespaceChanged(original, mutated); changed != tc.expect {
 				t.Errorf("expect canaryNamespaceChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := canaryNamespaceChanged(original, updated); !updatedChanged {
+					t.Error("canaryNamespaceChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := canaryNamespaceChanged(mutated, updated); changedAgain {
 					t.Error("canaryNamespaceChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/canary/route_test.go
+++ b/pkg/operator/controller/canary/route_test.go
@@ -134,6 +134,9 @@ func Test_canaryRouteChanged(t *testing.T) {
 			if changed, updated := canaryRouteChanged(original, mutated); changed != tc.expect {
 				t.Errorf("expected canaryRouteChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := canaryRouteChanged(original, updated); !updatedChanged {
+					t.Error("canaryRouteChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := canaryRouteChanged(mutated, updated); changedAgain {
 					t.Error("canaryRouteChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/gatewayapi/crds.go
+++ b/pkg/operator/controller/gatewayapi/crds.go
@@ -114,7 +114,9 @@ func (r *reconciler) updateCRD(ctx context.Context, current, desired *apiextensi
 // the expected spec and if not returns an updated one.
 func crdChanged(current, expected *apiextensionsv1.CustomResourceDefinition) (bool, *apiextensionsv1.CustomResourceDefinition) {
 	crdCmpOpts := []cmp.Option{
-		// Ignore fields that the API may have modified.
+		// Ignore fields that the API may have modified.  Note: This
+		// list must be kept consistent with the updated.Spec.Foo =
+		// current.Spec.Foo assignments below!
 		cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinitionSpec{}, "Conversion"),
 		cmpopts.EquateEmpty(),
 	}
@@ -124,6 +126,10 @@ func crdChanged(current, expected *apiextensionsv1.CustomResourceDefinition) (bo
 
 	updated := current.DeepCopy()
 	updated.Spec = expected.Spec
+	// Preserve fields that the API, other controllers, or user may have
+	// modified.  Note: This list must be kept consistent with crdCmpOpts
+	// above!
+	updated.Spec.Conversion = current.Spec.Conversion
 
 	return true, updated
 }

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1510,7 +1510,7 @@ func hashableProbe(probe *corev1.Probe) *corev1.Probe {
 
 	var hashableProbe corev1.Probe
 
-	copyProbe(probe, &hashableProbe)
+	copyProbe(probe, &hashableProbe, false)
 
 	return &hashableProbe
 }
@@ -1611,9 +1611,9 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	updated.Spec.Template.Spec.Containers[0].SecurityContext = expected.Spec.Template.Spec.Containers[0].SecurityContext
 	updated.Spec.Template.Spec.Containers[0].Env = expected.Spec.Template.Spec.Containers[0].Env
 	updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
-	copyProbe(expected.Spec.Template.Spec.Containers[0].LivenessProbe, updated.Spec.Template.Spec.Containers[0].LivenessProbe)
-	copyProbe(expected.Spec.Template.Spec.Containers[0].ReadinessProbe, updated.Spec.Template.Spec.Containers[0].ReadinessProbe)
-	copyProbe(expected.Spec.Template.Spec.Containers[0].StartupProbe, updated.Spec.Template.Spec.Containers[0].StartupProbe)
+	copyProbe(expected.Spec.Template.Spec.Containers[0].LivenessProbe, updated.Spec.Template.Spec.Containers[0].LivenessProbe, true)
+	copyProbe(expected.Spec.Template.Spec.Containers[0].ReadinessProbe, updated.Spec.Template.Spec.Containers[0].ReadinessProbe, true)
+	copyProbe(expected.Spec.Template.Spec.Containers[0].StartupProbe, updated.Spec.Template.Spec.Containers[0].StartupProbe, true)
 	updated.Spec.Template.Spec.Containers[0].VolumeMounts = expected.Spec.Template.Spec.Containers[0].VolumeMounts
 	updated.Spec.Template.Spec.Containers[0].Ports = expected.Spec.Template.Spec.Containers[0].Ports
 	updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
@@ -1629,8 +1629,9 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 }
 
 // copyProbe copies probe parameters that the operator manages from probe a to
-// probe b.
-func copyProbe(a, b *corev1.Probe) {
+// probe b.  If a field in probe a has the default value, then the value is
+// copied to probe b only if copyDefaultValues is true.
+func copyProbe(a, b *corev1.Probe, copyDefaultValues bool) {
 	if a == nil || b == nil {
 		return
 	}
@@ -1641,7 +1642,7 @@ func copyProbe(a, b *corev1.Probe) {
 			Port: a.ProbeHandler.HTTPGet.Port,
 			Host: a.ProbeHandler.HTTPGet.Host,
 		}
-		if a.ProbeHandler.HTTPGet.Scheme != "HTTP" {
+		if copyDefaultValues || a.ProbeHandler.HTTPGet.Scheme != "HTTP" {
 			b.ProbeHandler.HTTPGet.Scheme = a.ProbeHandler.HTTPGet.Scheme
 		}
 	}
@@ -1651,14 +1652,14 @@ func copyProbe(a, b *corev1.Probe) {
 
 	// Users are permitted to modify the timeout, so *don't* copy it.
 
-	// Don't copy default values that the API set.
-	if a.PeriodSeconds != int32(10) {
+	// Conditionally copy default values that the API sets.
+	if copyDefaultValues || a.PeriodSeconds != int32(10) {
 		b.PeriodSeconds = a.PeriodSeconds
 	}
-	if a.SuccessThreshold != int32(1) {
+	if copyDefaultValues || a.SuccessThreshold != int32(1) {
 		b.SuccessThreshold = a.SuccessThreshold
 	}
-	if a.FailureThreshold != int32(3) {
+	if copyDefaultValues || a.FailureThreshold != int32(3) {
 		b.FailureThreshold = a.FailureThreshold
 	}
 }

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -432,7 +433,8 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		Name: statsVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: statsSecretName,
+				DefaultMode: ptr.To[int32](0644),
+				SecretName:  statsSecretName,
 			},
 		},
 	}
@@ -459,7 +461,8 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		Name: certsVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: certsSecretName,
+				DefaultMode: ptr.To[int32](0644),
+				SecretName:  certsSecretName,
 			},
 		},
 	}
@@ -478,6 +481,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 			Name: "error-pages",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: ptr.To[int32](0644),
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: configmapName.Name,
 					},
@@ -767,6 +771,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 				Name: "rsyslog-config",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
+						DefaultMode: ptr.To[int32](0644),
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: controller.RsyslogConfigMapName(ci).Name,
 						},
@@ -1061,6 +1066,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 				Name: clientCAVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
+						DefaultMode: ptr.To[int32](0644),
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: clientCAConfigmapName.Name,
 						},

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1636,13 +1636,16 @@ func copyProbe(a, b *corev1.Probe, copyDefaultValues bool) {
 		return
 	}
 
+	// Always copy values that differ from the default values, as well as
+	// values where the default value is the same as the zero value.
+
 	if a.ProbeHandler.HTTPGet != nil {
 		b.ProbeHandler.HTTPGet = &corev1.HTTPGetAction{
 			Path: a.ProbeHandler.HTTPGet.Path,
 			Port: a.ProbeHandler.HTTPGet.Port,
 			Host: a.ProbeHandler.HTTPGet.Host,
 		}
-		if copyDefaultValues || a.ProbeHandler.HTTPGet.Scheme != "HTTP" {
+		if a.ProbeHandler.HTTPGet.Scheme != "HTTP" {
 			b.ProbeHandler.HTTPGet.Scheme = a.ProbeHandler.HTTPGet.Scheme
 		}
 	}
@@ -1652,14 +1655,24 @@ func copyProbe(a, b *corev1.Probe, copyDefaultValues bool) {
 
 	// Users are permitted to modify the timeout, so *don't* copy it.
 
-	// Conditionally copy default values that the API sets.
-	if copyDefaultValues || a.PeriodSeconds != int32(10) {
+	if a.PeriodSeconds != int32(10) {
 		b.PeriodSeconds = a.PeriodSeconds
 	}
-	if copyDefaultValues || a.SuccessThreshold != int32(1) {
+	if a.SuccessThreshold != int32(1) {
 		b.SuccessThreshold = a.SuccessThreshold
 	}
-	if copyDefaultValues || a.FailureThreshold != int32(3) {
+	if a.FailureThreshold != int32(3) {
+		b.FailureThreshold = a.FailureThreshold
+	}
+
+	// If copyDefaultValues is true, copy values even if they are the
+	// default values that the API sets.
+	if copyDefaultValues {
+		if a.ProbeHandler.HTTPGet != nil {
+			b.ProbeHandler.HTTPGet.Scheme = a.ProbeHandler.HTTPGet.Scheme
+		}
+		b.PeriodSeconds = a.PeriodSeconds
+		b.SuccessThreshold = a.SuccessThreshold
 		b.FailureThreshold = a.FailureThreshold
 	}
 }

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -467,6 +467,21 @@ func Test_desiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvSorted(t, deployment)
 }
 
+// assertHasVolumes asserts that the given slice of volumes has all of the
+// named volumes.
+func assertHasVolumes(t *testing.T, volumes []corev1.Volume, expectedVolumeNames []string) {
+	t.Helper()
+
+	actualVolumeNames := []string{}
+	for _, volume := range volumes {
+		actualVolumeNames = append(actualVolumeNames, volume.Name)
+	}
+	assert.Equal(t, len(expectedVolumeNames), len(actualVolumeNames))
+	for _, volume := range expectedVolumeNames {
+		assert.Contains(t, actualVolumeNames, volume)
+	}
+}
+
 // assertVolumeHasDefaultMode asserts that the given int32 pointer points to a
 // value that is equal to the given int32 value.
 func assertVolumeHasDefaultMode(t *testing.T, expected int32, actual *int32, volumeName string) {
@@ -490,11 +505,19 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
 		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
 	}
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+	}
+	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
 		if secretName, ok := expectedVolumeSecretPairs[volume.Name]; ok {
 			if volume.Secret.SecretName != secretName {
 				t.Errorf("router Deployment expected volume %s to have secret %s, got %s", volume.Name, secretName, volume.Secret.SecretName)
 			}
+			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
 			continue
 		}
 		switch volume.Name {
@@ -638,10 +661,26 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		t.Errorf("expected empty startup probe host, got %q", deployment.Spec.Template.Spec.Containers[0].StartupProbe.ProbeHandler.HTTPGet.Host)
 	}
 
-	if len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts) <= 4 || deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name != "error-pages" {
-		t.Errorf("deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name %v", deployment.Spec.Template.Spec.Containers[0].VolumeMounts)
-		//log.Info(fmt.Sprintf("deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name %v", deployment.Spec.Template.Spec.Containers[0]))
-		t.Error("router Deployment is missing error code pages volume mount")
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+		"error-pages",
+		"rsyslog-config",
+		"rsyslog-socket",
+	}
+	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		switch volume.Name {
+		case "default-certificate", "metrics-certs", "stats-auth":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
+		case "error-pages", "rsyslog-config", "service-ca-bundle":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case "rsyslog-socket":
+		default:
+			t.Errorf("router deployment has unexpected volume %s", volume.Name)
+		}
 	}
 
 	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
@@ -864,18 +903,24 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
 		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
 	}
-
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+	}
+	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
 		if secretName, ok := expectedVolumeSecretPairs[volume.Name]; ok {
 			if volume.Secret.SecretName != secretName {
 				t.Errorf("router Deployment expected volume %s to have secret %s, got %s", volume.Name, secretName, volume.Secret.SecretName)
 			}
+			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
 			continue
 		}
 		switch volume.Name {
 		case "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
-		case "error-pages":
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
@@ -982,6 +1027,54 @@ func TestDesiredRouterDeploymentSingleReplica(t *testing.T) {
 
 	if deployment.Spec.Strategy.Type != "" || deployment.Spec.Strategy.RollingUpdate != nil {
 		t.Errorf("expected default deployment strategy, got %s", deployment.Spec.Strategy.Type)
+	}
+}
+
+// TestDesiredRouterDeploymentClientTLS verifies that desiredRouterDeployment
+// returns the expected deployment when client TLS is enabled.
+func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
+	ic.Spec.ClientTLS = operatorv1.ClientTLS{
+		AllowedSubjectPatterns:  []string{"foo", "bar"},
+		ClientCertificatePolicy: "Optional",
+		ClientCA: configv1.ConfigMapNameReference{
+			Name: "baz",
+		},
+	}
+	clientCAConfigmap := &corev1.ConfigMap{}
+	deployment, err := desiredRouterDeployment(ic, ingressControllerImage, ingressConfig, infraConfig, apiConfig, networkConfig, false, true, clientCAConfigmap, clusterProxyConfig)
+	if err != nil {
+		t.Fatalf("invalid router deployment: %v", err)
+	}
+
+	env := []envData{
+		{"ROUTER_MUTUAL_TLS_AUTH", true, "optional"},
+		{"ROUTER_MUTUAL_TLS_AUTH_CA", true, "/etc/pki/tls/client-ca/ca-bundle.pem"},
+		{"ROUTER_MUTUAL_TLS_AUTH_FILTER", true, `(?:foo|bar)`},
+	}
+	if err := checkDeploymentEnvironment(t, deployment, env); err != nil {
+		t.Error(err)
+	}
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+		"client-ca",
+	}
+	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		switch volume.Name {
+		case "default-certificate", "metrics-certs", "stats-auth":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
+		case "service-ca-bundle":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case "client-ca":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+			assert.Equal(t, "router-client-ca-default", volume.VolumeSource.ConfigMap.LocalObjectReference.Name)
+		default:
+			t.Errorf("router deployment has unexpected volume %s", volume.Name)
+		}
 	}
 }
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1866,6 +1866,9 @@ func Test_deploymentConfigChanged(t *testing.T) {
 			if changed, updated := deploymentConfigChanged(&original, mutated); changed != tc.expect {
 				t.Errorf("expect deploymentConfigChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := deploymentConfigChanged(&original, updated); !updatedChanged {
+					t.Error("deploymentConfigChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := deploymentConfigChanged(mutated, updated); changedAgain {
 					t.Error("deploymentConfigChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -465,6 +467,16 @@ func Test_desiredRouterDeployment(t *testing.T) {
 	checkDeploymentHasEnvSorted(t, deployment)
 }
 
+// assertVolumeHasDefaultMode asserts that the given int32 pointer points to a
+// value that is equal to the given int32 value.
+func assertVolumeHasDefaultMode(t *testing.T, expected int32, actual *int32, volumeName string) {
+	t.Helper()
+
+	if assert.NotNil(t, actual, "router deployment volume %s does not specify defaultMode", volumeName) {
+		assert.Equal(t, expected, *actual, "router deployment volume %s has unexpected defaultMode; expected: %O, got %O", volumeName, expected, *actual)
+	}
+}
+
 func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
@@ -483,7 +495,12 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 			if volume.Secret.SecretName != secretName {
 				t.Errorf("router Deployment expected volume %s to have secret %s, got %s", volume.Name, secretName, volume.Secret.SecretName)
 			}
-		} else if volume.Name != "service-ca-bundle" {
+			continue
+		}
+		switch volume.Name {
+		case "service-ca-bundle":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}
@@ -853,7 +870,13 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 			if volume.Secret.SecretName != secretName {
 				t.Errorf("router Deployment expected volume %s to have secret %s, got %s", volume.Name, secretName, volume.Secret.SecretName)
 			}
-		} else if volume.Name != "service-ca-bundle" && volume.Name != "error-pages" {
+			continue
+		}
+		switch volume.Name {
+		case "service-ca-bundle":
+			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case "error-pages":
+		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -16,7 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1574,14 +1574,14 @@ func Test_deploymentConfigChanged(t *testing.T) {
 		{
 			description: "if the router container .securityContext.allowPrivilegeEscalation changes",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+				deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = ptr.To[bool](false)
 			},
 			expect: true,
 		},
 		{
 			description: "if the router container .securityContext.readOnlyRootFilesystem changes",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = pointer.Bool(true)
+				deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = ptr.To[bool](true)
 			},
 			expect: true,
 		},
@@ -1770,8 +1770,8 @@ func Test_deploymentConfigChanged(t *testing.T) {
 										},
 									},
 									SecurityContext: &corev1.SecurityContext{
-										AllowPrivilegeEscalation: pointer.Bool(true),
-										ReadOnlyRootFilesystem:   pointer.Bool(false),
+										AllowPrivilegeEscalation: ptr.To[bool](true),
+										ReadOnlyRootFilesystem:   ptr.To[bool](false),
 									},
 								},
 							},

--- a/pkg/operator/controller/ingress/internal_service.go
+++ b/pkg/operator/controller/ingress/internal_service.go
@@ -118,7 +118,8 @@ func internalServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 
 	serviceCmpOpts := []cmp.Option{
 		// Ignore fields that the API, other controllers, or user may
-		// have modified.
+		// have modified.  Note: This list must be kept consistent with
+		// the updated.Spec.Foo = current.Spec.Foo assignments below!
 		cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort"),
 		cmpopts.IgnoreFields(corev1.ServiceSpec{},
 			"ClusterIP", "ClusterIPs",
@@ -163,14 +164,18 @@ func internalServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 		}
 	}
 	// Preserve fields that the API, other controllers, or user may have
-	// modified.
+	// modified.  Note: This list must be kept consistent with
+	// serviceCmpOpts above!
 	updated.Spec.ClusterIP = current.Spec.ClusterIP
+	updated.Spec.ClusterIPs = current.Spec.ClusterIPs
 	updated.Spec.ExternalIPs = current.Spec.ExternalIPs
 	updated.Spec.HealthCheckNodePort = current.Spec.HealthCheckNodePort
+	updated.Spec.IPFamilies = current.Spec.IPFamilies
+	updated.Spec.IPFamilyPolicy = current.Spec.IPFamilyPolicy
 	for i, updatedPort := range updated.Spec.Ports {
 		for _, currentPort := range current.Spec.Ports {
 			if currentPort.Name == updatedPort.Name {
-				updated.Spec.Ports[i].TargetPort = currentPort.TargetPort
+				updated.Spec.Ports[i].NodePort = currentPort.NodePort
 			}
 		}
 	}

--- a/pkg/operator/controller/ingress/internal_service_test.go
+++ b/pkg/operator/controller/ingress/internal_service_test.go
@@ -126,6 +126,14 @@ func Test_internalServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if .spec.ports[*].nodePort changes",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.Ports[0].NodePort = int32(33337)
+				svc.Spec.Ports[1].NodePort = int32(33338)
+			},
+			expect: false,
+		},
+		{
 			description: "if .spec.ports changes by changing the metrics port's target port from an integer to a string",
 			mutate: func(svc *corev1.Service) {
 				for i := range svc.Spec.Ports {
@@ -227,6 +235,9 @@ func Test_internalServiceChanged(t *testing.T) {
 			if changed, updated := internalServiceChanged(&original, mutated); changed != tc.expect {
 				t.Errorf("expected internalServiceChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := internalServiceChanged(&original, updated); !updatedChanged {
+					t.Error("internalServiceChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := internalServiceChanged(mutated, updated); changedAgain {
 					t.Error("internalServiceChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/ingress/internal_service_test.go
+++ b/pkg/operator/controller/ingress/internal_service_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// test_desiredInternalIngressControllerService verifies that
+// Test_desiredInternalIngressControllerService verifies that
 // desiredInternalIngressControllerService returns the expected service.
 func Test_desiredInternalIngressControllerService(t *testing.T) {
 	ic := &operatorv1.IngressController{

--- a/pkg/operator/controller/ingress/internal_service_test.go
+++ b/pkg/operator/controller/ingress/internal_service_test.go
@@ -53,6 +53,7 @@ func Test_desiredInternalIngressControllerService(t *testing.T) {
 		Port:       int32(1936),
 		TargetPort: intstr.FromString("metrics"),
 	}}, svc.Spec.Ports)
+	assert.Equal(t, "None", string(svc.Spec.SessionAffinity))
 }
 
 // Test_internalServiceChanged verifies that internalServiceChanged properly

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -82,19 +82,21 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 		value   string
 	}
 	testCases := []struct {
-		description                string
-		strategy                   *operatorv1.EndpointPublishingStrategy
-		proxyNeeded                bool
-		expectService              bool
-		expectedServiceAnnotations map[string]annotationExpectation
-		platformStatus             *configv1.PlatformStatus
+		description                   string
+		strategy                      *operatorv1.EndpointPublishingStrategy
+		proxyNeeded                   bool
+		expectService                 bool
+		expectedServiceAnnotations    map[string]annotationExpectation
+		expectedExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy
+		platformStatus                *configv1.PlatformStatus
 	}{
 		{
-			description:    "external classic load balancer with scope for aws platform",
-			platformStatus: platformStatus(configv1.AWSPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			proxyNeeded:    true,
-			expectService:  true,
+			description:                   "external classic load balancer with scope for aws platform",
+			platformStatus:                platformStatus(configv1.AWSPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			proxyNeeded:                   true,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {false, ""},
@@ -107,10 +109,11 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:   "external classic load balancer with scope for aws platform and custom user tags",
-			strategy:      lbs(operatorv1.ExternalLoadBalancer),
-			proxyNeeded:   true,
-			expectService: true,
+			description:                   "external classic load balancer with scope for aws platform and custom user tags",
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			proxyNeeded:                   true,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {true, "classic-load-balancer-key-with-value=100,classic-load-balancer-key-with-empty-value="},
@@ -137,11 +140,12 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "external classic load balancer without LoadBalancerStrategy for aws platform",
-			platformStatus: platformStatus(configv1.AWSPlatformType),
-			strategy:       lbs(""),
-			proxyNeeded:    true,
-			expectService:  true,
+			description:                   "external classic load balancer without LoadBalancerStrategy for aws platform",
+			platformStatus:                platformStatus(configv1.AWSPlatformType),
+			strategy:                      lbs(""),
+			proxyNeeded:                   true,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {false, ""},
@@ -154,11 +158,12 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "internal classic load balancer for aws platform",
-			platformStatus: platformStatus(configv1.AWSPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			proxyNeeded:    true,
-			expectService:  true,
+			description:                   "internal classic load balancer for aws platform",
+			platformStatus:                platformStatus(configv1.AWSPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			proxyNeeded:                   true,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {true, "true"},
 				awsLBAdditionalResourceTags:                  {false, ""},
@@ -171,11 +176,12 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "external network load balancer without scope for aws platform",
-			platformStatus: platformStatus(configv1.AWSPlatformType),
-			strategy:       nlb(""),
-			proxyNeeded:    false,
-			expectService:  true,
+			description:                   "external network load balancer without scope for aws platform",
+			platformStatus:                platformStatus(configv1.AWSPlatformType),
+			strategy:                      nlb(""),
+			proxyNeeded:                   false,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {false, ""},
@@ -189,11 +195,12 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "external network load balancer with scope for aws platform",
-			platformStatus: platformStatus(configv1.AWSPlatformType),
-			strategy:       nlb(operatorv1.ExternalLoadBalancer),
-			proxyNeeded:    false,
-			expectService:  true,
+			description:                   "external network load balancer with scope for aws platform",
+			platformStatus:                platformStatus(configv1.AWSPlatformType),
+			strategy:                      nlb(operatorv1.ExternalLoadBalancer),
+			proxyNeeded:                   false,
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {false, ""},
@@ -225,6 +232,7 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 					}},
 				},
 			},
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				awsInternalLBAnnotation:                      {false, ""},
 				awsLBAdditionalResourceTags:                  {true, "network-load-balancer-key-with-value=200,network-load-balancer-key-with-empty-value="},
@@ -244,66 +252,73 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			expectService:  false,
 		},
 		{
-			description:    "external load balancer for ibm platform",
-			platformStatus: platformStatus(configv1.IBMCloudPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for ibm platform",
+			platformStatus:                platformStatus(configv1.IBMCloudPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				iksLBScopeAnnotation: {true, iksLBScopePublic},
 			},
 		},
 		{
-			description:    "internal load balancer for ibm platform",
-			platformStatus: platformStatus(configv1.IBMCloudPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for ibm platform",
+			platformStatus:                platformStatus(configv1.IBMCloudPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				iksLBScopeAnnotation: {true, iksLBScopePrivate},
 			},
 		},
 		{
-			description:    "external load balancer for Power VS platform",
-			platformStatus: platformStatus(configv1.PowerVSPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for Power VS platform",
+			platformStatus:                platformStatus(configv1.PowerVSPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				iksLBScopeAnnotation: {true, iksLBScopePublic},
 			},
 		},
 		{
-			description:    "internal load balancer for Power VS platform",
-			platformStatus: platformStatus(configv1.PowerVSPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for Power VS platform",
+			platformStatus:                platformStatus(configv1.PowerVSPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				iksLBScopeAnnotation: {true, iksLBScopePrivate},
 			},
 		},
 		{
-			description:    "external load balancer for azure platform",
-			platformStatus: platformStatus(configv1.AzurePlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for azure platform",
+			platformStatus:                platformStatus(configv1.AzurePlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				azureInternalLBAnnotation:   {false, ""},
 				localWithFallbackAnnotation: {true, ""},
 			},
 		},
 		{
-			description:    "internal load balancer for azure platform",
-			platformStatus: platformStatus(configv1.AzurePlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for azure platform",
+			platformStatus:                platformStatus(configv1.AzurePlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				azureInternalLBAnnotation:   {true, "true"},
 				localWithFallbackAnnotation: {true, ""},
 			},
 		},
 		{
-			description:    "external load balancer for gcp platform",
-			platformStatus: platformStatus(configv1.GCPPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for gcp platform",
+			platformStatus:                platformStatus(configv1.GCPPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				GCPGlobalAccessAnnotation:   {false, ""},
 				gcpLBTypeAnnotation:         {false, ""},
@@ -311,10 +326,11 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "internal load balancer for gcp platform",
-			platformStatus: platformStatus(configv1.GCPPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for gcp platform",
+			platformStatus:                platformStatus(configv1.GCPPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				GCPGlobalAccessAnnotation:   {false, ""},
 				gcpLBTypeAnnotation:         {true, "Internal"},
@@ -322,10 +338,11 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "internal load balancer for gcp platform with global ClientAccess",
-			platformStatus: platformStatus(configv1.GCPPlatformType),
-			strategy:       gcpLB(operatorv1.InternalLoadBalancer, operatorv1.GCPGlobalAccess),
-			expectService:  true,
+			description:                   "internal load balancer for gcp platform with global ClientAccess",
+			platformStatus:                platformStatus(configv1.GCPPlatformType),
+			strategy:                      gcpLB(operatorv1.InternalLoadBalancer, operatorv1.GCPGlobalAccess),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				GCPGlobalAccessAnnotation:   {true, "true"},
 				gcpLBTypeAnnotation:         {true, "Internal"},
@@ -333,10 +350,11 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "internal load balancer for gcp platform with local ClientAccess",
-			platformStatus: platformStatus(configv1.GCPPlatformType),
-			strategy:       gcpLB(operatorv1.InternalLoadBalancer, operatorv1.GCPLocalAccess),
-			expectService:  true,
+			description:                   "internal load balancer for gcp platform with local ClientAccess",
+			platformStatus:                platformStatus(configv1.GCPPlatformType),
+			strategy:                      gcpLB(operatorv1.InternalLoadBalancer, operatorv1.GCPLocalAccess),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				GCPGlobalAccessAnnotation:   {true, "false"},
 				gcpLBTypeAnnotation:         {true, "Internal"},
@@ -344,40 +362,44 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 			},
 		},
 		{
-			description:    "external load balancer for openstack platform",
-			platformStatus: platformStatus(configv1.OpenStackPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for openstack platform",
+			platformStatus:                platformStatus(configv1.OpenStackPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				openstackInternalLBAnnotation: {false, ""},
 				localWithFallbackAnnotation:   {true, ""},
 			},
 		},
 		{
-			description:    "internal load balancer for openstack platform",
-			platformStatus: platformStatus(configv1.OpenStackPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for openstack platform",
+			platformStatus:                platformStatus(configv1.OpenStackPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				openstackInternalLBAnnotation: {true, "true"},
 				localWithFallbackAnnotation:   {true, ""},
 			},
 		},
 		{
-			description:    "external load balancer for alibaba platform",
-			platformStatus: platformStatus(configv1.AlibabaCloudPlatformType),
-			strategy:       lbs(operatorv1.ExternalLoadBalancer),
-			expectService:  true,
+			description:                   "external load balancer for alibaba platform",
+			platformStatus:                platformStatus(configv1.AlibabaCloudPlatformType),
+			strategy:                      lbs(operatorv1.ExternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				alibabaCloudLBAddressTypeAnnotation: {true, alibabaCloudLBAddressTypeInternet},
 				localWithFallbackAnnotation:         {true, ""},
 			},
 		},
 		{
-			description:    "internal load balancer for alibaba platform",
-			platformStatus: platformStatus(configv1.AlibabaCloudPlatformType),
-			strategy:       lbs(operatorv1.InternalLoadBalancer),
-			expectService:  true,
+			description:                   "internal load balancer for alibaba platform",
+			platformStatus:                platformStatus(configv1.AlibabaCloudPlatformType),
+			strategy:                      lbs(operatorv1.InternalLoadBalancer),
+			expectService:                 true,
+			expectedExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 			expectedServiceAnnotations: map[string]annotationExpectation{
 				alibabaCloudLBAddressTypeAnnotation: {true, alibabaCloudLBAddressTypeIntranet},
 				localWithFallbackAnnotation:         {true, ""},
@@ -448,6 +470,20 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 					t.Errorf("service has unexpected annotation: %s=%s", k, v)
 				}
 			}
+			assert.Equal(t, "LoadBalancer", string(svc.Spec.Type))
+			assert.Equal(t, tc.expectedExternalTrafficPolicy, svc.Spec.ExternalTrafficPolicy)
+			assert.Equal(t, "Cluster", string(*svc.Spec.InternalTrafficPolicy))
+			assert.Equal(t, []corev1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       int32(80),
+				TargetPort: intstr.FromString("http"),
+			}, {
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       int32(443),
+				TargetPort: intstr.FromString("https"),
+			}}, svc.Spec.Ports)
 			assert.Equal(t, "None", string(svc.Spec.SessionAffinity))
 		})
 	}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -872,6 +872,9 @@ func Test_loadBalancerServiceChanged(t *testing.T) {
 			if changed, updated := loadBalancerServiceChanged(&original, mutated); changed != tc.expect {
 				t.Errorf("expected loadBalancerServiceChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := loadBalancerServiceChanged(&original, updated); !updatedChanged {
+					t.Error("loadBalancerServiceChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := loadBalancerServiceChanged(mutated, updated); changedAgain {
 					t.Error("loadBalancerServiceChanged does not behave as a fixed point function")
 				}
@@ -970,6 +973,9 @@ func Test_loadBalancerServiceAnnotationsChanged(t *testing.T) {
 			if changed, updated := loadBalancerServiceAnnotationsChanged(&current, &expected, tc.managedAnnotations); changed != tc.expect {
 				t.Errorf("expected loadBalancerServiceAnnotationsChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := loadBalancerServiceAnnotationsChanged(&current, updated, tc.managedAnnotations); !updatedChanged {
+					t.Error("loadBalancerServiceAnnotationsChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := loadBalancerServiceAnnotationsChanged(&expected, updated, tc.managedAnnotations); changedAgain {
 					t.Error("loadBalancerServiceAnnotationsChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -448,6 +448,7 @@ func Test_desiredLoadBalancerService(t *testing.T) {
 					t.Errorf("service has unexpected annotation: %s=%s", k, v)
 				}
 			}
+			assert.Equal(t, "None", string(svc.Spec.SessionAffinity))
 		})
 	}
 }

--- a/pkg/operator/controller/ingress/monitoring_test.go
+++ b/pkg/operator/controller/ingress/monitoring_test.go
@@ -41,7 +41,12 @@ func Test_serviceMonitorChanged(t *testing.T) {
 	}
 	if changed, sm3 := serviceMonitorChanged(sm1, sm2); !changed {
 		t.Fatal("expected changed to be true after clearing servicemonitor's selector")
-	} else if changedAgain, _ := serviceMonitorChanged(sm2, sm3); changedAgain {
-		t.Fatal("serviceMonitorChanged does not behave as a fixed-point function")
+	} else {
+		if updatedChanged, _ := serviceMonitorChanged(sm1, sm3); !updatedChanged {
+			t.Error("serviceMonitorChanged reported changes but did not make any update")
+		}
+		if changedAgain, _ := serviceMonitorChanged(sm2, sm3); changedAgain {
+			t.Fatal("serviceMonitorChanged does not behave as a fixed-point function")
+		}
 	}
 }

--- a/pkg/operator/controller/ingress/namespace_test.go
+++ b/pkg/operator/controller/ingress/namespace_test.go
@@ -58,6 +58,9 @@ func Test_routerNamespaceChanged(t *testing.T) {
 			if changed, updated := routerNamespaceChanged(mutated, desired); changed != tc.expect {
 				t.Errorf("expect routerNamespaceChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := routerNamespaceChanged(mutated, updated); !updatedChanged {
+					t.Error("routerNamespaceChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := routerNamespaceChanged(desired, updated); changedAgain {
 					t.Error("routerNamespaceChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -134,8 +134,9 @@ func desiredNodePortService(ic *operatorv1.IngressController, deploymentRef meta
 					TargetPort: intstr.FromString("metrics"),
 				},
 			},
-			Selector: controller.IngressControllerDeploymentPodSelector(ic).MatchLabels,
-			Type:     corev1.ServiceTypeNodePort,
+			Selector:        controller.IngressControllerDeploymentPodSelector(ic).MatchLabels,
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Type:            corev1.ServiceTypeNodePort,
 		},
 	}
 	if !wantMetricsPort {

--- a/pkg/operator/controller/ingress/nodeport_service.go
+++ b/pkg/operator/controller/ingress/nodeport_service.go
@@ -195,7 +195,8 @@ func nodePortServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 
 	serviceCmpOpts := []cmp.Option{
 		// Ignore fields that the API, other controllers, or user may
-		// have modified.
+		// have modified.  Note: This list must be kept consistent with
+		// the updated.Spec.Foo = current.Spec.Foo assignments below!
 		cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort"),
 		cmpopts.IgnoreFields(corev1.ServiceSpec{},
 			"ClusterIP", "ClusterIPs",
@@ -240,10 +241,14 @@ func nodePortServiceChanged(current, expected *corev1.Service) (bool, *corev1.Se
 		}
 	}
 	// Preserve fields that the API, other controllers, or user may have
-	// modified.
+	// modified.  Note: This list must be kept consistent with
+	// serviceCmpOpts above!
 	updated.Spec.ClusterIP = current.Spec.ClusterIP
+	updated.Spec.ClusterIPs = current.Spec.ClusterIPs
 	updated.Spec.ExternalIPs = current.Spec.ExternalIPs
 	updated.Spec.HealthCheckNodePort = current.Spec.HealthCheckNodePort
+	updated.Spec.IPFamilies = current.Spec.IPFamilies
+	updated.Spec.IPFamilyPolicy = current.Spec.IPFamilyPolicy
 	for i, updatedPort := range updated.Spec.Ports {
 		for _, currentPort := range current.Spec.Ports {
 			if currentPort.Name == updatedPort.Name {

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -332,6 +332,9 @@ func Test_nodePortServiceChanged(t *testing.T) {
 			if changed, updated := nodePortServiceChanged(&original, mutated); changed != tc.expect {
 				t.Errorf("expect nodePortServiceChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := nodePortServiceChanged(&original, updated); !updatedChanged {
+					t.Error("nodePortServiceChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := nodePortServiceChanged(mutated, updated); changedAgain {
 					t.Error("nodePortServiceChanged does not behave as a fixed point function")
 				}

--- a/pkg/operator/controller/ingress/nodeport_service_test.go
+++ b/pkg/operator/controller/ingress/nodeport_service_test.go
@@ -72,7 +72,8 @@ func Test_desiredNodePortService(t *testing.T) {
 					Selector: map[string]string{
 						"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default",
 					},
-					Type: "NodePort",
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            "NodePort",
 				},
 			},
 		},
@@ -120,7 +121,8 @@ func Test_desiredNodePortService(t *testing.T) {
 					Selector: map[string]string{
 						"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default",
 					},
-					Type: "NodePort",
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Type:            "NodePort",
 				},
 			},
 		},

--- a/pkg/operator/controller/ingress/poddisruptionbudget_test.go
+++ b/pkg/operator/controller/ingress/poddisruptionbudget_test.go
@@ -148,6 +148,9 @@ func Test_podDisruptionBudgetChange(t *testing.T) {
 		if changed, updatedPdb := podDisruptionBudgetChanged(originalPdb, mutatedPdb); changed != tc.expect {
 			t.Errorf("%s, expect podDisruptionBudgetChanged to be %t, got %t", tc.description, tc.expect, changed)
 		} else if changed {
+			if updatedChanged, _ := podDisruptionBudgetChanged(originalPdb, updatedPdb); !updatedChanged {
+				t.Error("podDisruptionBudgetChanged reported changes but did not make any update")
+			}
 			if changedAgain, _ := podDisruptionBudgetChanged(mutatedPdb, updatedPdb); changedAgain {
 				t.Errorf("%s, podDisruptionBudgetChanged does not behave as a fixed point function", tc.description)
 			}

--- a/pkg/operator/controller/ingressclass/ingressclass_test.go
+++ b/pkg/operator/controller/ingressclass/ingressclass_test.go
@@ -182,6 +182,9 @@ func Test_ingressClassChanged(t *testing.T) {
 			if changed, updated := ingressClassChanged(&original, mutated); changed != tc.expect {
 				t.Errorf("expect ingressClassChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
+				if updatedChanged, _ := ingressClassChanged(&original, updated); !updatedChanged {
+					t.Error("ingressClassChanged reported changes but did not make any update")
+				}
 				if changedAgain, _ := ingressClassChanged(mutated, updated); changedAgain {
 					t.Error("ingressClassChanged does not behave as a fixed point function")
 				}

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -81,6 +81,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouteMetricsControllerRouteAndNamespaceSelector", TestRouteMetricsControllerRouteAndNamespaceSelector)
 		t.Run("TestSetIngressControllerResponseHeaders", TestSetIngressControllerResponseHeaders)
 		t.Run("TestSetRouteResponseHeaders", TestSetRouteResponseHeaders)
+		t.Run("TestReconcileInternalService", TestReconcileInternalService)
 	})
 
 	t.Run("serial", func(t *testing.T) {

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -971,23 +971,23 @@ func TestHostNetworkEndpointPublishingStrategy(t *testing.T) {
 // TestHostNetworkPortBinding creates two ingresscontrollers on the same node
 // with different port bindings and verifies that both routers are available.
 func TestHostNetworkPortBinding(t *testing.T) {
-	// deploy first ingresscontroller with the default port bindings
+	t.Log("creating an ingresscontroller with the default port bindings")
 	name1 := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkportbinding"}
 	ing1 := newHostNetworkController(name1, name1.Name+"."+dnsConfig.Spec.BaseDomain)
 	if err := kclient.Create(context.TODO(), ing1); err != nil {
 		t.Fatalf("failed to create the first ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ing1)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing1) })
 
 	err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name1, availableConditionsForIngressControllerWithHostNetwork...)
 	if err != nil {
 		t.Errorf("failed to observe expected conditions for the first ingresscontroller: %v", err)
 	}
 
-	// get first router's single replica
+	t.Log("getting pod list for the first ingresscontroller")
 	pods := &corev1.PodList{}
 	if err := kclient.List(context.TODO(), pods, client.InNamespace(operandNamespace)); err != nil {
-		t.Fatalf("failed to list the first ingresscontroller's PODs: %v", err)
+		t.Fatalf("failed to list the first ingresscontroller's pods: %v", err)
 	}
 	var pod1 *corev1.Pod
 	for _, p := range pods.Items {
@@ -997,7 +997,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 		}
 	}
 	if pod1 == nil {
-		t.Fatal("failed to find the first ingresscontroller's POD")
+		t.Fatal("failed to find the first ingresscontroller's pod")
 	}
 
 	routerContainer := pod1.Spec.Containers[0]
@@ -1008,14 +1008,16 @@ func TestHostNetworkPortBinding(t *testing.T) {
 		t.Errorf("pod %s is not running on the host's network", pod1.Name)
 	}
 
-	// create second ingresscontroller on the same node but with different port bindings
+	t.Log("creating a second ingresscontroller on the same node but with different port bindings")
 	name2 := types.NamespacedName{Namespace: operatorNamespace, Name: "samehost"}
 	strategy := &operatorv1.HostNetworkStrategy{
 		HTTPPort:  9080,
 		HTTPSPort: 9443,
 		StatsPort: 9936,
 	}
-	// take the node placement of the first router
+	// Take the node name of the first ingresscontroller and configure a
+	// node selector on the second ingresscontroller to force the router
+	// pods all to land on the same node host.
 	placement := &operatorv1.NodePlacement{
 		Tolerations: pod1.Spec.Tolerations,
 		NodeSelector: &metav1.LabelSelector{
@@ -1029,15 +1031,16 @@ func TestHostNetworkPortBinding(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ing2); err != nil {
 		t.Fatalf("failed to create the second ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ing2)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing2) })
 
 	err = waitForIngressControllerCondition(t, kclient, 5*time.Minute, name2, availableConditionsForIngressControllerWithHostNetwork...)
 	if err != nil {
 		t.Errorf("failed to observe expected conditions for the second ingresscontroller: %v", err)
 	}
 
+	t.Log("getting pod list for the second ingresscontroller")
 	if err := kclient.List(context.TODO(), pods, client.InNamespace(operandNamespace)); err != nil {
-		t.Fatalf("failed to list the first ingresscontroller's PODs: %v", err)
+		t.Fatalf("failed to list the first ingresscontroller's pods: %v", err)
 	}
 	var pod2 *corev1.Pod
 	for _, p := range pods.Items {
@@ -1047,7 +1050,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 		}
 	}
 	if pod2 == nil {
-		t.Fatalf("failed to find the second ingresscontroller's POD")
+		t.Fatalf("failed to find the second ingresscontroller's pod")
 	}
 	routerContainer = pod2.Spec.Containers[0]
 	assertContainerHasPort(t, routerContainer, "http", 9080)

--- a/vendor/k8s.io/utils/integer/integer.go
+++ b/vendor/k8s.io/utils/integer/integer.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package integer
 
+import "math"
+
 // IntMax returns the maximum of the params
 func IntMax(a, b int) int {
 	if b > a {
@@ -65,9 +67,7 @@ func Int64Min(a, b int64) int64 {
 }
 
 // RoundToInt32 rounds floats into integer numbers.
+// Deprecated: use math.Round() and a cast directly.
 func RoundToInt32(a float64) int32 {
-	if a < 0 {
-		return int32(a - 0.5)
-	}
-	return int32(a + 0.5)
+	return int32(math.Round(a))
 }

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Deprecated: Use functions in k8s.io/utils/ptr instead: ptr.To to obtain
+// a pointer, ptr.Deref to dereference a pointer, ptr.Equal to compare
+// dereferenced pointers.
 package pointer
 
 import (
-	"fmt"
-	"reflect"
 	"time"
+
+	"k8s.io/utils/ptr"
 )
 
 // AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
@@ -28,383 +31,219 @@ import (
 //
 // This function is only valid for structs and pointers to structs.  Any other
 // type will cause a panic.  Passing a typed nil pointer will return true.
-func AllPtrFieldsNil(obj interface{}) bool {
-	v := reflect.ValueOf(obj)
-	if !v.IsValid() {
-		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
-	}
-	if v.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return true
-		}
-		v = v.Elem()
-	}
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
-			return false
-		}
-	}
-	return true
-}
+//
+// Deprecated: Use ptr.AllPtrFieldsNil instead.
+var AllPtrFieldsNil = ptr.AllPtrFieldsNil
 
-// Int returns a pointer to an int
-func Int(i int) *int {
-	return &i
-}
+// Int returns a pointer to an int.
+var Int = ptr.To[int]
 
 // IntPtr is a function variable referring to Int.
 //
-// Deprecated: Use Int instead.
+// Deprecated: Use ptr.To instead.
 var IntPtr = Int // for back-compat
 
 // IntDeref dereferences the int ptr and returns it if not nil, or else
 // returns def.
-func IntDeref(ptr *int, def int) int {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var IntDeref = ptr.Deref[int]
 
 // IntPtrDerefOr is a function variable referring to IntDeref.
 //
-// Deprecated: Use IntDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var IntPtrDerefOr = IntDeref // for back-compat
 
 // Int32 returns a pointer to an int32.
-func Int32(i int32) *int32 {
-	return &i
-}
+var Int32 = ptr.To[int32]
 
 // Int32Ptr is a function variable referring to Int32.
 //
-// Deprecated: Use Int32 instead.
+// Deprecated: Use ptr.To instead.
 var Int32Ptr = Int32 // for back-compat
 
 // Int32Deref dereferences the int32 ptr and returns it if not nil, or else
 // returns def.
-func Int32Deref(ptr *int32, def int32) int32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Int32Deref = ptr.Deref[int32]
 
 // Int32PtrDerefOr is a function variable referring to Int32Deref.
 //
-// Deprecated: Use Int32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Int32PtrDerefOr = Int32Deref // for back-compat
 
 // Int32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Int32Equal(a, b *int32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Int32Equal = ptr.Equal[int32]
 
 // Uint returns a pointer to an uint
-func Uint(i uint) *uint {
-	return &i
-}
+var Uint = ptr.To[uint]
 
 // UintPtr is a function variable referring to Uint.
 //
-// Deprecated: Use Uint instead.
+// Deprecated: Use ptr.To instead.
 var UintPtr = Uint // for back-compat
 
 // UintDeref dereferences the uint ptr and returns it if not nil, or else
 // returns def.
-func UintDeref(ptr *uint, def uint) uint {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var UintDeref = ptr.Deref[uint]
 
 // UintPtrDerefOr is a function variable referring to UintDeref.
 //
-// Deprecated: Use UintDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var UintPtrDerefOr = UintDeref // for back-compat
 
 // Uint32 returns a pointer to an uint32.
-func Uint32(i uint32) *uint32 {
-	return &i
-}
+var Uint32 = ptr.To[uint32]
 
 // Uint32Ptr is a function variable referring to Uint32.
 //
-// Deprecated: Use Uint32 instead.
+// Deprecated: Use ptr.To instead.
 var Uint32Ptr = Uint32 // for back-compat
 
 // Uint32Deref dereferences the uint32 ptr and returns it if not nil, or else
 // returns def.
-func Uint32Deref(ptr *uint32, def uint32) uint32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Uint32Deref = ptr.Deref[uint32]
 
 // Uint32PtrDerefOr is a function variable referring to Uint32Deref.
 //
-// Deprecated: Use Uint32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Uint32PtrDerefOr = Uint32Deref // for back-compat
 
 // Uint32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Uint32Equal(a, b *uint32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Uint32Equal = ptr.Equal[uint32]
 
 // Int64 returns a pointer to an int64.
-func Int64(i int64) *int64 {
-	return &i
-}
+var Int64 = ptr.To[int64]
 
 // Int64Ptr is a function variable referring to Int64.
 //
-// Deprecated: Use Int64 instead.
+// Deprecated: Use ptr.To instead.
 var Int64Ptr = Int64 // for back-compat
 
 // Int64Deref dereferences the int64 ptr and returns it if not nil, or else
 // returns def.
-func Int64Deref(ptr *int64, def int64) int64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Int64Deref = ptr.Deref[int64]
 
 // Int64PtrDerefOr is a function variable referring to Int64Deref.
 //
-// Deprecated: Use Int64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Int64PtrDerefOr = Int64Deref // for back-compat
 
 // Int64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Int64Equal(a, b *int64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Int64Equal = ptr.Equal[int64]
 
 // Uint64 returns a pointer to an uint64.
-func Uint64(i uint64) *uint64 {
-	return &i
-}
+var Uint64 = ptr.To[uint64]
 
 // Uint64Ptr is a function variable referring to Uint64.
 //
-// Deprecated: Use Uint64 instead.
+// Deprecated: Use ptr.To instead.
 var Uint64Ptr = Uint64 // for back-compat
 
 // Uint64Deref dereferences the uint64 ptr and returns it if not nil, or else
 // returns def.
-func Uint64Deref(ptr *uint64, def uint64) uint64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Uint64Deref = ptr.Deref[uint64]
 
 // Uint64PtrDerefOr is a function variable referring to Uint64Deref.
 //
-// Deprecated: Use Uint64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Uint64PtrDerefOr = Uint64Deref // for back-compat
 
 // Uint64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Uint64Equal(a, b *uint64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Uint64Equal = ptr.Equal[uint64]
 
 // Bool returns a pointer to a bool.
-func Bool(b bool) *bool {
-	return &b
-}
+var Bool = ptr.To[bool]
 
 // BoolPtr is a function variable referring to Bool.
 //
-// Deprecated: Use Bool instead.
+// Deprecated: Use ptr.To instead.
 var BoolPtr = Bool // for back-compat
 
 // BoolDeref dereferences the bool ptr and returns it if not nil, or else
 // returns def.
-func BoolDeref(ptr *bool, def bool) bool {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var BoolDeref = ptr.Deref[bool]
 
 // BoolPtrDerefOr is a function variable referring to BoolDeref.
 //
-// Deprecated: Use BoolDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var BoolPtrDerefOr = BoolDeref // for back-compat
 
 // BoolEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func BoolEqual(a, b *bool) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var BoolEqual = ptr.Equal[bool]
 
 // String returns a pointer to a string.
-func String(s string) *string {
-	return &s
-}
+var String = ptr.To[string]
 
 // StringPtr is a function variable referring to String.
 //
-// Deprecated: Use String instead.
+// Deprecated: Use ptr.To instead.
 var StringPtr = String // for back-compat
 
 // StringDeref dereferences the string ptr and returns it if not nil, or else
 // returns def.
-func StringDeref(ptr *string, def string) string {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var StringDeref = ptr.Deref[string]
 
 // StringPtrDerefOr is a function variable referring to StringDeref.
 //
-// Deprecated: Use StringDeref instead.
+// Deprecated: Use ptr.Deref instead.
 var StringPtrDerefOr = StringDeref // for back-compat
 
 // StringEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func StringEqual(a, b *string) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var StringEqual = ptr.Equal[string]
 
 // Float32 returns a pointer to a float32.
-func Float32(i float32) *float32 {
-	return &i
-}
+var Float32 = ptr.To[float32]
 
 // Float32Ptr is a function variable referring to Float32.
 //
-// Deprecated: Use Float32 instead.
+// Deprecated: Use ptr.To instead.
 var Float32Ptr = Float32
 
 // Float32Deref dereferences the float32 ptr and returns it if not nil, or else
 // returns def.
-func Float32Deref(ptr *float32, def float32) float32 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Float32Deref = ptr.Deref[float32]
 
 // Float32PtrDerefOr is a function variable referring to Float32Deref.
 //
-// Deprecated: Use Float32Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Float32PtrDerefOr = Float32Deref // for back-compat
 
 // Float32Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Float32Equal(a, b *float32) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Float32Equal = ptr.Equal[float32]
 
 // Float64 returns a pointer to a float64.
-func Float64(i float64) *float64 {
-	return &i
-}
+var Float64 = ptr.To[float64]
 
 // Float64Ptr is a function variable referring to Float64.
 //
-// Deprecated: Use Float64 instead.
+// Deprecated: Use ptr.To instead.
 var Float64Ptr = Float64
 
 // Float64Deref dereferences the float64 ptr and returns it if not nil, or else
 // returns def.
-func Float64Deref(ptr *float64, def float64) float64 {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var Float64Deref = ptr.Deref[float64]
 
 // Float64PtrDerefOr is a function variable referring to Float64Deref.
 //
-// Deprecated: Use Float64Deref instead.
+// Deprecated: Use ptr.Deref instead.
 var Float64PtrDerefOr = Float64Deref // for back-compat
 
 // Float64Equal returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func Float64Equal(a, b *float64) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var Float64Equal = ptr.Equal[float64]
 
 // Duration returns a pointer to a time.Duration.
-func Duration(d time.Duration) *time.Duration {
-	return &d
-}
+var Duration = ptr.To[time.Duration]
 
 // DurationDeref dereferences the time.Duration ptr and returns it if not nil, or else
 // returns def.
-func DurationDeref(ptr *time.Duration, def time.Duration) time.Duration {
-	if ptr != nil {
-		return *ptr
-	}
-	return def
-}
+var DurationDeref = ptr.Deref[time.Duration]
 
 // DurationEqual returns true if both arguments are nil or both arguments
 // dereference to the same value.
-func DurationEqual(a, b *time.Duration) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return *a == *b
-}
+var DurationEqual = ptr.Equal[time.Duration]

--- a/vendor/k8s.io/utils/ptr/OWNERS
+++ b/vendor/k8s.io/utils/ptr/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- apelisse
+- stewart-yu
+- thockin
+reviewers:
+- apelisse
+- stewart-yu
+- thockin

--- a/vendor/k8s.io/utils/ptr/README.md
+++ b/vendor/k8s.io/utils/ptr/README.md
@@ -1,0 +1,3 @@
+# Pointer
+
+This package provides some functions for pointer-based operations.

--- a/vendor/k8s.io/utils/ptr/ptr.go
+++ b/vendor/k8s.io/utils/ptr/ptr.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ptr
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
+// for example, an API struct is handled by plugins which need to distinguish
+// "no plugin accepted this spec" from "this spec is empty".
+//
+// This function is only valid for structs and pointers to structs.  Any other
+// type will cause a panic.  Passing a typed nil pointer will return true.
+func AllPtrFieldsNil(obj interface{}) bool {
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() {
+		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+			return false
+		}
+	}
+	return true
+}
+
+// To returns a pointer to the given value.
+func To[T any](v T) *T {
+	return &v
+}
+
+// Deref dereferences ptr and returns the value it points to if no nil, or else
+// returns def.
+func Deref[T any](ptr *T, def T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Equal[T comparable](a, b *T) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}

--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -192,7 +192,7 @@ func (t *Trace) Log() {
 	t.endTime = &endTime
 	t.lock.Unlock()
 	// an explicit logging request should dump all the steps out at the higher level
-	if t.parentTrace == nil { // We don't start logging until Log or LogIfLong is called on the root trace
+	if t.parentTrace == nil && klogV(2) { // We don't start logging until Log or LogIfLong is called on the root trace
 		t.logTrace()
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1183,7 +1183,7 @@ k8s.io/kube-openapi/pkg/schemamutation
 k8s.io/kube-openapi/pkg/spec3
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
-# k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
+# k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 ## explicit; go 1.18
 k8s.io/utils/buffer
 k8s.io/utils/clock
@@ -1192,6 +1192,7 @@ k8s.io/utils/integer
 k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
+k8s.io/utils/ptr
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.16.3


### PR DESCRIPTION
This is a manual cherry-pick of #1072
Replaces #1079 

git cherry-pick 71eead5286597657de281306876b5d94dea7e4ad 5d0939ad56e239919acfd962882ab7c076b4b7d9 14daecdb9ca49a7742afd922a8a9b55acf6935a6 f2060e0c0440d9ac79e0c456b564ef0047709007 0cbd86a4438c45be8c2917b781503b06f52bd55e 826745c3a1db822c0538f3322e98b33bd628ed13 50e8a730070d8f0864694df476da4c9fdf2a168b eb1623e71ca636ab3a3ecf2b39ab59e42209f5b8 87975f7833badbe8cbb9942eaf0a46c3c9481f9a caeca655be660dd93be63d3bc370c8616deb8641 2aed24f184b7f98124547d293a5a316e3eeca535 
go mod tidy (to add module update to 2aed24f1)
go mod vendor
modify pkg/operator/controller/ingress/deployment_test.go 
git add go.*
git add vendor/*
git add pkg/operator/controller/ingress/deployment_test.go 
git commit --amend (to add Modified-by to 2aed24f1)
make update
make verify
make build
make test
git cherry-pick 1f9795b4f6d1c2829c2ed53eb5b08d70e917cafe 77595d00a45865819153d2094b1f15b40e508111
go mod tidy
go mod vendor
make update
make verify
make build
make test
