### PR TITLE
OCPBUGS-35356: Retry IngressController updates in router status E2E

### DIFF
--- a/test/e2e/router_status_test.go
+++ b/test/e2e/router_status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -122,15 +123,13 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 
 	// Update the ingress controller to not select routeFooLabel to be admitted, but to select
 	// routeBarLabel instead.
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingress resource: %v", err)
-	}
-	ic.Spec.RouteSelector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"type": "bar",
-		},
-	}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
+	if err := updateIngressControllerSpecWithRetryOnConflict(t, icName, 5*time.Minute, func(spec *operatorv1.IngressControllerSpec) {
+		spec.RouteSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"type": "bar",
+			},
+		}
+	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 
@@ -236,15 +235,13 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 
 	// Update the ingress controller to not select routeFooLabel to be admitted, but to select
 	// routeBarLabel instead.
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingress resource: %v", err)
-	}
-	ic.Spec.NamespaceSelector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"type": "bar",
-		},
-	}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
+	if err := updateIngressControllerSpecWithRetryOnConflict(t, icName, 5*time.Minute, func(spec *operatorv1.IngressControllerSpec) {
+		spec.NamespaceSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"type": "bar",
+			},
+		}
+	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 


### PR DESCRIPTION
Use updateIngressControllerSpecWithRetryOnConflict to resolve E2E flakiness caused by the IngressController being updated after the E2E test retrieves a local copy, resulting in an "object has been modified" error.

[Example Flake](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-ingress-operator/1014/pull-ci-openshift-cluster-ingress-operator-release-4.15-e2e-azure-operator/1800626575222247424#1:build-log.txt:284-285)

[Search.CI Link](https://search.dptools.openshift.org/?search=FAIL%3A+TestAll%2Fparallel%2FTestIngressControllerRouteSelectorUpdateShouldClearRouteStatus&maxAge=48h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)