### PR TITLE
OCPBUGS-35368: Add Regexp Anchor to TestAll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build -o $(BIN) $(GO_GCFLAGS) $(MAIN_PACKAGE)
 
-TEST ?= TestAll
+TEST ?= ^TestAll$
 
 .PHONY: build
 build: generate


### PR DESCRIPTION
The Makefile variable `Test` is assigned `TestAll` by default so that the E2E tests in `all_test.go` run by default. However, since Go interprets this as a regexp, both `TestAllowedSourceRanges` and `TestAllowedSourceRangesStatus` get run twice because their names starts with `TestAll`. Adding a regexp anchor will ensure the default `make test-e2e` command only runs the tests in `all_test.go`.