### PR TITLE
OCPBUGS-36465: Delete and recreate canary route to clear spec.host

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -112,6 +112,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestUpdateDefaultIngressControllerSecret", TestUpdateDefaultIngressControllerSecret)
 		t.Run("TestCanaryRoute", TestCanaryRoute)
 		t.Run("TestCanaryWithMTLS", TestCanaryWithMTLS)
+		t.Run("TestCanaryRouteClearsSpecHost", TestCanaryRouteClearsSpecHost)
 		t.Run("TestRouteHTTP2EnableAndDisableIngressConfig", TestRouteHTTP2EnableAndDisableIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -127,6 +127,64 @@ func TestCanaryRoute(t *testing.T) {
 	}
 }
 
+// TestCanaryRouteClearsSpecHost verifies that the operator clears the canary
+// route's spec.host field (which requires deleting and recreating the route) if
+// spec.host gets set.
+//
+// This is a serial test because it modifies the canary route.
+func TestCanaryRouteClearsSpecHost(t *testing.T) {
+	t.Log("Waiting for the default IngressController to be available...")
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, defaultName, defaultAvailableConditions...); err != nil {
+		t.Fatal(err)
+	}
+
+	var canaryRoute routev1.Route
+	canaryRouteName := controller.CanaryRouteName()
+	t.Log("Getting the canary route...")
+	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), canaryRouteName, &canaryRoute); err != nil {
+			t.Log(err)
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if v := canaryRoute.Spec.Host; len(v) != 0 {
+		t.Fatalf("Expected canary route to have empty spec.host, found %q.", v)
+	}
+
+	const bogusHost = "foo.bar"
+	canaryRoute.Spec.Host = bogusHost
+	t.Log("Setting a bogus spec.host...")
+	if err := kclient.Update(context.TODO(), &canaryRoute); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Waiting for the operator to clear spec.host...")
+	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := kclient.Get(context.TODO(), canaryRouteName, &canaryRoute); err != nil {
+			t.Log(err)
+			return false, nil
+		}
+
+		switch v := canaryRoute.Spec.Host; v {
+		case bogusHost:
+			t.Log("The operator has not yet cleared spec.host.")
+			return false, nil
+		case "":
+			t.Log("The operator has cleared spec.host.")
+			return true, nil
+		default:
+			return true, fmt.Errorf("found unexpected spec.host: %q", v)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // buildCanaryCurlPod returns a pod definition for a pod with the given name and image
 // and in the given namespace that curls the specified route via the route's hostname.
 func buildCanaryCurlPod(name, namespace, image, host string) *corev1.Pod {


### PR DESCRIPTION
Fix the update logic for the canary route to handle clearing `spec.host`. Attempts to clear `spec.host` using a simple update may be ignored (see https://github.com/openshift/origin/commit/54c072c122b48c5d7074fe8904d493d0534733e2).  Therefore it is necessary to delete and recreate the route.  

Before this change, the operator would set `spec.subdomain`, but it did not actually clear `spec.host`, and so setting `spec.subdomain` had no effect.

After this change, the operator should clear `spec.host`, and `spec.subdomain` should be in effect.

Follow-up to #1047.