### PR TITLE
[release-4.16] OCPBUGS-32887: Delete and recreate canary route to clear spec.host

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -111,6 +111,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouterCompressionOperation", TestRouterCompressionOperation)
 		t.Run("TestUpdateDefaultIngressControllerSecret", TestUpdateDefaultIngressControllerSecret)
 		t.Run("TestCanaryRoute", TestCanaryRoute)
+		t.Run("TestCanaryRouteClearsSpecHost", TestCanaryRouteClearsSpecHost)
 		t.Run("TestRouteHTTP2EnableAndDisableIngressConfig", TestRouteHTTP2EnableAndDisableIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)


### PR DESCRIPTION
Fix the update logic for the canary route to handle clearing `spec.host`. Attempts to clear `spec.host` using a simple update may be ignored (see https://github.com/openshift/origin/commit/54c072c122b48c5d7074fe8904d493d0534733e2).  Therefore it is necessary to delete and recreate the route.  

Before this change, the operator would set `spec.subdomain`, but it did not actually clear `spec.host`, and so setting `spec.subdomain` had no effect.

After this change, the operator should clear `spec.host`, and `spec.subdomain` should be in effect.

Follow-up to #1047.

---

This is manual cherry-pick of #1095.  #978 added the `TestCanaryWithMTLS` test to `test/e2e/all_test.go` in the release-4.17 branch, and this test is not in the release-4.16 branch, so it caused a conflict for this backport that required manual resolution.