### PR TITLE
 [release-4.14] OCPBUGS-36467: Allow operator to update Route spec.subdomain

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -210,6 +210,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - '*'
 

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -109,6 +109,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestRouterCompressionOperation", TestRouterCompressionOperation)
 		t.Run("TestUpdateDefaultIngressControllerSecret", TestUpdateDefaultIngressControllerSecret)
 		t.Run("TestCanaryRoute", TestCanaryRoute)
+		t.Run("TestCanaryRouteClearsSpecHost", TestCanaryRouteClearsSpecHost)
 		t.Run("TestRouteHTTP2EnableAndDisableIngressConfig", TestRouteHTTP2EnableAndDisableIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressConfig", TestRouteHardStopAfterEnableOnIngressConfig)
 		t.Run("TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig", TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig)


### PR DESCRIPTION
#### Allow operator to update Route `spec.subdomain`

Before this change, cluster-ingress-operator did not have permission to update `spec.host` or `spec.subdomain` on an existing route as the operator's serviceaccount did not have the necessary "routes/custom-host" permission.  #965 added logic to the operator to clear `spec.host` and instead set `spec.subdomain`, but without the required permission, the update would fail with the following error message:

    ERROR   operator.init   controller/controller.go:265    Reconciler error {"controller": "canary_controller", "object": {"name":"default","namespace":"openshift-ingress-operator"}, "namespace": "openshift-ingress-operator", "name": "default", "reconcileID": "463061e3-93a1-4067-802e-03e3f1f8cdd0", "error": "failed to ensure canary route: failed to update canary route openshift-ingress-canary/canary: Route.route.openshift.io \"canary\" is invalid: spec.subdomain: Invalid value: \"canary-openshift-ingress-canary\": field is immutable"}

This PR adds the needed permission to the clusterrole for the operator's serviceaccount so that the update can succeed.

#### Delete and recreate canary route to clear `spec.host`

Fix the update logic for the canary route to handle clearing `spec.host`. Attempts to clear `spec.host` using a simple update may be ignored (see https://github.com/openshift/origin/commit/54c072c122b48c5d7074fe8904d493d0534733e2).  Therefore it is necessary to delete and recreate the route.  

Before this change, the operator would set `spec.subdomain`, but it did not actually clear `spec.host`, and so setting `spec.subdomain` had no effect.

After this change, the operator should clear `spec.host`, and `spec.subdomain` should be in effect.

---

This is manual cherry-pick of #1100 so that we can test the changes in OpenShift 4.14 to verify [OCPBUGS-36465](https://issues.redhat.com/browse/OCPBUGS-36465) and unblock #1095, #1099, and #1100.  Cc: @melvinjoseph86.  