### PR TITLE
OCPBUGS-31664: Fix SyncLoadBalancerFailed status message of IngressController

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -751,7 +751,7 @@ func loadBalancerServiceIsProgressing(ic *operatorv1.IngressController, service 
 		err := fmt.Errorf("The IngressController scope was changed from %q to %q.", haveScope, wantScope)
 		switch platform.Type {
 		case configv1.AWSPlatformType, configv1.IBMCloudPlatformType:
-			err = fmt.Errorf("%[1]s  To effectuate this change, you must delete the service: `oc -n %[2]s delete svc/%[3]s`; the service load-balancer will then be deprovisioned and a new one created.  This will most likely cause the new load-balancer to have a different host name and IP address from the old one's.  Alternatively, you can revert the change to the IngressController: `oc -n openshift-ingress-operator patch ingresscontrollers/%[4]s --type=merge --patch='{\"spec\":{\"endpointPublishingStrategy\":{\"loadBalancer\":{\"scope\":\"%[5]s\"}}}}'", err.Error(), service.Namespace, service.Name, ic.Name, haveScope)
+			err = fmt.Errorf("%[1]s  To effectuate this change, you must delete the service: `oc -n %[2]s delete svc/%[3]s`; the service load-balancer will then be deprovisioned and a new one created.  This will most likely cause the new load-balancer to have a different host name and IP address from the old one's.  Alternatively, you can revert the change to the IngressController: `oc -n openshift-ingress-operator patch ingresscontrollers/%[4]s --type=merge --patch='{\"spec\":{\"endpointPublishingStrategy\":{\"loadBalancer\":{\"scope\":\"%[5]s\"}}}}'`", err.Error(), service.Namespace, service.Name, ic.Name, haveScope)
 		}
 		errs = append(errs, err)
 	}

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -871,7 +871,7 @@ func computeLoadBalancerStatus(ic *operatorv1.IngressController, service *corev1
 			if involved.Kind == "Service" && involved.Namespace == service.Namespace && involved.Name == service.Name && involved.UID == service.UID {
 				reason = "SyncLoadBalancerFailed"
 				message = fmt.Sprintf("The %s component is reporting SyncLoadBalancerFailed events like: %s\n%s",
-					event.Source.Component, event.Message, "The kube-controller-manager logs may contain more details.")
+					event.Source.Component, event.Message, "The cloud-controller-manager logs may contain more details.")
 				break
 			}
 		}


### PR DESCRIPTION
This PR revises status condition messages of IngessController with small changes.

As mentioned in the issue:
The ingress controller provides the `SyncLoadBalancerFailed` status for the `LoadBalancerReady` condition with a message that says `The kube-controller-manager logs may contain more details.`.

This is no longer true following the move from in-tree cloud providers to external cloud providers that are implemented by using the Cloud Controller Manager. To reflect that, the message is changed to `The cloud-controller-manager logs may contain more details.`


I was having trouble reproducing the Load Balancer service pending state as a day 2 operation to see the status message in the cluster. However, this is only a cosmetic change.

- `pkg/operator/controller/ingress/status.go` (`computeLoadBalancerStatus`): Change "kube-controller-manager" to "cloud-controller-manager" in IngressController status message.
- `pkg/operator/controller/ingress/load_balancer_service.go` (`loadBalancerServiceIsProgressing`): Fix a typo - add the closing backtick on a commmand described in the IngressController status message.
