### PR TITLE
OCPBUGS-34413: Refine logging for accurate infra CR status updates

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -1149,11 +1149,11 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		} else if updated {
 			if err := r.client.Status().Update(context.TODO(), infraConfig); err != nil {
 				errs = append(errs, fmt.Errorf("failed to update Infrastructure CR after updating Ingress LB IPs: %w", err))
+			} else {
+				log.Info("successfully updated Infra CR with Ingress Load Balancer IPs")
 			}
 		}
-		log.Info("successfully updated Infra CR with Ingress Load Balancer IPs")
 	}
-
 	errs = append(errs, r.syncRouteStatus(ci)...)
 
 	return retryable.NewMaybeRetryableAggregate(errs)


### PR DESCRIPTION
This PR revises the triggered log messages for the Cluster-ingress-operator

As mentioned in the issue:
In the cluster ingress operator, I addressed a logic error related to the log message triggered during updates to the Infrastructure CR. Previously, the log entry was generated even when no changes were made to the CR. 
To rectify this, I revised the logic to ensure that the log entry is now triggered only when a legitimate update to the Infra CR takes place.