### PR TITLE
OCPBUGS-37220:  Fix DNS for Gateway API on AWS

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -592,6 +592,8 @@ func (m *Provider) change(record *iov1.DNSRecord, zone configv1.DNSZone, action 
 		log.Info("upserted DNS record", "record", record.Spec, "zone", zone)
 	case deleteAction:
 		log.Info("deleted DNS record", "record", record.Spec, "zone", zone)
+	default:
+		log.Info("unrecognized action verb", "action", string(action))
 	}
 	return nil
 }
@@ -648,7 +650,7 @@ func (m *Provider) updateRecord(domain, zoneID, target, targetHostedZoneID, acti
 		}
 		return fmt.Errorf("couldn't update DNS record in zone %s: %v", zoneID, err)
 	}
-	log.Info("updated DNS record", "zone id", zoneID, "domain", domain, "target", target, "response", resp)
+	log.Info("upserted DNS record", "zone id", zoneID, "domain", domain, "target", target, "response", resp)
 	return nil
 }
 

--- a/pkg/resources/dnsrecord/dns.go
+++ b/pkg/resources/dnsrecord/dns.go
@@ -71,6 +71,10 @@ func EnsureDNSRecord(client client.Client, name types.NamespacedName, dnsRecordL
 	if err != nil {
 		return false, nil, err
 	}
+	if !wantWC {
+		log.Info("no dnsRecord desired", "domain", domain, "service", service)
+		return haveWC, current, nil
+	}
 
 	switch {
 	case wantWC && !haveWC:
@@ -83,6 +87,7 @@ func EnsureDNSRecord(client client.Client, name types.NamespacedName, dnsRecordL
 		if updated, err := updateDNSRecord(client, current, desired); err != nil {
 			return true, current, fmt.Errorf("failed to update dnsrecord %s/%s: %v", desired.Namespace, desired.Name, err)
 		} else if updated {
+			log.Info("updated dnsrecord", "olddnsrecord", current, "desireddnsrecord", desired)
 			return CurrentDNSRecord(client, name)
 		}
 	}


### PR DESCRIPTION
Before this change, a new Gateway API dnsRecord created on AWS was being deleted right after it was published.

pkg/operator/controller/gateway-service-dns/controller.go - add a predicate to ensure only dnsRecords for Gateway API are watched; export the ManagedByIstioLabelKey for use by the general dns controller; add logging to ensureDNSRecordsForGateway and deleteStaleDNSRecordsForGateway

pkg/resources/dnsrecord/dns.go - minor tweak and logging added to EnsureDNSRecord 
pkg/dns/aws/dns.go - add logging