### PR TITLE
OCPBUGS-37627: Fix getRouteHost error handling

### DIFF
--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -75,7 +75,10 @@ func TestCanaryRoute(t *testing.T) {
 		t.Fatalf("failed to observe canary route: %v", err)
 	}
 
-	canaryRouteHost := getRouteHost(t, canaryRoute, defaultName.Name)
+	canaryRouteHost := getRouteHost(canaryRoute, defaultName.Name)
+	if canaryRouteHost == "" {
+		t.Fatalf("failed to find host name for the %q router in route %s/%s: %#v", defaultName.Name, name.Namespace, name.Name, canaryRoute)
+	}
 
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildCanaryCurlPod("canary-route-check", canaryRoute.Namespace, image, canaryRouteHost)

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -169,7 +169,7 @@ func TestClientTLS(t *testing.T) {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Name: echoRoute.Name, Namespace: echoRoute.Namespace}, echoRoute); err != nil {
 			return false, fmt.Errorf("failed to get route %q: %w", echoRoute.Name, err)
 		}
-		routeHost = getRouteHost(t, echoRoute, ic.Name)
+		routeHost = getRouteHost(echoRoute, ic.Name)
 		return routeHost != "", nil
 	})
 
@@ -1073,7 +1073,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				if err := kclient.Get(context.TODO(), types.NamespacedName{Name: echoRoute.Name, Namespace: echoRoute.Namespace}, echoRoute); err != nil {
 					return false, fmt.Errorf("failed to get route %q: %w", echoRoute.Name, err)
 				}
-				routeHost = getRouteHost(t, echoRoute, ic.Name)
+				routeHost = getRouteHost(echoRoute, ic.Name)
 				return routeHost != "", nil
 			})
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2620,7 +2620,10 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
 		t.Fatalf("failed to get the console route: %v", err)
 	}
-	routeHost := getRouteHost(t, route, ic.Name)
+	routeHost := getRouteHost(route, ic.Name)
+	if routeHost == "" {
+		t.Fatalf("failed to find host name for the %q router in route %s/%s: %#v", ic.Name, routeName.Name, routeName.Name, route)
+	}
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "headertest",
@@ -2761,7 +2764,10 @@ func TestHTTPCookieCapture(t *testing.T) {
 	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
 		t.Fatalf("failed to get the console route: %v", err)
 	}
-	routeHost := getRouteHost(t, route, ic.Name)
+	routeHost := getRouteHost(route, ic.Name)
+	if routeHost == "" {
+		t.Fatalf("failed to find host name for the %q router in route %s/%s: %#v", ic.Name, routeName.Name, routeName.Name, route)
+	}
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cookietest",

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -283,7 +283,10 @@ func TestRouterCompressionOperation(t *testing.T) {
 		t.Fatalf("failed to get route: %v", err)
 	}
 
-	routeHost := getRouteHost(t, helloRoute, ic.Name)
+	routeHost := getRouteHost(helloRoute, ic.Name)
+	if routeHost == "" {
+		t.Fatalf("failed to find host name for the %q router in route %s/%s: %#v", ic.Name, routeName.Name, routeName.Name, helloRoute)
+	}
 
 	// curl to hello pod, without the Accept-Encoding header set to gzip.
 	if err := testContentEncoding(t, client, routeHost, false, ""); err != nil {

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -832,15 +832,12 @@ func assertDeletedWaitForCleanup(t *testing.T, cl client.Client, thing client.Ob
 
 // getRouteHost returns the host name of the given route for the named
 // IngressController.  If the IngressController has not added its host name to
-// the route's status, this function causes a fatal error.  For simplicity, this
+// the route's status, this function returns an empty string.  For simplicity, this
 // function does not check the "Admitted" status condition, so it will return
 // the host name if it is set even if the IngressController has rejected the
 // route.
-func getRouteHost(t *testing.T, route *routev1.Route, router string) string {
-	t.Helper()
-
+func getRouteHost(route *routev1.Route, router string) string {
 	if route == nil {
-		t.Fatal("route is nil")
 		return ""
 	}
 
@@ -850,7 +847,6 @@ func getRouteHost(t *testing.T, route *routev1.Route, router string) string {
 		}
 	}
 
-	t.Fatalf("failed to find host name for default router in route: %#v", route)
 	return ""
 }
 


### PR DESCRIPTION
Some E2E tests were calling `getRouteHost` and expected it not to call `t.Fatal` when the hostname couldn't be found. However, `getRouteHost` did call `t.Fatal`, causing E2E test flakes. This fix moves the `t.Fatal` call outside of `getRouteHost`, allowing the function callers to handle the error as they wish.