### PR TITLE
NE-1907: Manage OSSM operator subscription manually to ensure a compatible version is installed

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -32,7 +32,9 @@ import (
 const (
 	// defaultTrustedCABundle is the fully qualified path of the trusted CA bundle
 	// that is mounted from configmap openshift-ingress-operator/trusted-ca.
-	defaultTrustedCABundle = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	defaultGatewayAPIOperatorChannel = "stable"
+	defaultGatewayAPIOperatorVersion = "servicemeshoperator.v2.6.2"
 )
 
 type StartOptions struct {
@@ -51,6 +53,10 @@ type StartOptions struct {
 	CanaryImage string
 	// ReleaseVersion is the cluster version which the operator will converge to.
 	ReleaseVersion string
+	// GatewayAPIOperatorChannel is the release channel of the Gateway API implementation to install.
+	GatewayAPIOperatorChannel string
+	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
+	GatewayAPIOperatorVersion string
 }
 
 func NewStartCommand() *cobra.Command {
@@ -74,6 +80,8 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.ReleaseVersion, "release-version", "", statuscontroller.UnknownVersionValue, "the release version the operator should converge to (required)")
 	cmd.Flags().StringVarP(&options.MetricsListenAddr, "metrics-listen-addr", "", "127.0.0.1:60000", "metrics endpoint listen address (required)")
 	cmd.Flags().StringVarP(&options.ShutdownFile, "shutdown-file", "s", defaultTrustedCABundle, "if provided, shut down the operator when this file changes")
+	cmd.Flags().StringVarP(&options.GatewayAPIOperatorChannel, "gateway-api-operator-channel", "", defaultGatewayAPIOperatorChannel, "release channel of the Gateway API implementation to install")
+	cmd.Flags().StringVarP(&options.GatewayAPIOperatorVersion, "gateway-api-operator-version", "", defaultGatewayAPIOperatorVersion, "name and release of the Gateway API implementation to install")
 
 	if err := cmd.MarkFlagRequired("namespace"); err != nil {
 		panic(err)
@@ -118,10 +126,12 @@ func start(opts *StartOptions) error {
 	defer cancel()
 
 	operatorConfig := operatorconfig.Config{
-		OperatorReleaseVersion: opts.ReleaseVersion,
-		Namespace:              opts.OperatorNamespace,
-		IngressControllerImage: opts.IngressControllerImage,
-		CanaryImage:            opts.CanaryImage,
+		OperatorReleaseVersion:    opts.ReleaseVersion,
+		Namespace:                 opts.OperatorNamespace,
+		IngressControllerImage:    opts.IngressControllerImage,
+		CanaryImage:               opts.CanaryImage,
+		GatewayAPIOperatorChannel: opts.GatewayAPIOperatorChannel,
+		GatewayAPIOperatorVersion: opts.GatewayAPIOperatorVersion,
 	}
 
 	// Start operator metrics.

--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -178,6 +178,7 @@ rules:
   - operators.coreos.com
   resources:
   - subscriptions
+  - installplans
   verbs:
   - '*'
 

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -35,6 +35,10 @@ spec:
         - $(CANARY_IMAGE)
         - --release-version
         - $(RELEASE_VERSION)
+        - --gateway-api-operator-channel
+        - $(GATEWAY_API_OPERATOR_CHANNEL)
+        - --gateway-api-operator-version
+        - $(GATEWAY_API_OPERATOR_VERSION)
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
@@ -46,6 +50,10 @@ spec:
           value: openshift/origin-haproxy-router:v4.0
         - name: CANARY_IMAGE
           value: openshift/origin-cluster-ingress-operator:latest
+        - name: GATEWAY_API_OPERATOR_CHANNEL
+          value: stable
+        - name: GATEWAY_API_OPERATOR_VERSION
+          value: servicemeshoperator.v2.6.2
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -64,6 +64,10 @@ spec:
           - "$(CANARY_IMAGE)"
           - --release-version
           - "$(RELEASE_VERSION)"
+          - --gateway-api-operator-channel
+          - "$(GATEWAY_API_OPERATOR_CHANNEL)"
+          - --gateway-api-operator-version
+          - "$(GATEWAY_API_OPERATOR_VERSION)"
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
@@ -75,6 +79,10 @@ spec:
               value: openshift/origin-haproxy-router:v4.0
             - name: CANARY_IMAGE
               value: openshift/origin-cluster-ingress-operator:latest
+            - name: GATEWAY_API_OPERATOR_CHANNEL
+              value: stable
+            - name: GATEWAY_API_OPERATOR_VERSION
+              value: servicemeshoperator.v2.6.2
           resources:
             requests:
               cpu: 10m

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -15,5 +15,11 @@ type Config struct {
 	// CanaryImage is the ingress operator image, which runs a canary command.
 	CanaryImage string
 
+	// GatewayAPIOperatorChannel is the release channel of the Gateway API implementation to install.
+	GatewayAPIOperatorChannel string
+
+	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
+	GatewayAPIOperatorVersion string
+
 	Stop chan struct{}
 }

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
@@ -26,7 +27,7 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context) 
 		return false, nil, err
 	}
 
-	desired, err := desiredSubscription(name)
+	desired, err := desiredSubscription(name, r.config.GatewayAPIOperatorChannel, r.config.GatewayAPIOperatorVersion)
 	if err != nil {
 		return have, current, err
 	}
@@ -48,18 +49,19 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context) 
 }
 
 // desiredSubscription returns the desired subscription.
-func desiredSubscription(name types.NamespacedName) (*operatorsv1alpha1.Subscription, error) {
+func desiredSubscription(name types.NamespacedName, gwapiOperatorChannel, gwapiOperatorVersion string) (*operatorsv1alpha1.Subscription, error) {
 	subscription := operatorsv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: name.Namespace,
 			Name:      name.Name,
 		},
 		Spec: &operatorsv1alpha1.SubscriptionSpec{
-			Channel:                "stable",
-			InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,
+			Channel:                gwapiOperatorChannel,
+			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
 			Package:                "servicemeshoperator",
 			CatalogSource:          "redhat-operators",
 			CatalogSourceNamespace: "openshift-marketplace",
+			StartingCSV:            gwapiOperatorVersion,
 		},
 	}
 	return &subscription, nil
@@ -106,6 +108,95 @@ func (r *reconciler) updateSubscription(ctx context.Context, current, desired *o
 // subscription matches the expected subscription and the updated subscription
 // if they do not match.
 func subscriptionChanged(current, expected *operatorsv1alpha1.Subscription) (bool, *operatorsv1alpha1.Subscription) {
+	if cmp.Equal(current.Spec, expected.Spec, cmpopts.EquateEmpty()) {
+		return false, nil
+	}
+
+	updated := current.DeepCopy()
+	updated.Spec = expected.Spec
+
+	return true, updated
+}
+
+// ensureServiceMeshOperatorInstallPlan attempts to ensure that the install plan for the appropriate OSSM operator
+// version is approved.
+func (r *reconciler) ensureServiceMeshOperatorInstallPlan(ctx context.Context) (bool, *operatorsv1alpha1.InstallPlan, error) {
+	haveInstallPlan, current, err := r.currentInstallPlan(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+	switch {
+	case !haveInstallPlan:
+		// The OLM operator creates the initial InstallPlan, so if it doesn't exist yet or it's been deleted, do nothing
+		// and let the OLM operator handle it.
+		return false, nil, nil
+	case haveInstallPlan:
+		desired := desiredInstallPlan(current)
+		if updated, err := r.updateInstallPlan(ctx, current, desired); err != nil {
+			return true, current, err
+		} else if updated {
+			return r.currentInstallPlan(ctx)
+		}
+	}
+	return false, current, nil
+}
+
+// currentInstallPlan returns the InstallPlan that describes installing the expected version of the GatewayAPI
+// implementation, if one exists.
+func (r *reconciler) currentInstallPlan(ctx context.Context) (bool, *operatorsv1alpha1.InstallPlan, error) {
+	_, subscription, err := r.currentSubscription(ctx, operatorcontroller.ServiceMeshSubscriptionName())
+	if err != nil {
+		return false, nil, err
+	}
+	installPlans := &operatorsv1alpha1.InstallPlanList{}
+	if err := r.client.List(ctx, installPlans, client.InNamespace(operatorcontroller.OpenshiftOperatorNamespace)); err != nil {
+		return false, nil, err
+	}
+	if installPlans == nil || len(installPlans.Items) == 0 {
+		return false, nil, nil
+	}
+	for _, installPlan := range installPlans.Items {
+		if len(installPlan.OwnerReferences) == 0 || len(installPlan.Spec.ClusterServiceVersionNames) == 0 {
+			continue
+		}
+		for _, ownerRef := range installPlan.OwnerReferences {
+			if ownerRef.UID == subscription.UID {
+				for _, csvName := range installPlan.Spec.ClusterServiceVersionNames {
+					if csvName == r.config.GatewayAPIOperatorVersion {
+						return true, &installPlan, nil
+					}
+				}
+			}
+		}
+	}
+	// No valid InstallPlan found.
+	return false, nil, nil
+}
+
+// desiredInstallPlan returns a version of the expected InstallPlan that is approved.
+func desiredInstallPlan(current *operatorsv1alpha1.InstallPlan) *operatorsv1alpha1.InstallPlan {
+	desired := current.DeepCopy()
+	desired.Spec.Approved = true
+	return desired
+}
+
+// updateInstallPlan updates an existing InstallPlan if it differs from the desired state.
+func (r *reconciler) updateInstallPlan(ctx context.Context, current, desired *operatorsv1alpha1.InstallPlan) (bool, error) {
+	changed, updated := installPlanChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+	diff := cmp.Diff(current.Spec, updated.Spec, cmpopts.EquateEmpty())
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, fmt.Errorf("failed to update InstallPlan %s/%s: %w", current.Namespace, current.Name, err)
+	}
+	log.Info("updated InstallPlan", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+	return true, nil
+}
+
+// installPlanChanged returns a Boolean indicating whether the current InstallPlan matches the expected InstallPlan and
+// the updated InstallPlan if they do not match.
+func installPlanChanged(current, expected *operatorsv1alpha1.InstallPlan) (bool, *operatorsv1alpha1.InstallPlan) {
 	if cmp.Equal(current.Spec, expected.Spec, cmpopts.EquateEmpty()) {
 		return false, nil
 	}

--- a/pkg/operator/controller/gatewayclass/subscription_test.go
+++ b/pkg/operator/controller/gatewayclass/subscription_test.go
@@ -1,0 +1,416 @@
+package gatewayclass
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_ensureServiceMeshOperatorInstallPlan(t *testing.T) {
+	tests := []struct {
+		name            string
+		channel         string
+		version         string
+		existingObjects []runtime.Object
+		expectCreate    []client.Object
+		expectUpdate    []client.Object
+		expectDelete    []client.Object
+	}{
+		{
+			// No InstallPlan found; no changes expected.
+			name:            "No InstallPlan",
+			channel:         "stable",
+			version:         "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{},
+			expectCreate:    []client.Object{},
+			expectUpdate:    []client.Object{},
+			expectDelete:    []client.Object{},
+		},
+		{
+			// InstallPlan exists but is already approved. No changes expected.
+			name:    "InstallPlan already approved",
+			channel: "stable",
+			version: "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshSubscriptionName().Name,
+						UID:       "foobar",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator.v1.0.0",
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: true,
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			// InstallPlan exists and is not yet approved. Expect InstallPlan.Spec.Approved = true
+			name:    "InstallPlan not yet approved",
+			channel: "stable",
+			version: "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshSubscriptionName().Name,
+						UID:       "foobar",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator.v1.0.0",
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-foo",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: false,
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-foo",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: true,
+					},
+				},
+			},
+			expectDelete: []client.Object{},
+		},
+		{
+			// Multiple InstallPlans exist, and the desired InstallPlan is not approved. Expect InstallPlan.Spec.Approved = true only for the desired InstallPlan
+			name:    "Multiple InstallPlans, none approved",
+			channel: "stable",
+			version: "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshSubscriptionName().Name,
+						UID:       "foobar",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator.v1.0.0",
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-foo",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: false,
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-bar",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.1.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: false,
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-foo",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: true,
+					},
+				},
+			},
+			expectDelete: []client.Object{},
+		},
+		{
+			// An InstallPlan with the correct version exists, but it's owned by a different subscription. Expect no change.
+			name:    "InstallPlan is for different subscription",
+			channel: "stable",
+			version: "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshSubscriptionName().Name,
+						UID:       "foobar",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator.v1.0.0",
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "Install-foo",
+						Namespace: operatorcontroller.OpenshiftOperatorNamespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "bazquux",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.0.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: false,
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			// InstallPlan exists but is the incorrect version. No changes expected.
+			name:    "InstallPlan is incorrect version",
+			channel: "stable",
+			version: "servicemeshoperator.v1.0.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshSubscriptionName().Name,
+						UID:       "foobar",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator.v1.0.0",
+					},
+				},
+				&operatorsv1alpha1.InstallPlan{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								UID: "foobar",
+							},
+						},
+					},
+					Spec: operatorsv1alpha1.InstallPlanSpec{
+						ClusterServiceVersionNames: []string{
+							"servicemeshoperator.v1.1.0",
+						},
+						Approval: operatorsv1alpha1.ApprovalManual,
+						Approved: false,
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	configv1.Install(scheme)
+	apiextensionsv1.AddToScheme(scheme)
+	operatorsv1alpha1.AddToScheme(scheme)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.existingObjects...).
+				Build()
+			cl := &fakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+			reconciler := &reconciler{
+				client: cl,
+				config: Config{
+					OperatorNamespace:         "",
+					OperandNamespace:          "",
+					GatewayAPIOperatorChannel: tc.channel,
+					GatewayAPIOperatorVersion: tc.version,
+				},
+			}
+			_, _, err := reconciler.ensureServiceMeshOperatorInstallPlan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cmpOpts := []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Annotations", "ResourceVersion"),
+				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
+				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
+			}
+			if diff := cmp.Diff(tc.expectCreate, cl.added, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual creates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectUpdate, cl.updated, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual updates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectDelete, cl.deleted, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual deletes: %s", diff)
+			}
+		})
+	}
+}
+
+type fakeCache struct {
+	cache.Informers
+	client.Reader
+}
+
+type fakeClientRecorder struct {
+	client.Client
+	*testing.T
+
+	added   []client.Object
+	updated []client.Object
+	deleted []client.Object
+}
+
+func (c *fakeClientRecorder) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *fakeClientRecorder) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	return c.Client.List(ctx, obj, opts...)
+}
+
+func (c *fakeClientRecorder) Scheme() *runtime.Scheme {
+	return c.Client.Scheme()
+}
+
+func (c *fakeClientRecorder) RESTMapper() meta.RESTMapper {
+	return c.Client.RESTMapper()
+}
+
+func (c *fakeClientRecorder) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.added = append(c.added, obj)
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *fakeClientRecorder) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.deleted = append(c.deleted, obj)
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c *fakeClientRecorder) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.Client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *fakeClientRecorder) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updated = append(c.updated, obj)
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *fakeClientRecorder) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *fakeClientRecorder) Status() client.StatusWriter {
+	return c.Client.Status()
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -284,7 +284,7 @@ func ServiceMeshControlPlaneName(operandNamespace string) types.NamespacedName {
 // to install OpenShift Service Mesh.
 func ServiceMeshSubscriptionName() types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: "openshift-operators",
+		Namespace: OpenshiftOperatorNamespace,
 		Name:      "servicemeshoperator",
 	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -293,8 +293,10 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	// the manager; the gatewayapi controller starts it after it creates the
 	// Gateway API CRDs.
 	gatewayClassController, err := gatewayclasscontroller.NewUnmanaged(mgr, gatewayclasscontroller.Config{
-		OperatorNamespace: config.Namespace,
-		OperandNamespace:  operatorcontroller.DefaultOperandNamespace,
+		OperatorNamespace:         config.Namespace,
+		OperandNamespace:          operatorcontroller.DefaultOperandNamespace,
+		GatewayAPIOperatorChannel: config.GatewayAPIOperatorChannel,
+		GatewayAPIOperatorVersion: config.GatewayAPIOperatorVersion,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gatewayclass controller: %w", err)


### PR DESCRIPTION
Istio and the Gateway API CRDs need to be in sync to work. The CRDs are baked into a particular openshift release, so this change updates the ingress operator to install a compatible version with the CRDs it already installs.