### PR TITLE
OCPBUGS-31550: Gateway API - recreating SMCP which breaks Gateway API

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -2,13 +2,20 @@ package gatewayclass
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	maistrav2 "github.com/maistra/istio-operator/pkg/apis/maistra/v2"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"k8s.io/client-go/tools/record"
 
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -35,6 +42,7 @@ const (
 )
 
 var log = logf.Logger.WithName(controllerName)
+var gatewayClassController controller.Controller
 
 // NewUnmanaged creates and returns a controller that watches gatewayclasses and
 // installs and configures Istio.  This is an unmanaged controller, which means
@@ -61,6 +69,15 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, &handler.EnqueueRequestForObject{}, isOurGatewayClass, notIstioGatewayClass)); err != nil {
 		return nil, err
 	}
+
+	isServiceMeshSubscription := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == operatorcontroller.ServiceMeshSubscriptionName().Name
+	})
+	if err = c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.Subscription{},
+		enqueueRequestForDefaultGatewayClassController(config.OperandNamespace), isServiceMeshSubscription)); err != nil {
+		return nil, err
+	}
+	gatewayClassController = c
 	return c, nil
 }
 
@@ -81,6 +98,23 @@ type reconciler struct {
 	client   client.Client
 	cache    cache.Cache
 	recorder record.EventRecorder
+
+	startSMCPWatch sync.Once
+}
+
+func enqueueRequestForDefaultGatewayClassController(namespace string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, a client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: namespace,
+						Name:      OpenShiftDefaultGatewayClassName,
+					},
+				},
+			}
+		},
+	)
 }
 
 // Reconcile expects request to refer to a GatewayClass and creates or
@@ -95,10 +129,23 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	var errs []error
 	if _, _, err := r.ensureServiceMeshOperatorSubscription(ctx); err != nil {
-		errs = append(errs, err)
+		errs = append(errs, fmt.Errorf("failed to ensure ServiceMeshOperatorSubscription: %w", err))
 	}
 	if _, _, err := r.ensureServiceMeshControlPlane(ctx, &gatewayclass); err != nil {
 		errs = append(errs, err)
+	} else {
+		// The OSSM operator installs the maistra.io CRDs, Need to create the SMCP watch after the OSSM operator is installed.
+		// Using sync.Once here, to start the watch for SMCP, which should run only once.
+		r.startSMCPWatch.Do(func() {
+			isOurSMCP := predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetName() == operatorcontroller.ServiceMeshControlPlaneName(r.config.OperandNamespace).Name
+			})
+			if err = gatewayClassController.Watch(source.Kind[client.Object](r.cache, &maistrav2.ServiceMeshControlPlane{}, enqueueRequestForDefaultGatewayClassController(r.config.OperandNamespace), isOurSMCP)); err != nil {
+				log.Error(err, "failed to watch ServiceMeshControlPlane", "request", request)
+				errs = append(errs, err)
+			}
+		})
 	}
+
 	return reconcile.Result{}, utilerrors.NewAggregate(errs)
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -47,6 +47,10 @@ const (
 	// Remote worker label, used for node affinity of router deployment.
 	// Router should not run on remote worker nodes
 	RemoteWorkerLabel = "node.openshift.io/remote-worker"
+
+	// OpenshiftOperatorNamespace is the default namespace for
+	// the openshift operator resources.
+	OpenshiftOperatorNamespace = "openshift-operators"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -147,6 +147,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 				operatorcontroller.DefaultOperandNamespace:               {},
 				operatorcontroller.DefaultCanaryNamespace:                {},
 				operatorcontroller.GlobalMachineSpecifiedConfigNamespace: {},
+				operatorcontroller.OpenshiftOperatorNamespace:            {},
 			},
 		},
 		// Use a non-caching client everywhere. The default split client does not

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -99,6 +99,7 @@ func testGatewayAPIResources(t *testing.T) {
 // - the OSSM Istio operator is installed successfully and has status Running and Ready. e.g. istio-operator-9f5c88857-2xfrr  -n openshift-operators
 // - Istiod is installed successfully and has status Running and Ready.  e.g istiod-openshift-gateway-867bb8d5c7-4z6mp -n openshift-ingress
 // - the SMCP is created successfully (OSSM 2.x).
+// - deletes SMCP and subscription and tests if it gets recreated
 func testGatewayAPIIstioInstallation(t *testing.T) {
 	t.Helper()
 
@@ -117,6 +118,22 @@ func testGatewayAPIIstioInstallation(t *testing.T) {
 	// TODO - In OSSM 3.x the configuration object to check will be different.
 	if err := assertSMCP(t); err != nil {
 		t.Fatalf("failed to find expected SMCP: %v", err)
+	}
+	// delete existing SMCP to test it gets recreated
+	if err := deleteExistingSMCP(t); err != nil {
+		t.Fatalf("failed to delete existing SMCP: %v", err)
+	}
+	// check if SMCP gets recreated
+	if err := assertSMCP(t); err != nil {
+		t.Fatalf("failed to find expected SMCP: %v", err)
+	}
+	// delete existing Subscription to test it gets recreated
+	if err := deleteExistingSubscription(t, openshiftOperatorsNamespace, expectedSubscriptionName); err != nil {
+		t.Fatalf("failed to delete existing Subscription %s: %v", expectedSubscriptionName, err)
+	}
+	// checks if subscription gets recreated.
+	if err := assertSubscription(t, openshiftOperatorsNamespace, expectedSubscriptionName); err != nil {
+		t.Fatalf("failed to find expected Subscription %s: %v", expectedSubscriptionName, err)
 	}
 }
 


### PR DESCRIPTION
Recreating the SMCP and subscription, in case the SMCP or subscriptions are deleted manually.