### PR TITLE
OCPBUGS-36340: Retry IngressController and Route updates in E2E tests

### DIFF
--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -203,7 +203,6 @@ func IngressControllerDeploymentPodSelector(ic *operatorv1.IngressController) *m
 }
 
 func InternalIngressControllerServiceName(ic *operatorv1.IngressController) types.NamespacedName {
-	// TODO: remove hard-coded namespace
 	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-internal-" + ic.Name}
 }
 
@@ -215,7 +214,11 @@ func IngressControllerServiceMonitorName(ic *operatorv1.IngressController) types
 }
 
 func LoadBalancerServiceName(ic *operatorv1.IngressController) types.NamespacedName {
-	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-" + ic.Name}
+	return LoadBalancerServiceNameFromICName(ic.Name)
+}
+
+func LoadBalancerServiceNameFromICName(icName string) types.NamespacedName {
+	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-" + icName}
 }
 
 func NodePortServiceName(ic *operatorv1.IngressController) types.NamespacedName {

--- a/test/e2e/allowed_source_ranges_test.go
+++ b/test/e2e/allowed_source_ranges_test.go
@@ -92,11 +92,9 @@ func TestAllowedSourceRanges(t *testing.T) {
 	// Update the AllowedSourceRanges and verify that LoadBalancerSourceRanges field is updated as well.
 	updatedCIDR := "10.0.0.0/8"
 	t.Log("Updating AllowedSourceRanges")
-	if err := kclient.Get(context.TODO(), name, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller %s: %v", name, err)
-	}
-	ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges = []operatorv1.CIDR{operatorv1.CIDR(updatedCIDR)}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
+	if err := updateIngressControllerWithRetryOnConflict(t, name, timeout, func(ic *operatorv1.IngressController) {
+		ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges = []operatorv1.CIDR{operatorv1.CIDR(updatedCIDR)}
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -271,11 +271,9 @@ func TestCanaryWithMTLS(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Reset client TLS.
-		if err := kclient.Get(context.TODO(), defaultName, defaultIC); err != nil {
-			t.Fatalf("Failed to get default ingresscontroller: %v", err)
-		}
-		defaultIC.Spec.ClientTLS = *originalClientTLS
-		if err := kclient.Update(context.TODO(), defaultIC); err != nil {
+		if err := updateIngressControllerWithRetryOnConflict(t, defaultName, timeout, func(defaultIC *operatorv1.IngressController) {
+			defaultIC.Spec.ClientTLS = *originalClientTLS
+		}); err != nil {
 			t.Fatalf("Failed to restore default ingress configuration: %v", err)
 		}
 		t.Log("Restored clientTLS config for default ingresscontroller.")

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -309,12 +309,10 @@ func TestClientTLS(t *testing.T) {
 	}
 
 	// Now make the client certificate TLS mandatory, and add a filter.
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller %q: %v", icName, err)
-	}
-	ic.Spec.ClientTLS.ClientCertificatePolicy = "Required"
-	ic.Spec.ClientTLS.AllowedSubjectPatterns = []string{"/CN=allowed"}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
+	if err := updateIngressControllerWithRetryOnConflict(t, icName, timeout, func(ic *operatorv1.IngressController) {
+		ic.Spec.ClientTLS.ClientCertificatePolicy = "Required"
+		ic.Spec.ClientTLS.AllowedSubjectPatterns = []string{"/CN=allowed"}
+	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller %q: %v", icName, err)
 	}
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_MUTUAL_TLS_AUTH", "required"); err != nil {

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -194,13 +194,11 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 
 	// Verify that we get the expected behavior if we set the policy to
 	// "append" explicitly.
-	if err := kclient.Get(context.TODO(), icName, ic); err != nil {
-		t.Fatalf("failed to get ingresscontroller: %v", err)
-	}
-	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
-		ForwardedHeaderPolicy: operatorv1.AppendHTTPHeaderPolicy,
-	}
-	if err := kclient.Update(context.TODO(), ic); err != nil {
+	if err := updateIngressControllerWithRetryOnConflict(t, icName, timeout, func(ic *operatorv1.IngressController) {
+		ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
+			ForwardedHeaderPolicy: operatorv1.AppendHTTPHeaderPolicy,
+		}
+	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_SET_FORWARDED_HEADERS", "append"); err != nil {

--- a/test/e2e/http2_disable_test.go
+++ b/test/e2e/http2_disable_test.go
@@ -113,15 +113,12 @@ func TestRouteHTTP2EnableAndDisableIngressConfig(t *testing.T) {
 	// setHTTP2EnabledForIngressController() as we preserve the
 	// annotation if the value is "false".
 	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		if err := kclient.Get(context.TODO(), defaultName, ic); err != nil {
-			t.Logf("Get failed: %v, retrying...", err)
-			return false, nil
-		}
-		if ic.Annotations == nil {
-			ic.Annotations = map[string]string{}
-		}
-		ic.Annotations[ingress.RouterDefaultEnableHTTP2Annotation] = "false"
-		if err := kclient.Update(context.TODO(), ic); err != nil {
+		if err := updateIngressControllerWithRetryOnConflict(t, defaultName, timeout, func(ic *operatorv1.IngressController) {
+			if ic.Annotations == nil {
+				ic.Annotations = map[string]string{}
+			}
+			ic.Annotations[ingress.RouterDefaultEnableHTTP2Annotation] = "false"
+		}); err != nil {
 			t.Logf("failed to update ingress controller: %v", err)
 			return false, nil
 		}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3072,14 +3072,12 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 
 	// Configure the route with a 90-second timeout.
 	routeName := types.NamespacedName{Namespace: route.Namespace, Name: route.Name}
-	if err := kclient.Get(context.TODO(), routeName, route); err != nil {
-		t.Fatalf("failed to get route: %v", err)
-	}
-	if route.Annotations == nil {
-		route.Annotations = map[string]string{}
-	}
-	route.Annotations["haproxy.router.openshift.io/timeout"] = "90s"
-	if err := kclient.Update(context.TODO(), route); err != nil {
+	if err := updateRouteWithRetryOnConflict(t, routeName, timeout, func(route *routev1.Route) {
+		if route.Annotations == nil {
+			route.Annotations = map[string]string{}
+		}
+		route.Annotations["haproxy.router.openshift.io/timeout"] = "90s"
+	}); err != nil {
 		t.Fatalf("failed to update route: %v", err)
 	}
 

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -520,6 +520,32 @@ func probe(timeout, period, success, failure int) *corev1.Probe {
 	}
 }
 
+// updateRouteWithRetryOnConflict gets a fresh copy of the named route,
+// calls mutateRouteFn() where callers can modify fields of the route,
+// and then updates the route object. If there is a conflict error
+// on update then the complete sequence of get, mutate, and update
+// is retried until timeout is reached.
+func updateRouteWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateRouteFn func(route *routev1.Route)) error {
+	t.Helper()
+	route := &routev1.Route{}
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, route); err != nil {
+			t.Logf("error getting route %v: %v, retrying...", name, err)
+			return false, nil
+		}
+		mutateRouteFn(route)
+		if err := kclient.Update(ctx, route); err != nil {
+			if errors.IsConflict(err) {
+				t.Logf("conflict when updating route %v: %v, retrying...", name, err)
+				return false, nil
+			}
+			t.Logf("error updating route %v: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 // updateIngressControllerWithRetryOnConflict gets a fresh copy of
 // the named ingresscontroller, calls mutateIngressControllerFn() where
 // callers can modify fields of the ingresscontroller, and then updates


### PR DESCRIPTION
This PR fixes flakes in e2e tests due to the IngressController or Route objects being updated after the e2e test retrieves a local copy, resulting in an "object has been modified" error.

This is achieved by using the existing helper function `updateIngressControllerWithRetryOnConflict`.

Also a new helper function `updateRouteWithRetryOnConflict` was added to retry updates of Route object in the same way.

Example fail to update IngressController:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-ingress-operator/1114/pull-ci-openshift-cluster-ingress-operator-master-e2e-azure-operator/1818681004299128832

Example fail to update Route:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-ingress-operator/1023/pull-ci-openshift-cluster-ingress-operator-master-e2e-gcp-operator/1815818916132294656

