### PR TITLE
OCPBUGS-37491: Ingress operator status not degraded when canary route fails

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -439,7 +439,7 @@ func mergeStatuses(zones []configv1.DNSZone, statuses, updates []iov1.DNSZoneSta
 var clock utilclock.Clock = utilclock.RealClock{}
 
 // mergeConditions adds or updates matching conditions, and updates
-// the transition time if details of a condition have changed. Returns
+// the transition time if the status of a condition changed. Returns
 // the updated condition array.
 func mergeConditions(conditions, updates []iov1.DNSZoneCondition) []iov1.DNSZoneCondition {
 	now := metav1.NewTime(clock.Now())
@@ -449,13 +449,13 @@ func mergeConditions(conditions, updates []iov1.DNSZoneCondition) []iov1.DNSZone
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if update.Status != conditions[j].Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				conditions[j].Status = update.Status
+				break
 			}
 		}
 		if add {
@@ -465,10 +465,6 @@ func mergeConditions(conditions, updates []iov1.DNSZoneCondition) []iov1.DNSZone
 	}
 	conditions = append(conditions, additions...)
 	return conditions
-}
-
-func conditionChanged(a, b iov1.DNSZoneCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // migrateRecordStatusConditions purges deprecated fields from DNS Record

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -126,7 +126,7 @@ func (r *reconciler) syncIngressControllerSelectorStatus(ic *operatorv1.IngressC
 }
 
 // MergeConditions adds or updates matching conditions, and updates
-// the transition time if details of a condition have changed. Returns
+// the transition time if the status of a condition changed. Returns
 // the updated condition array.
 func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
 	now := metav1.NewTime(clock.Now())
@@ -136,13 +136,13 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if update.Status != conditions[j].Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				conditions[j].Status = update.Status
+				break
 			}
 		}
 		if add {
@@ -833,10 +833,6 @@ func conditionsEqual(a, b []operatorv1.OperatorCondition) bool {
 	}
 
 	return cmp.Equal(a, b, conditionCmpOpts...)
-}
-
-func conditionChanged(a, b operatorv1.OperatorCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // computeLoadBalancerStatus returns the set of current

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -555,7 +555,7 @@ func computeOperatorAvailableCondition(ingresses []operatorv1.IngressController)
 }
 
 // mergeConditions adds or updates matching conditions, and updates
-// the transition time if details of a condition have changed. Returns
+// the transition time if the status of a condition changed. Returns
 // the updated condition array.
 func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updates ...configv1.ClusterOperatorStatusCondition) []configv1.ClusterOperatorStatusCondition {
 	now := metav1.NewTime(clock.Now())
@@ -565,13 +565,13 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 		for j, cond := range conditions {
 			if cond.Type == update.Type {
 				add = false
-				if conditionChanged(cond, update) {
-					conditions[j].Status = update.Status
-					conditions[j].Reason = update.Reason
-					conditions[j].Message = update.Message
+				if update.Status != conditions[j].Status {
 					conditions[j].LastTransitionTime = now
-					break
 				}
+				conditions[j].Reason = update.Reason
+				conditions[j].Message = update.Message
+				conditions[j].Status = update.Status
+				break
 			}
 		}
 		if add {
@@ -581,10 +581,6 @@ func mergeConditions(conditions []configv1.ClusterOperatorStatusCondition, updat
 	}
 	conditions = append(conditions, additions...)
 	return conditions
-}
-
-func conditionChanged(a, b configv1.ClusterOperatorStatusCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
 }
 
 // operatorStatusesEqual compares two ClusterOperatorStatus values.  Returns


### PR DESCRIPTION
The status was not being set to degraded because the lastTransitionTime was being set unnecessarily. It should only be set when the status changes.  See https://github.com/openshift/cluster-dns-operator/pull/375

The fix involves recognizing when the condition status changes, and only updating the transition time when this happens.

* pkg/operator/controller/condition.go - export the ConditionChanged func
  for use by all previous callers.
* pkg/operator/controller/dns/controller.go - use the new ConditionChanged,
  update logic for setting condition transition time.
* pkg/operator/controller/ingress/status.go - use the new ConditionChanged,
  update logic for setting condition transition time.
* pkg/operator/controller/status/controller.go - use the new ConditionChanged,
  update logic for setting condition transition time.