### PR TITLE
OCPBUGS-32776: Fix IBM Public Cloud DNS Provider Update Logic

### DIFF
--- a/pkg/dns/ibm/private/client/fake_client.go
+++ b/pkg/dns/ibm/private/client/fake_client.go
@@ -43,6 +43,10 @@ func (c *FakeDnsClient) RecordedCall(zoneID string) (string, bool) {
 	return call, ok
 }
 
+func (c *FakeDnsClient) ClearCallHistory() {
+	c.CallHistory = map[string]string{}
+}
+
 func (FakeDnsClient) NewListResourceRecordsOptions(instanceID string, dnszoneID string) *dnssvcsv1.ListResourceRecordsOptions {
 	return &dnssvcsv1.ListResourceRecordsOptions{}
 }

--- a/pkg/dns/ibm/private/dnssvcs_provider_test.go
+++ b/pkg/dns/ibm/private/dnssvcs_provider_test.go
@@ -65,18 +65,12 @@ func Test_Delete(t *testing.T) {
 			},
 		},
 		{
-			desc:         "listFailError",
-			recordedCall: "DELETE",
-			DNSName:      "testDelete",
-			target:       "11.22.33.44",
+			desc:    "listFailError",
+			DNSName: "testDelete",
+			target:  "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
 				OutputError:      errors.New("error in ListAllDnsRecords"),
 				OutputStatusCode: http.StatusRequestTimeout,
-			},
-			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
 			},
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
@@ -121,6 +115,7 @@ func Test_Delete(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			dnsService.ClearCallHistory()
 
 			record := iov1.DNSRecord{
 				Spec: iov1.DNSRecordSpec{
@@ -209,10 +204,9 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			},
 		},
 		{
-			desc:         "listFailError",
-			DNSName:      "testUpdate",
-			target:       "11.22.33.44",
-			recordedCall: "PUT",
+			desc:    "listFailError",
+			DNSName: "testUpdate",
+			target:  "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
 				OutputError:      errors.New("error in ListAllDnsRecords"),
 				OutputStatusCode: http.StatusRequestTimeout,
@@ -245,6 +239,7 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			dnsService.ClearCallHistory()
 
 			record := iov1.DNSRecord{
 				Spec: iov1.DNSRecordSpec{

--- a/pkg/dns/ibm/private/dnssvcs_provider_test.go
+++ b/pkg/dns/ibm/private/dnssvcs_provider_test.go
@@ -6,10 +6,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/networking-go-sdk/dnssvcsv1"
+
 	configv1 "github.com/openshift/api/config/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	dnsclient "github.com/openshift/cluster-ingress-operator/pkg/dns/ibm/private/client"
+
 	"github.com/stretchr/testify/assert"
+
+	"k8s.io/utils/pointer"
 )
 
 func Test_Delete(t *testing.T) {
@@ -35,75 +41,181 @@ func Test_Delete(t *testing.T) {
 		expectErrorContains          string
 	}{
 		{
-			desc:         "happy path",
+			desc:         "delete happy path A record type",
 			recordedCall: "DELETE",
 			DNSName:      "testDelete",
 			target:       "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
 			},
 			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				InputId:        "testDelete",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
 			},
 		},
 		{
-			desc:         "listFail",
+			desc:         "delete happy path CNAME record type",
 			recordedCall: "DELETE",
 			DNSName:      "testDelete",
-			target:       "11.22.33.44",
+			target:       "example.com",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusNotFound,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"cname": "example.com"},
+						Type:  pointer.String(string(iov1.CNAMERecordType)),
+					}},
+				},
 			},
 			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				InputId:        "testDelete",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
 			},
 		},
 		{
-			desc:    "listFailError",
+			desc:    "list failure with 404",
 			DNSName: "testDelete",
 			target:  "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      errors.New("error in ListAllDnsRecords"),
-				OutputStatusCode: http.StatusRequestTimeout,
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusNotFound},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{},
+				},
+			},
+		},
+		{
+			desc:    "list failure (fake timeout)",
+			DNSName: "testDelete",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
 			},
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
 		{
-			desc:         "deleteRecordNotFound",
+			desc:         "delete failure with 404 (record disappears)",
 			recordedCall: "DELETE",
 			DNSName:      "testDelete",
 			target:       "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
 			},
 			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      errors.New("error in DeleteDnsRecord"),
-				OutputStatusCode: http.StatusNotFound,
+				InputId:        "testDelete",
+				OutputError:    errors.New("error in DeleteDnsRecord"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusNotFound},
 			},
 		},
 		{
-			desc:         "deleteError",
+			desc:         "delete failure (fake timeout)",
 			recordedCall: "DELETE",
 			DNSName:      "testDelete",
 			target:       "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
 			},
 			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      errors.New("error in DeleteDnsRecord"),
-				OutputStatusCode: http.StatusRequestTimeout,
+				InputId:        "testDelete",
+				OutputError:    errors.New("error in DeleteDnsRecord"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
 			},
 			expectErrorContains: "error in DeleteDnsRecord",
+		},
+		{
+			desc:    "list success but mismatching target",
+			DNSName: "testDelete",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"ip": "22.33.44.55"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
+			},
+		},
+		{
+			desc:    "list success but record type is nil",
+			DNSName: "testDelete",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testDelete"),
+						Name:  pointer.String("testDelete"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+					}},
+				},
+			},
+			expectErrorContains: "delete: failed to get resource type, resourceRecord.Type is nil",
+		},
+		{
+			desc:    "list success but nil results",
+			DNSName: "testDelete",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+			},
+			expectErrorContains: "delete: ListResourceRecords returned nil as result",
+		},
+		{
+			desc:    "list success but nil dns record list",
+			DNSName: "testDelete",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+		},
+		{
+			desc:    "list failure and nil response",
+			DNSName: "testList",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: nil,
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			expectErrorContains: "delete: failed to list the dns record: error in ListAllDnsRecords",
 		},
 		{
 			desc:                "empty DNSName",
@@ -126,8 +238,6 @@ func Test_Delete(t *testing.T) {
 				},
 			}
 
-			tc.listAllDnsRecordsInputOutput.RecordName = tc.DNSName
-			tc.listAllDnsRecordsInputOutput.RecordTarget = tc.target
 			dnsService.ListAllDnsRecordsInputOutput = tc.listAllDnsRecordsInputOutput
 
 			dnsService.DeleteDnsRecordInputOutput = tc.deleteDnsRecordInputOutput
@@ -171,63 +281,189 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 		recordedCall                 string
 		listAllDnsRecordsInputOutput dnsclient.ListAllDnsRecordsInputOutput
 		updateDnsRecordInputOutput   dnsclient.UpdateDnsRecordInputOutput
+		createDnsRecordInputOutput   dnsclient.CreateDnsRecordInputOutput
 		expectErrorContains          string
 	}{
 		{
-			desc:         "happy path",
+			desc:         "update happy path A record type",
 			DNSName:      "testUpdate",
 			target:       "11.22.33.44",
 			recordedCall: "PUT",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testUpdate"),
+						Name:  pointer.String("testUpdate"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
 			},
 			updateDnsRecordInputOutput: dnsclient.UpdateDnsRecordInputOutput{
-				InputId:          "testUpdate",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				InputId:        "testUpdate",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
 			},
 		},
 		{
-			desc:         "listFail",
+			desc:         "update happy path CNAME record type",
 			DNSName:      "testUpdate",
-			target:       "11.22.33.44",
+			target:       "example.com",
 			recordedCall: "PUT",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      errors.New("error in ListAllDnsRecords"),
-				OutputStatusCode: http.StatusNotFound,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testUpdate"),
+						Name:  pointer.String("testUpdate"),
+						Rdata: map[string]interface{}{"cname": "example.com"},
+						Type:  pointer.String(string(iov1.CNAMERecordType)),
+					}},
+				},
 			},
 			updateDnsRecordInputOutput: dnsclient.UpdateDnsRecordInputOutput{
-				InputId:          "testUpdate",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				InputId:        "testUpdate",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
 			},
 		},
 		{
-			desc:    "listFailError",
+			desc:         "list failure with 404",
+			DNSName:      "testCreate",
+			target:       "11.22.33.44",
+			recordedCall: "CREATE",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusNotFound},
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			createDnsRecordInputOutput: dnsclient.CreateDnsRecordInputOutput{
+				InputId:     "testCreate",
+				OutputError: nil,
+				OutputResponse: &core.DetailedResponse{
+					StatusCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			desc:    "list failure (fake timeout)",
 			DNSName: "testUpdate",
 			target:  "11.22.33.44",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      errors.New("error in ListAllDnsRecords"),
-				OutputStatusCode: http.StatusRequestTimeout,
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
 			},
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
 		{
-			desc:         "updateError",
+			desc:         "update error",
 			DNSName:      "testUpdate",
 			target:       "11.22.33.44",
 			recordedCall: "PUT",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testUpdate"),
+						Name:  pointer.String("testUpdate"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
 			},
 			updateDnsRecordInputOutput: dnsclient.UpdateDnsRecordInputOutput{
-				InputId:          "testUpdate",
-				OutputError:      errors.New("error in UpdateDnsRecord"),
-				OutputStatusCode: http.StatusRequestTimeout,
+				InputId:        "testUpdate",
+				OutputError:    errors.New("error in UpdateDnsRecord"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
 			},
 			expectErrorContains: "error in UpdateDnsRecord",
+		},
+		{
+			desc:         "create happy path",
+			DNSName:      "testCreate",
+			target:       "11.22.33.44",
+			recordedCall: "CREATE",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			createDnsRecordInputOutput: dnsclient.CreateDnsRecordInputOutput{
+				InputId:        "testCreate",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+			},
+		},
+		{
+			desc:         "create error",
+			DNSName:      "testCreate",
+			recordedCall: "CREATE",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			createDnsRecordInputOutput: dnsclient.CreateDnsRecordInputOutput{
+				InputId:        "testCreate",
+				OutputError:    errors.New("error in CreateDnsRecord"),
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
+			},
+			expectErrorContains: "error in CreateDnsRecord",
+		},
+		{
+			desc:    "list success but record type is nil",
+			DNSName: "testList",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						ID:    pointer.String("testList"),
+						Name:  pointer.String("testList"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+					}},
+				},
+			},
+			expectErrorContains: "createOrUpdateDNSRecord: failed to get resource type, resourceRecord.Type is nil",
+		},
+		{
+			desc:    "list success but nil results",
+			DNSName: "testList",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+			},
+			expectErrorContains: "createOrUpdateDNSRecord: ListResourceRecords returned nil as result",
+		},
+		{
+			desc:         "list success but nil dns record list",
+			DNSName:      "testCreate",
+			recordedCall: "CREATE",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			createDnsRecordInputOutput: dnsclient.CreateDnsRecordInputOutput{
+				InputId:        "testCreate",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+			},
+		},
+		{
+			desc:    "list failure and nil response",
+			DNSName: "testList",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    errors.New("error in ListAllDnsRecords"),
+				OutputResponse: nil,
+				OutputResult:   &dnssvcsv1.ListResourceRecords{},
+			},
+			expectErrorContains: "createOrUpdateDNSRecord: failed to list the dns record: error in ListAllDnsRecords",
 		},
 		{
 			desc:                "empty DNSName",
@@ -250,12 +486,9 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 				},
 			}
 
-			tc.listAllDnsRecordsInputOutput.RecordName = tc.DNSName
-			tc.listAllDnsRecordsInputOutput.RecordTarget = tc.target
-
 			dnsService.ListAllDnsRecordsInputOutput = tc.listAllDnsRecordsInputOutput
-
 			dnsService.UpdateDnsRecordInputOutput = tc.updateDnsRecordInputOutput
+			dnsService.CreateDnsRecordInputOutput = tc.createDnsRecordInputOutput
 
 			err = provider.createOrUpdateDNSRecord(&record, zone)
 

--- a/pkg/dns/ibm/private/dnssvcs_provider_test.go
+++ b/pkg/dns/ibm/private/dnssvcs_provider_test.go
@@ -109,6 +109,23 @@ func Test_Delete(t *testing.T) {
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
 		{
+			desc:    "list success but missing ID",
+			DNSName: "testList",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						Name:  pointer.String("testList"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
+			},
+			expectErrorContains: "delete: record id is nil",
+		},
+		{
 			desc:         "delete failure with 404 (record disappears)",
 			recordedCall: "DELETE",
 			DNSName:      "testDelete",
@@ -359,6 +376,23 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
 		{
+			desc:    "list success but missing ID",
+			DNSName: "testList",
+			target:  "11.22.33.44",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusRequestTimeout},
+				OutputResult: &dnssvcsv1.ListResourceRecords{
+					ResourceRecords: []dnssvcsv1.ResourceRecord{{
+						Name:  pointer.String("testList"),
+						Rdata: map[string]interface{}{"ip": "11.22.33.44"},
+						Type:  pointer.String(string(iov1.ARecordType)),
+					}},
+				},
+			},
+			expectErrorContains: "createOrUpdateDNSRecord: record id is nil",
+		},
+		{
 			desc:         "update error",
 			DNSName:      "testUpdate",
 			target:       "11.22.33.44",
@@ -441,7 +475,7 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			expectErrorContains: "createOrUpdateDNSRecord: ListResourceRecords returned nil as result",
 		},
 		{
-			desc:         "list success but nil dns record list",
+			desc:         "list success but empty target",
 			DNSName:      "testCreate",
 			recordedCall: "CREATE",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{

--- a/pkg/dns/ibm/public/cis_provider.go
+++ b/pkg/dns/ibm/public/cis_provider.go
@@ -107,6 +107,8 @@ func (p *Provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
 	// "." when it creates a wildcard DNS record.
 	dnsName := strings.TrimSuffix(record.Spec.DNSName, ".")
 	opt.SetName(dnsName)
+	// While creating DNS records with multiple targets is unsupported, we still
+	// iterate through all targets during deletion to be extra cautious.
 	for _, target := range record.Spec.Targets {
 		opt.SetContent(target)
 		result, response, err := dnsService.ListAllDnsRecords(opt)
@@ -152,6 +154,9 @@ func (p *Provider) createOrUpdateDNSRecord(record *iov1.DNSRecord, zone configv1
 		log.Info("Warning: TTL must be between 120 and 2,147,483,647 seconds, or 1 for Automatic. RecordTTL set to default", "default CIS record TTL", defaultCISRecordTTL)
 		record.Spec.RecordTTL = defaultCISRecordTTL
 	}
+	if len(record.Spec.Targets) > 1 {
+		return fmt.Errorf("createOrUpdateDNSRecord: only one target is supported, but found %d: targets=%v", len(record.Spec.Targets), record.Spec.Targets)
+	}
 
 	listOpt := dnsService.NewListAllDnsRecordsOptions()
 	listOpt.SetType(string(record.Spec.RecordType))
@@ -160,41 +165,45 @@ func (p *Provider) createOrUpdateDNSRecord(record *iov1.DNSRecord, zone configv1
 	// "." when it creates a wildcard DNS record.
 	dnsName := strings.TrimSuffix(record.Spec.DNSName, ".")
 	listOpt.SetName(dnsName)
-	for _, target := range record.Spec.Targets {
-		listOpt.SetContent(target)
-		result, response, err := dnsService.ListAllDnsRecords(listOpt)
+
+	result, response, err := dnsService.ListAllDnsRecords(listOpt)
+	if err != nil {
+		// Avoid continuing with an invalid list response, as we can't determine
+		// whether to create or update the DNS record, leading to further issues.
+		if response == nil || response.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("createOrUpdateDNSRecord: failed to list the dns record: %w", err)
+		}
+	}
+	if result == nil || result.Result == nil {
+		return fmt.Errorf("createOrUpdateDNSRecord: ListAllDnsRecords returned nil as result")
+	}
+
+	target := record.Spec.Targets[0]
+	if len(result.Result) == 0 {
+		createOpt := dnsService.NewCreateDnsRecordOptions()
+		createOpt.SetName(record.Spec.DNSName)
+		createOpt.SetType(string(record.Spec.RecordType))
+		createOpt.SetContent(target)
+		createOpt.SetTTL(record.Spec.RecordTTL)
+		_, _, err := dnsService.CreateDnsRecord(createOpt)
 		if err != nil {
-			if response != nil && response.StatusCode != http.StatusNotFound {
-				return fmt.Errorf("createOrUpdateDNSRecord: failed to list the dns record: %w", err)
-			}
-			continue
+			return fmt.Errorf("createOrUpdateDNSRecord: failed to create the dns record: %w", err)
 		}
-		if result == nil || result.Result == nil {
-			return fmt.Errorf("createOrUpdateDNSRecord: ListAllDnsRecords returned nil as result")
+		log.Info("created DNS record", "record", record.Spec, "zone", zone, "target", target)
+	} else {
+		if result.Result[0].ID == nil {
+			return fmt.Errorf("createOrUpdateDNSRecord: record id is nil")
 		}
-		if len(result.Result) == 0 {
-			createOpt := dnsService.NewCreateDnsRecordOptions()
-			createOpt.SetName(record.Spec.DNSName)
-			createOpt.SetType(string(record.Spec.RecordType))
-			createOpt.SetContent(target)
-			createOpt.SetTTL(record.Spec.RecordTTL)
-			_, _, err := dnsService.CreateDnsRecord(createOpt)
-			if err != nil {
-				return fmt.Errorf("createOrUpdateDNSRecord: failed to create the dns record: %w", err)
-			}
-			log.Info("created DNS record", "record", record.Spec, "zone", zone, "target", target)
-		} else {
-			updateOpt := dnsService.NewUpdateDnsRecordOptions(*result.Result[0].ID)
-			updateOpt.SetName(record.Spec.DNSName)
-			updateOpt.SetType(string(record.Spec.RecordType))
-			updateOpt.SetContent(target)
-			updateOpt.SetTTL(record.Spec.RecordTTL)
-			_, _, err := dnsService.UpdateDnsRecord(updateOpt)
-			if err != nil {
-				return fmt.Errorf("createOrUpdateDNSRecord: failed to update the dns record: %w", err)
-			}
-			log.Info("updated DNS record", "record", record.Spec, "zone", zone, "target", target)
+		updateOpt := dnsService.NewUpdateDnsRecordOptions(*result.Result[0].ID)
+		updateOpt.SetName(record.Spec.DNSName)
+		updateOpt.SetType(string(record.Spec.RecordType))
+		updateOpt.SetContent(target)
+		updateOpt.SetTTL(record.Spec.RecordTTL)
+		_, _, err := dnsService.UpdateDnsRecord(updateOpt)
+		if err != nil {
+			return fmt.Errorf("createOrUpdateDNSRecord: failed to update the dns record: %w", err)
 		}
+		log.Info("updated DNS record", "record", record.Spec, "zone", zone, "target", target)
 	}
 
 	return nil

--- a/pkg/dns/ibm/public/cis_provider_test.go
+++ b/pkg/dns/ibm/public/cis_provider_test.go
@@ -65,17 +65,11 @@ func Test_Delete(t *testing.T) {
 			},
 		},
 		{
-			desc:         "listFailError",
-			DNSName:      "testDelete",
-			recordedCall: "DELETE",
+			desc:    "listFailError",
+			DNSName: "testDelete",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
 				OutputError:      errors.New("error in ListAllDnsRecords"),
 				OutputStatusCode: http.StatusRequestTimeout,
-			},
-			deleteDnsRecordInputOutput: dnsclient.DeleteDnsRecordInputOutput{
-				InputId:          "testDelete",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
 			},
 			expectErrorContains: "error in ListAllDnsRecords",
 		},
@@ -117,6 +111,7 @@ func Test_Delete(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			dnsService.ClearCallHistory()
 
 			record := iov1.DNSRecord{
 				Spec: iov1.DNSRecordSpec{
@@ -188,23 +183,16 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			},
 		},
 		{
-			desc:         "listFail",
-			DNSName:      "testUpdate",
-			recordedCall: "PUT",
+			desc:    "listFail",
+			DNSName: "testUpdate",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
-				OutputError:      errors.New("Error in ListAllDnsRecords"),
+				OutputError:      errors.New("error in ListAllDnsRecords"),
 				OutputStatusCode: http.StatusNotFound,
-			},
-			updateDnsRecordInputOutput: dnsclient.UpdateDnsRecordInputOutput{
-				InputId:          "testUpdate",
-				OutputError:      nil,
-				OutputStatusCode: http.StatusOK,
 			},
 		},
 		{
-			desc:         "listFailError",
-			DNSName:      "testUpdate",
-			recordedCall: "PUT",
+			desc:    "listFailError",
+			DNSName: "testUpdate",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
 				OutputError:      errors.New("error in ListAllDnsRecords"),
 				OutputStatusCode: http.StatusRequestTimeout,
@@ -235,6 +223,7 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			dnsService.ClearCallHistory()
 
 			record := iov1.DNSRecord{
 				Spec: iov1.DNSRecordSpec{
@@ -244,7 +233,6 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 					RecordTTL:  120,
 				},
 			}
-
 			dnsService.ListAllDnsRecordsInputOutput = tc.listAllDnsRecordsInputOutput
 
 			dnsService.UpdateDnsRecordInputOutput = tc.updateDnsRecordInputOutput

--- a/pkg/dns/ibm/public/cis_provider_test.go
+++ b/pkg/dns/ibm/public/cis_provider_test.go
@@ -258,14 +258,20 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			},
 		},
 		{
-			desc:    "list failure with 404",
-			DNSName: "testUpdate",
+			desc:         "list failure with 404",
+			DNSName:      "testCreate",
+			recordedCall: "CREATE",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
 				OutputError:    errors.New("error in ListAllDnsRecords"),
 				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusNotFound},
 				OutputResult: &dnsrecordsv1.ListDnsrecordsResp{
 					Result: []dnsrecordsv1.DnsrecordDetails{},
 				},
+			},
+			createDnsRecordInputOutput: dnsclient.CreateDnsRecordInputOutput{
+				InputId:        "testCreate",
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
 			},
 		},
 		{
@@ -334,6 +340,21 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 			expectErrorContains: "error in CreateDnsRecord",
 		},
 		{
+			desc:    "list success but missing ID",
+			DNSName: "testList",
+			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
+				OutputError:    nil,
+				OutputResponse: &core.DetailedResponse{StatusCode: http.StatusOK},
+				OutputResult: &dnsrecordsv1.ListDnsrecordsResp{
+					Result: []dnsrecordsv1.DnsrecordDetails{{
+						Name:    pointer.String("testList"),
+						Content: pointer.String("11.22.33.44"),
+					}},
+				},
+			},
+			expectErrorContains: "createOrUpdateDNSRecord: record id is nil",
+		},
+		{
 			desc:    "list success but nil results",
 			DNSName: "testList",
 			listAllDnsRecordsInputOutput: dnsclient.ListAllDnsRecordsInputOutput{
@@ -360,6 +381,7 @@ func Test_createOrUpdateDNSRecord(t *testing.T) {
 				OutputResponse: nil,
 				OutputResult:   &dnsrecordsv1.ListDnsrecordsResp{},
 			},
+			expectErrorContains: "createOrUpdateDNSRecord: failed to list the dns record: error in ListAllDnsRecords",
 		},
 		{
 			desc:                "empty DNSName",

--- a/pkg/dns/ibm/public/client/fake_client.go
+++ b/pkg/dns/ibm/public/client/fake_client.go
@@ -10,25 +10,33 @@ import (
 type FakeDnsClient struct {
 	CallHistory                  map[string]string
 	DeleteDnsRecordInputOutput   DeleteDnsRecordInputOutput
+	CreateDnsRecordInputOutput   CreateDnsRecordInputOutput
 	ListAllDnsRecordsInputOutput ListAllDnsRecordsInputOutput
 	UpdateDnsRecordInputOutput   UpdateDnsRecordInputOutput
 }
 
 type DeleteDnsRecordInputOutput struct {
-	InputId          string
-	OutputError      error
-	OutputStatusCode int
+	InputId        string
+	OutputError    error
+	OutputResponse *core.DetailedResponse
 }
 
 type UpdateDnsRecordInputOutput struct {
-	InputId          string
-	OutputError      error
-	OutputStatusCode int
+	InputId        string
+	OutputError    error
+	OutputResponse *core.DetailedResponse
+}
+
+type CreateDnsRecordInputOutput struct {
+	InputId        string
+	OutputError    error
+	OutputResponse *core.DetailedResponse
 }
 
 type ListAllDnsRecordsInputOutput struct {
-	OutputError      error
-	OutputStatusCode int
+	OutputResult   *dnsrecordsv1.ListDnsrecordsResp
+	OutputError    error
+	OutputResponse *core.DetailedResponse
 }
 
 func NewFake() (*FakeDnsClient, error) {
@@ -45,54 +53,41 @@ func (c *FakeDnsClient) ClearCallHistory() {
 }
 
 func (fdc FakeDnsClient) ListAllDnsRecords(listAllDnsRecordsOptions *dnsrecordsv1.ListAllDnsRecordsOptions) (result *dnsrecordsv1.ListDnsrecordsResp, response *core.DetailedResponse, err error) {
-	fakeListDnsrecordsResp := &dnsrecordsv1.ListDnsrecordsResp{}
-
-	fakeListDnsrecordsResp.Result = append(fakeListDnsrecordsResp.Result, dnsrecordsv1.DnsrecordDetails{ID: listAllDnsRecordsOptions.Name})
-
-	resp := &core.DetailedResponse{
-		StatusCode: fdc.ListAllDnsRecordsInputOutput.OutputStatusCode,
-		Headers:    map[string][]string{},
-		Result:     result,
-		RawResult:  []byte{},
-	}
-
-	return fakeListDnsrecordsResp, resp, fdc.ListAllDnsRecordsInputOutput.OutputError
+	// Return the fields in ListAllDnsRecordsInputOutput which will be populated in each of the unit test cases.
+	return fdc.ListAllDnsRecordsInputOutput.OutputResult, fdc.ListAllDnsRecordsInputOutput.OutputResponse, fdc.ListAllDnsRecordsInputOutput.OutputError
 }
 
-func (FakeDnsClient) CreateDnsRecord(createDnsRecordOptions *dnsrecordsv1.CreateDnsRecordOptions) (result *dnsrecordsv1.DnsrecordResp, response *core.DetailedResponse, err error) {
-	return nil, nil, nil
+func (fdc FakeDnsClient) CreateDnsRecord(createDnsRecordOptions *dnsrecordsv1.CreateDnsRecordOptions) (result *dnsrecordsv1.DnsrecordResp, response *core.DetailedResponse, err error) {
+	// Check InputID against the incoming createDnsRecordOptions to ensure the
+	// createOrUpdateDNSRecord method is using the correct record name in createDnsRecordOptions.
+	if fdc.CreateDnsRecordInputOutput.InputId != *createDnsRecordOptions.Name {
+		return nil, nil, errors.New("createDnsRecord: inputs don't match")
+	}
+
+	fdc.CallHistory[*createDnsRecordOptions.Name] = "CREATE"
+	return nil, fdc.CreateDnsRecordInputOutput.OutputResponse, fdc.CreateDnsRecordInputOutput.OutputError
 }
 
 func (fdc FakeDnsClient) DeleteDnsRecord(deleteDnsRecordOptions *dnsrecordsv1.DeleteDnsRecordOptions) (result *dnsrecordsv1.DeleteDnsrecordResp, response *core.DetailedResponse, err error) {
+	// Check InputID against the incoming deleteDnsRecordOptions to ensure the
+	// Delete method is using the correct dnsrecordIdentifier in deleteDnsRecordOptions.
 	if fdc.DeleteDnsRecordInputOutput.InputId != *deleteDnsRecordOptions.DnsrecordIdentifier {
 		return nil, nil, errors.New("deleteDnsRecord: inputs don't match")
 	}
 
-	resp := &core.DetailedResponse{
-		StatusCode: fdc.DeleteDnsRecordInputOutput.OutputStatusCode,
-		Headers:    map[string][]string{},
-		Result:     result,
-		RawResult:  []byte{},
-	}
-
 	fdc.CallHistory[*deleteDnsRecordOptions.DnsrecordIdentifier] = "DELETE"
-	return nil, resp, fdc.DeleteDnsRecordInputOutput.OutputError
+	return nil, fdc.DeleteDnsRecordInputOutput.OutputResponse, fdc.DeleteDnsRecordInputOutput.OutputError
 }
 
 func (fdc FakeDnsClient) UpdateDnsRecord(updateDnsRecordOptions *dnsrecordsv1.UpdateDnsRecordOptions) (result *dnsrecordsv1.DnsrecordResp, response *core.DetailedResponse, err error) {
+	// Check InputID against the incoming updateDnsRecordOptions to ensure the
+	// createOrUpdateDNSRecord method is using the correct dnsrecordIdentifier in updateDnsRecordOptions.
 	if fdc.UpdateDnsRecordInputOutput.InputId != *updateDnsRecordOptions.DnsrecordIdentifier {
 		return nil, nil, errors.New("updateDnsRecord: inputs don't match")
 	}
 
-	resp := &core.DetailedResponse{
-		StatusCode: fdc.UpdateDnsRecordInputOutput.OutputStatusCode,
-		Headers:    map[string][]string{},
-		Result:     result,
-		RawResult:  []byte{},
-	}
-
 	fdc.CallHistory[*updateDnsRecordOptions.DnsrecordIdentifier] = "PUT"
-	return nil, resp, fdc.UpdateDnsRecordInputOutput.OutputError
+	return nil, fdc.UpdateDnsRecordInputOutput.OutputResponse, fdc.UpdateDnsRecordInputOutput.OutputError
 }
 
 func (FakeDnsClient) NewCreateDnsRecordOptions() *dnsrecordsv1.CreateDnsRecordOptions {

--- a/pkg/dns/ibm/public/client/fake_client.go
+++ b/pkg/dns/ibm/public/client/fake_client.go
@@ -40,6 +40,10 @@ func (c *FakeDnsClient) RecordedCall(zoneID string) (string, bool) {
 	return call, ok
 }
 
+func (c *FakeDnsClient) ClearCallHistory() {
+	c.CallHistory = map[string]string{}
+}
+
 func (fdc FakeDnsClient) ListAllDnsRecords(listAllDnsRecordsOptions *dnsrecordsv1.ListAllDnsRecordsOptions) (result *dnsrecordsv1.ListDnsrecordsResp, response *core.DetailedResponse, err error) {
 	fakeListDnsrecordsResp := &dnsrecordsv1.ListDnsrecordsResp{}
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1575,7 +1575,7 @@ func TestScopeChange(t *testing.T) {
 			Status: operatorv1.ConditionFalse,
 		}
 		if err := waitForIngressControllerCondition(t, kclient, 1*time.Minute, name, progressingFalse); err != nil {
-			t.Fatalf("failed to observe the ingresscontroller report Progressing=True: %v", err)
+			t.Fatalf("failed to observe the ingresscontroller report Progressing=False: %v", err)
 		}
 	case configv1.AzurePlatformType, configv1.GCPPlatformType:
 		err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
@@ -1636,6 +1636,12 @@ func TestScopeChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected load balancer to become internal: %v", err)
 	}
+
+	// Verify that the IngressController provisions successfully to identify bugs like OCPBUGS-32776.
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableNotProgressingConditionsForIngressControllerWithLoadBalancer...); err != nil {
+		t.Fatalf("failed to observe expected conditions: %v", err)
+	}
+
 }
 
 // TestNodePortServiceEndpointPublishingStrategy creates an ingresscontroller


### PR DESCRIPTION
The IBM Public Cloud DNS provider (`cis_provider.go`) had a bug in `createOrUpdateDNSRecord` where it checked for the existence of a DNS record by filtering both DNS name and target. If the target was updated (e.g., due to a load balancer recreation), the logic would not match the existing DNS record. As a result, the function would attempt to create a new record, but fail because a record with that name already existed, as multiple DNS records with the same
name are not allowed in IBM Cloud DNS providers.

The fix is to remove the filtering by target and rely solely on filtering by name, as the name is the only attribute that needs to be unique.

This fix also includes a subtle fix in `createOrUpdateDNSRecord` of cis_provider.go to fall through to the create logic in the case of a not-found (404) error.

Additionally, the IBM DNS logic doesn't work for multiple targets and this creates unexpected and problematic results. The logic has been refactored to only create using the first target and it warns the user when multiple targets are set. This change is low risk since the Ingress Operator will never create a DNSRecord with multiple targets in `desiredDNSRecord`.

Additionally, modify TestScopeChange to check for `Available=True` after deleting the service to add test coverage for this issue.

This PR also includes some unit test fix up and missing unit test coverage for the IBM CIS Provider.

This resolves the same DNS issues for public PowerVS cloud as it uses the same logic.