### PR TITLE
OCPBUGS-38871: ingress: deployment: explicitly set DeploymentStrategy in SingleReplica case

### DIFF
--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1034,8 +1034,13 @@ func TestDesiredRouterDeploymentSingleReplica(t *testing.T) {
 		t.Errorf("expected no pod affinity, got %+v", *deployment.Spec.Template.Spec.Affinity)
 	}
 
-	if deployment.Spec.Strategy.Type != "" || deployment.Spec.Strategy.RollingUpdate != nil {
-		t.Errorf("expected default deployment strategy, got %s", deployment.Spec.Strategy.Type)
+	if deployment.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType ||
+		deployment.Spec.Strategy.RollingUpdate == nil ||
+		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable == nil ||
+		deployment.Spec.Strategy.RollingUpdate.MaxSurge == nil ||
+		*deployment.Spec.Strategy.RollingUpdate.MaxUnavailable != intstr.FromString("25%") ||
+		*deployment.Spec.Strategy.RollingUpdate.MaxSurge != intstr.FromString("25%") {
+		t.Errorf("expected default deployment strategy, got %+v", deployment.Spec.Strategy)
 	}
 }
 


### PR DESCRIPTION
Currently, the code does not set `deployment.Spec.Strategy` before breaking out in the SingleReplica case. This results in the kube-apiserver defaulting the `Strategy`. On the next reconcile pass, this code will attempt to unset the defaulted values leading to a hot reconciliation loop.

To avoid this, explicitly set the `Strategy` to the kube default before the `break` out of the switch.

xref https://github.com/openshift/cluster-ingress-operator/pull/810