### PR TITLE
OCPBUGS-39151: Add Missing Scope Change Instructions

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -793,8 +793,7 @@ func loadBalancerServiceIsProgressing(ic *operatorv1.IngressController, service 
 	}
 	if wantScope != haveScope {
 		err := fmt.Errorf("The IngressController scope was changed from %q to %q.", haveScope, wantScope)
-		switch platform.Type {
-		case configv1.AWSPlatformType, configv1.IBMCloudPlatformType:
+		if _, ok := platformsWithMutableScope[platform.Type]; !ok {
 			err = fmt.Errorf("%[1]s  To effectuate this change, you must delete the service: `oc -n %[2]s delete svc/%[3]s`; the service load-balancer will then be deprovisioned and a new one created.  This will most likely cause the new load-balancer to have a different host name and IP address from the old one's.  Alternatively, you can revert the change to the IngressController: `oc -n openshift-ingress-operator patch ingresscontrollers/%[4]s --type=merge --patch='{\"spec\":{\"endpointPublishingStrategy\":{\"loadBalancer\":{\"scope\":\"%[5]s\"}}}}'`", err.Error(), service.Namespace, service.Name, ic.Name, haveScope)
 		}
 		errs = append(errs, err)


### PR DESCRIPTION
The instructions for effectuating a scope change were missing because the `loadBalancerServiceIsProgressing` did not account for the PowerVS, Alibaba, and OpenStack platform types. This update add those instructions for these platforms when they change an IngressController's scope.

Originally split from https://github.com/openshift/cluster-ingress-operator/pull/1133