### PR TITLE
OCPBUGS-37932: Always log AWS service endpoints

### DIFF
--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -209,14 +209,12 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 		for _, ep := range config.ServiceEndpoints {
 			// TODO: Add custom endpoint support for elbv2. See the following for details:
 			// https://docs.aws.amazon.com/general/latest/gr/elb.html
-			switch {
-			case route53Found && elbFound && tagFound:
-				break
-			case ep.Name == Route53Service:
+			switch ep.Name {
+			case Route53Service:
 				route53Found = true
 				r53Config = r53Config.WithEndpoint(ep.URL)
 				log.Info("using route53 custom endpoint", "url", ep.URL)
-			case ep.Name == TaggingService:
+			case TaggingService:
 				if tagConfig == nil {
 					log.Info("found resourcegroupstaggingapi custom endpoint which will be ignored since the %s region does not support that API", region)
 					continue
@@ -230,10 +228,15 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 				}
 				tagConfig = tagConfig.WithEndpoint(url)
 				log.Info("using group tagging custom endpoint", "url", url)
-			case ep.Name == ELBService:
+			case ELBService:
 				elbFound = true
 				elbConfig = elbConfig.WithEndpoint(ep.URL)
 				log.Info("using elb custom endpoint", "url", ep.URL)
+			}
+			// Once the three service endpoints have been found,
+			// ignore any further service endpoint specifications.
+			if route53Found && elbFound && tagFound {
+				break
 			}
 		}
 	}

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -213,10 +213,10 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 			case Route53Service:
 				route53Found = true
 				r53Config = r53Config.WithEndpoint(ep.URL)
-				log.Info("using route53 custom endpoint", "url", ep.URL)
+				log.Info("Found route53 custom endpoint", "url", ep.URL)
 			case TaggingService:
 				if tagConfig == nil {
-					log.Info("found resourcegroupstaggingapi custom endpoint which will be ignored since the %s region does not support that API", region)
+					log.Info(fmt.Sprintf("Found resourcegroupstaggingapi custom endpoint, which will be ignored since the %s region does not support that API", region))
 					continue
 				}
 				tagFound = true
@@ -227,11 +227,11 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 					url = govCloudTaggingEndpoint
 				}
 				tagConfig = tagConfig.WithEndpoint(url)
-				log.Info("using group tagging custom endpoint", "url", url)
+				log.Info("Found resourcegroupstaggingapi custom endpoint", "url", url)
 			case ELBService:
 				elbFound = true
 				elbConfig = elbConfig.WithEndpoint(ep.URL)
-				log.Info("using elb custom endpoint", "url", ep.URL)
+				log.Info("Found elb custom endpoint", "url", ep.URL)
 			}
 			// Once the three service endpoints have been found,
 			// ignore any further service endpoint specifications.

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -207,6 +207,8 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 		elbFound := false
 		tagFound := false
 		for _, ep := range config.ServiceEndpoints {
+			// TODO: Add custom endpoint support for elbv2. See the following for details:
+			// https://docs.aws.amazon.com/general/latest/gr/elb.html
 			switch {
 			case route53Found && elbFound && tagFound:
 				break
@@ -240,9 +242,7 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 		tags = resourcegroupstaggingapi.New(sess, tagConfig)
 	}
 	p := &Provider{
-		elb: elb.New(sess, elbConfig),
-		// TODO: Add custom endpoint support for elbv2. See the following for details:
-		// https://docs.aws.amazon.com/general/latest/gr/elb.html
+		elb:       elb.New(sess, elbConfig),
 		elbv2:     elbv2.New(sess, aws.NewConfig().WithRegion(region)),
 		route53:   route53.New(sessRoute53, r53Config),
 		tags:      tags,

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -250,7 +250,7 @@ func NewProvider(config Config, operatorReleaseVersion string) (*Provider, error
 		idsToTags: map[string]map[string]string{},
 		lbZones:   map[string]string{},
 	}
-	if err := validateServiceEndpoints(p); err != nil {
+	if err := validateServiceEndpointsFn(p); err != nil {
 		return nil, fmt.Errorf("failed to validate aws provider service endpoints: %v", err)
 	}
 	return p, nil
@@ -280,6 +280,10 @@ func validateServiceEndpoints(provider *Provider) error {
 	}
 	return kerrors.NewAggregate(errs)
 }
+
+// validateServiceEndpointsFn is an alias for validateServiceEndpoints in normal
+// operation but can be overridden in unit tests.
+var validateServiceEndpointsFn = validateServiceEndpoints
 
 // getZoneID finds the ID of given zoneConfig in Route53. If an ID is already
 // known, return that; otherwise, use tags to search for the zone. Returns an

--- a/pkg/dns/aws/dns_test.go
+++ b/pkg/dns/aws/dns_test.go
@@ -133,3 +133,107 @@ func Test_zoneIDFromResource(t *testing.T) {
 		})
 	}
 }
+
+// Test_NewProvider verifies that NewProvider creates clients with the expected
+// service endpoints.
+func Test_NewProvider(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		config                               Config
+		expectedTaggingServiceEndpoint       string
+		expectedElbServiceEndpointEndpoint   string
+		expectedElbv2ServiceEndpointEndpoint string
+		expectedRoute53ServiceEndpoint       string
+	}{{
+		name: "default service endpoints, us-east-1",
+		config: Config{
+			Region: "us-east-1",
+		},
+		expectedTaggingServiceEndpoint:       "https://tagging.us-east-1.amazonaws.com",
+		expectedElbServiceEndpointEndpoint:   "https://elasticloadbalancing.us-east-1.amazonaws.com",
+		expectedElbv2ServiceEndpointEndpoint: "https://elasticloadbalancing.us-east-1.amazonaws.com",
+		expectedRoute53ServiceEndpoint:       "https://route53.amazonaws.com",
+	}, {
+		name: "custom service endpoints",
+		config: Config{
+			Region: "us-east-1",
+			ServiceEndpoints: []ServiceEndpoint{
+				// Service endpoints with unrecognized names
+				// are ignored.
+				{Name: "bogus", URL: "http://ignored"},
+				// When the same service endpoint is specified
+				// more than once, the last one is used, until
+				// all service endpoints have been set.
+				{Name: "tagging", URL: "http://overridden1"},
+				{Name: "tagging", URL: "http://overridden2"},
+				{Name: "tagging", URL: "http://x"},
+				{Name: "elasticloadbalancing", URL: "http://y"},
+				{Name: "route53", URL: "http://z"},
+				// Once all service endpoints have been set,
+				// any further entries are ignored.
+				{Name: "tagging", URL: "http://ignored"},
+				{Name: "elasticloadbalancing", URL: "http://ignored"},
+				{Name: "route53", URL: "http://ignored"},
+			},
+		},
+		expectedTaggingServiceEndpoint:       "http://x",
+		expectedElbServiceEndpointEndpoint:   "http://y",
+		expectedElbv2ServiceEndpointEndpoint: "https://elasticloadbalancing.us-east-1.amazonaws.com",
+		expectedRoute53ServiceEndpoint:       "http://z",
+	}, {
+		name: "default service endpoints, GovCloud East",
+		config: Config{
+			Region: "us-gov-east-1",
+		},
+		expectedTaggingServiceEndpoint:       "https://tagging.us-gov-west-1.amazonaws.com",
+		expectedElbServiceEndpointEndpoint:   "https://elasticloadbalancing.us-gov-east-1.amazonaws.com",
+		expectedElbv2ServiceEndpointEndpoint: "https://elasticloadbalancing.us-gov-east-1.amazonaws.com",
+		expectedRoute53ServiceEndpoint:       "https://route53.us-gov.amazonaws.com",
+	}, {
+		name: "default service endpoints, C2S",
+		config: Config{
+			Region: "us-iso-east-1",
+		},
+		expectedTaggingServiceEndpoint:       "",
+		expectedElbServiceEndpointEndpoint:   "https://elasticloadbalancing.us-iso-east-1.c2s.ic.gov",
+		expectedElbv2ServiceEndpointEndpoint: "https://elasticloadbalancing.us-iso-east-1.c2s.ic.gov",
+		expectedRoute53ServiceEndpoint:       "https://route53.c2s.ic.gov",
+	}, {
+		name: "default service endpoints, China North",
+		config: Config{
+			Region: "cn-north-1",
+		},
+		expectedTaggingServiceEndpoint:       "https://tagging.cn-northwest-1.amazonaws.com.cn",
+		expectedElbServiceEndpointEndpoint:   "https://elasticloadbalancing.cn-north-1.amazonaws.com.cn",
+		expectedElbv2ServiceEndpointEndpoint: "https://elasticloadbalancing.cn-north-1.amazonaws.com.cn",
+		expectedRoute53ServiceEndpoint:       "https://route53.amazonaws.com.cn",
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			validateServiceEndpointsFn = func(provider *Provider) error {
+				return nil
+			}
+
+			provider, err := NewProvider(tc.config, "0.0.0-0")
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.NotNil(t, provider.elb)
+			assert.Equal(t, tc.expectedElbServiceEndpointEndpoint, provider.elb.Client.Endpoint)
+
+			assert.NotNil(t, provider.elbv2)
+			assert.Equal(t, tc.expectedElbv2ServiceEndpointEndpoint, provider.elbv2.Client.Endpoint)
+
+			assert.NotNil(t, provider.route53)
+			assert.Equal(t, tc.expectedRoute53ServiceEndpoint, provider.route53.Client.Endpoint)
+
+			if tc.expectedTaggingServiceEndpoint == "" {
+				assert.Nil(t, provider.tags)
+			} else {
+				assert.NotNil(t, provider.tags)
+				assert.Equal(t, tc.expectedTaggingServiceEndpoint, provider.tags.Client.Endpoint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### aws/dns: Move a to-do for elbv2 custom endpoint

Move a to-do comment closer to the relevant source code.

#### aws/dns: Remove a useless `break` statement

Remove a useless, misleading `break` statement.  Rewrite the relevant code to be clearer.  Add a comment to describe how the service endpoints configuration is interpreted.

The AWS DNS provider implementation loops over the configured service endpoints to set service endpoint for the various clients: route53, elb, and tagging.  Inside this loop is a `switch` statement.  The first `case` statement has a `break` statement.  It appears that the intent may have been to break the loop.  However, because it is inside the `switch` statement, it only breaks out of the switch.  As there is nothing between the `switch` and the bottom of the loop, the `break` itself has no effect and can be removed.

However, because this `case` statement is the first one in the switch, it can prevent subsequent `case` statements from executing, so although it doesn't break the loop, the `case` statement does make subsequent loop iterations no-ops.

This commit changes the logic to be simpler and easier to understand by using an `if` statement and making the `switch` statement simply match on the name of the service endpoint.

The existing `Test_NewProvider` test proves that this commit does not ultimately change the behavior.

#### aws/dns: Tidy up logging for custom endpoints

Fix capitalization, and use `fmt.Sprintf` as `log.Info` does not expand formats.

#### aws/dns: Always log AWS API endpoints

Log the endpoint for every AWS API that we use, irrespective of whether a custom endpoint was configured for that API.

#### aws/dns: Add test for `NewProvider`

Add a new test to verify that `NewProvider` uses the expected AWS service endpoints.