### PR TITLE
OCPBUGS-41527: Add tolerations to survive scheduler taint manager e2e tests on workers

### DIFF
--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -69,6 +69,14 @@ spec:
           - mountPath: /var/run/configmaps/service-ca
             name: service-ca-bundle
             readOnly: true
+      tolerations:
+      # Ensure the pod isn't deleted during serial NoExecuteTaintManager tests.
+      # Remember that NoExecute uses Delete, not Evict, because removing the pod
+      # is non-optional.  This means that PDBs are not honored.
+      - key: "kubernetes.io/e2e-evict-taint-key"
+        operator: "Equal"
+        value: "evictTaintVal"
+        effect: "NoExecute"
       volumes:
       - name: default-certificate
         secret:

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -410,9 +410,15 @@ func Test_desiredRouterDeployment(t *testing.T) {
 	if len(deployment.Spec.Template.Spec.NodeSelector) == 0 {
 		t.Error("router Deployment has no default node selector")
 	}
-	if len(deployment.Spec.Template.Spec.Tolerations) != 0 {
-		t.Errorf("router Deployment has unexpected toleration: %#v",
-			deployment.Spec.Template.Spec.Tolerations)
+	e2eToleration := corev1.Toleration{
+		Key:      "kubernetes.io/e2e-evict-taint-key",
+		Value:    "evictTaintVal",
+		Operator: corev1.TolerationOpEqual,
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+	expectedTolerations := []corev1.Toleration{e2eToleration}
+	if !reflect.DeepEqual(deployment.Spec.Template.Spec.Tolerations, expectedTolerations) {
+		t.Errorf("router Deployment has unexpected tolerations, expected: %#v, got: %#v", expectedTolerations, deployment.Spec.Template.Spec.Tolerations)
 	}
 	tests := []envData{
 		{"NAMESPACE_LABELS", true, "foo=bar"},


### PR DESCRIPTION
Courtesy PR demonstrating how to avoid pod deletion during serial e2e tests in runs like https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-vsphere-ovn-upi-serial/1832439322075205632 which cause the observed failures in [component readiness](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&Architecture=amd64&FeatureSet=default&FeatureSet=default&Installer=upi&Installer=upi&Network=ovn&Network=ovn&NetworkAccess=default&Platform=vsphere&Platform=vsphere&Scheduler=default&SecurityMode=default&Suite=serial&Suite=serial&Topology=ha&Topology=ha&Upgrade=none&Upgrade=none&baseEndTime=2024-06-27%2023%3A59%3A59&baseRelease=4.16&baseStartTime=2024-05-28%2000%3A00%3A00&capability=Operator&columnGroupBy=Architecture%2CNetwork%2CPlatform&component=Networking%20%2F%20router&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20upi%20ovn%20vsphere%20serial%20ha%20none&ignoreDisruption=true&ignoreMissing=false&includeVariant=Architecture%3Aamd64&includeVariant=FeatureSet%3Adefault&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=Owner%3Aeng&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&minFail=3&pity=5&sampleEndTime=2024-09-10%2023%3A59%3A59&sampleRelease=4.17&sampleStartTime=2024-09-03%2000%3A00%3A00&testId=openshift-tests%3Ab690e68fb6372a8924d84a0d6aa2f552&testName=%5Bbz-Routing%5D%20clusteroperator%2Fingress%20should%20not%20change%20condition%2FAvailable)

/assign @candita @Miciah 