### PR TITLE
OCPBUGS-31521: Don't allow DNS records for gateway to be created if they clash with any existing ingress controller.

### DIFF
--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
@@ -287,8 +288,12 @@ func ServiceMeshSubscriptionName() types.NamespacedName {
 // is named using the Gateway's name, listener's hashed host name, and the
 // suffix "-wildcard".
 func GatewayDNSRecordName(gateway *gatewayapiv1beta1.Gateway, host string) types.NamespacedName {
+	name := fmt.Sprintf("%s-%s", gateway.Name, util.Hash(host))
+	if strings.HasPrefix(host, "*.") {
+		name = name + "-wildcard"
+	}
 	return types.NamespacedName{
 		Namespace: gateway.Namespace,
-		Name:      fmt.Sprintf("%s-%s-wildcard", gateway.Name, util.Hash(host)),
+		Name:      name,
 	}
 }


### PR DESCRIPTION
If a gateway attempts to create a listener for a domain that's already served by an ingress controller, don't create a DNSRecord for that domain, and log an error.

In the future, some more visible method of error reporting should be added, such as an alert or a status condition on a relevant object, but that is intentionally left for a future change.