### PR TITLE
CFE-1134: Watch infrastructure and update AWS tags

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -1141,7 +1141,7 @@ func Test_loadBalancerServiceChanged(t *testing.T) {
 			mutate: func(svc *corev1.Service) {
 				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"] = "Key3=Value3,Key4=Value4"
 			},
-			expect: false,
+			expect: true,
 		},
 		{
 			description: "if the service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout annotation changes",

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -3022,7 +3022,7 @@ func Test_computeIngressUpgradeableCondition(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags annotation changes",
+			description: "if the service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags annotation changes not by ingress controller",
 			mutate: func(svc *corev1.Service) {
 				svc.Annotations[awsLBAdditionalResourceTags] = "Key2=Value2"
 			},

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -100,6 +100,7 @@ func TestAll(t *testing.T) {
 		t.Run("TestDefaultIngressClass", TestDefaultIngressClass)
 		t.Run("TestOperatorRecreatesItsClusterOperator", TestOperatorRecreatesItsClusterOperator)
 		t.Run("TestAWSLBTypeDefaulting", TestAWSLBTypeDefaulting)
+		t.Run("TestAWSResourceTagsChanged", TestAWSResourceTagsChanged)
 		t.Run("TestHstsPolicyWorks", TestHstsPolicyWorks)
 		t.Run("TestIngressControllerCustomEndpoints", TestIngressControllerCustomEndpoints)
 		t.Run("TestIngressStatus", TestIngressStatus)


### PR DESCRIPTION
The PR introduces the following changes:

- The ingress controller now watches for the `Infrastructure` object changes. This ensures that any modifications to user-defined tags (`platform.AWS.ResourceTags`) trigger an update of the load balancer service.

- Consider the `awsLBAdditionalResourceTags` annotation as a managed annotation. Any changes to user-defined tags in the Infrastructure object will be reflected in this annotation, prompting an update to the load balancer service.



Implements: [CFE-1134](https://issues.redhat.com//browse/CFE-1134)