### PR TITLE
[WIP] OCPBUGS-31353: Minimize wildcard privileges for CRDs and namespaces

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -15,13 +15,31 @@ rules:
   - ""
   resources:
   - configmaps
-  - namespaces
   - serviceaccounts
   - endpoints
   - services
   - secrets
   - pods
   - events
+  verbs:
+  - "*"
+
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - openshift-ingress
+  - openshift-ingress-canary
   verbs:
   - "*"
 
@@ -171,6 +189,20 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - gatewayclasses.gateway.networking.k8s.io
+  - gateways.gateway.networking.k8s.io
+  - httproutes.gateway.networking.k8s.io
+  - referencegrants.gateway.networking.k8s.io
   verbs:
   - '*'
 


### PR DESCRIPTION
- Scoped namespace permissions to read-only to enable informer watches.
- Restricted wildcard namespace permissions exclusively to operand namespaces (routers and canary).
- Scoped CRD permissions to read-only to enable informer watches.
- Restricted wildcard CRD permissions exclusively to Gateway API.