### PR TITLE
[WIP] OCPBUGS-31353: Minimize wildcard privileges for secrets, configmaps and service accounts

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -14,12 +14,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - namespaces
-  - serviceaccounts
   - endpoints
   - services
-  - secrets
   - pods
   - events
   verbs:

--- a/manifests/00-operand-namespace.yaml
+++ b/manifests/00-operand-namespace.yaml
@@ -1,0 +1,40 @@
+# Define operand namespaces to be able to restrict the operator's RBAC permissions.
+# This enables limiting the access to sensitive resources (e.g., Secrets, ServiceAccounts, ConfigMaps)
+# from cluster-wide scope to specific namespaces.
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
+    openshift.io/cluster-monitoring: "true"
+    name: openshift-ingress
+    # old and new forms of the label for matching with NetworkPolicy
+    network.openshift.io/policy-group: ingress
+    policy-group.network.openshift.io/ingress: ""
+    # Router deployment needs to allow privilege escalation, as well as host
+    # network and host ports for the "HostNetwork" endpoint publishing strategy,
+    # which is the default for on-premise platforms.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: openshift-ingress
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  name: openshift-ingress-canary

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -58,3 +58,77 @@ rules:
   - rolebindings
   verbs:
   - delete
+---
+# Role for the operator to manage the router certificates
+# in openshift-config-managed namespace.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-operator
+  namespace: openshift-config-manager
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - router-certs
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - default-ingress-cert
+  verbs:
+  - "*"
+---
+# Role for the operator to manage ingress controllers
+# in openshift-ingress namespace.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-operator
+  namespace: openshift-ingress
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - "*"
+---
+# Role for the operator to manage canary deployment
+# in openshift-ingressi-canary namespace.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ingress-operator
+  namespace: openshift-ingress-canary
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - "*"


### PR DESCRIPTION
- Defined operand namespaces in the operator payload to be able to create local roles.
- Defined local roles for secrets, configmaps and service accounts in the operand namespaces.
- Defined a local role for the certificate management in openshift-config-manager namespace.