### PR TITLE
[release-4.15] OCPBUGS-49392: Block Upgrades in release 4.15 for CA-Signed Certs Using SHA1

### DIFF
--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -733,7 +733,7 @@ func checkDefaultCertificate(secret *corev1.Secret, domain string) error {
 		// SHA1 can still be used by the root CA certificate.
 		if !isSelfSignedCert(cert) {
 			switch cert.SignatureAlgorithm {
-			case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
+			case x509.SHA1WithRSA, x509.ECDSAWithSHA1, x509.DSAWithSHA1:
 				return fmt.Errorf("a CA-signed certificate in secret %s/%s has weak SHA1 signature algorithm: %s (see https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-sha-haproxy-support-removed_release-notes for more details)", secret.Namespace, secret.Name, cert.SignatureAlgorithm)
 			}
 		}


### PR DESCRIPTION
Previously, upgrades from 4.15 to 4.16 were only blocked for default leaf certs using SHA1. However, in 4.16, any SHA1 cert that is CA-signed (not self-signed) is unsupported. As a result, we were incorrectly allowing upgrades for SHA1 intermediate certificates, while blocking upgrades for self-signed SHA1 leaf certificates.

This fix blocks upgrades to 4.16 for IngressControllers with default certificates containing CA-signed SHA1 certs. Root CA certs using SHA1 are still supported.

**Additional Fix For Blocking 4.15-->4.16 Upgrades for DSA SHA1 Default Certs:**

Previously, upgrades were not being blocked when default certificates used DSA SHA1. Although DSA certificates are rejected at the router level by our validation logic, they can still be used in a default certificate. In 4.15, DSA SHA1 certificates are allowed, but in 4.16, they are rejected by OpenSSL. This fix adds an upgrade blocker in the rare case that a user was using a DSA SHA1 default certificate.