### PR TITLE
NE-1260: Add Makefile target to run Gateway API conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ test-e2e: generate
 test-e2e-list: generate
 	@(cd ./test/e2e; E2E_TEST_MAIN_SKIP_SETUP=1 $(GO) test -list . -tags e2e | grep ^Test | sort)
 
+.PHONY: gatewayapi-conformance
+gatewayapi-conformance:
+	hack/gatewayapi-conformance.sh
+
 .PHONY: clean
 clean:
 	$(GO) clean

--- a/hack/gatewayapi-conformance.sh
+++ b/hack/gatewayapi-conformance.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Get Gateway API CRD bundle-version
+BUNDLE_VERSION=$(oc get crds gateways.gateway.networking.k8s.io -ojson | jq -r '.metadata.annotations."gateway.networking.k8s.io/bundle-version"')
+
+if [[ "${BUNDLE_VERSION}" == "null" ]]; then
+    echo "Cannot find bundle-version annotation from Gateway API CRD"
+    exit 1
+fi
+echo "Gateway API CRD bundle-version: ${BUNDLE_VERSION}"
+
+echo "Create GatewayClass gateway-conformance"
+oc apply -f -<<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: gateway-conformance
+spec:
+  controllerName: openshift.io/gateway-controller
+EOF
+
+oc wait --for=condition=Accepted=true gatewayclass/gateway-conformance --timeout=300s
+
+echo "All gatewayclass status:"
+oc get gatewayclass -A
+
+CLONE_DIR=$(mktemp -d)
+cd "${CLONE_DIR}"
+
+# find the branch of gateway-api repo
+RELEASE_VERSION=$(\grep -oP "^\d+\.\d+" <<<"${BUNDLE_VERSION#v}")
+BRANCH="release-${RELEASE_VERSION}"
+echo "gateway-api repo branch: ${BRANCH}"
+
+# clone the branch that matched the installed CRDs version
+# branch release-1.0 -> bundle-version v1.0.0
+# branch release-1.1 -> bundle-version v1.1.1
+# branch release-1.2 -> bundle-version v1.2.1
+git clone --branch "${BRANCH}" https://github.com/kubernetes-sigs/gateway-api
+cd gateway-api
+echo "Go version: $(go version)"
+go mod vendor
+
+# modify default timeout of "MaxTimeToConsistency" to make tests pass on AWS
+# because the AWS ELB needs extra ~60s for DNS propagation
+sed -i "s/MaxTimeToConsistency:              30/MaxTimeToConsistency:              90/g" conformance/utils/config/timeout.go
+
+SUPPORTED_FEATURES="Gateway,HTTPRoute,ReferenceGrant,GatewayPort8080,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRouteResponseHeaderModification,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors,HTTPRouteBackendProtocolH2C,HTTPRouteBackendProtocolWebSocket"
+
+echo "Start Gateway API Conformance Testing"
+go test ./conformance -v -timeout 10m -run TestConformance -args --supported-features=${SUPPORTED_FEATURES}


### PR DESCRIPTION
This PR adds new Makefile target and enables the upstream gateway-api conformance test.

Once this get merged, the follow up https://github.com/openshift/release/pull/60217 will add optional pre-submits job to run conformance test.