### PR TITLE
CORS-3907: Update ingress operator to with custom endpoints

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -114,6 +114,10 @@ type Config struct {
 	// PrivateHostedZoneAWSEnabled indicates whether the "SharedVPC" feature gate is
 	// enabled.
 	PrivateHostedZoneAWSEnabled bool
+
+	// GCPCustomEndpointsEnabled indicates whether the "GCPCustomAPIEndpoints"
+	// feature gate is enabled.
+	GCPCustomEndpointsEnabled bool
 }
 
 type reconciler struct {
@@ -698,9 +702,11 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 		dnsProvider = provider
 	case configv1.GCPPlatformType:
 		provider, err := gcpdns.New(gcpdns.Config{
-			Project:         platformStatus.GCP.ProjectID,
-			CredentialsJSON: creds.Data["service_account.json"],
-			UserAgent:       userAgent,
+			Project:                   platformStatus.GCP.ProjectID,
+			CredentialsJSON:           creds.Data["service_account.json"],
+			UserAgent:                 userAgent,
+			Endpoints:                 platformStatus.GCP.ServiceEndpoints,
+			GCPCustomEndpointsEnabled: r.config.GCPCustomEndpointsEnabled,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create GCP DNS provider: %v", err)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -137,6 +137,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	ingressControllerLBSubnetsAWSEnabled := featureGates.Enabled(features.FeatureGateIngressControllerLBSubnetsAWS)
 	ingressControllerEIPAllocationsAWSEnabled := featureGates.Enabled(features.FeatureGateSetEIPForNLBIngressController)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
+	gcpCustomEndpointsEnabled := featureGates.Enabled(features.FeatureGateGCPCustomAPIEndpoints)
 
 	// Set up an operator manager for the operator namespace.
 	mgr, err := manager.New(kubeConfig, manager.Options{
@@ -256,6 +257,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		OperatorReleaseVersion:       config.OperatorReleaseVersion,
 		AzureWorkloadIdentityEnabled: azureWorkloadIdentityEnabled,
 		PrivateHostedZoneAWSEnabled:  sharedVPCEnabled,
+		GCPCustomEndpointsEnabled:    gcpCustomEndpointsEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create dns controller: %v", err)
 	}


### PR DESCRIPTION
Enhancement link for the feature: https://github.com/openshift/enhancements/pull/1734

** Vendor update
** Set the endpoint information in the Config for GCP
** If an endpoint exists for the DNS service use the endpoint as an option when creating the new client.