### PR TITLE
NE-1981: Move controller test helpers to dedicated package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,13 @@ endif
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build -o $(BIN) $(GO_GCFLAGS) $(MAIN_PACKAGE)
 
-TEST ?= ^TestAll$
+ifdef TEST
+TEST_UNIT ?= $(TEST)
+TEST_E2E ?= $(TEST)
+else
+TEST_UNIT ?= ^.*$
+TEST_E2E ?= ^TestAll$
+endif
 
 .PHONY: build
 build: generate
@@ -45,7 +51,7 @@ manifests:
 
 .PHONY: test
 test: generate
-	CGO_ENABLED=1 $(GO) test ./...
+	CGO_ENABLED=1 $(GO) test -run "$(TEST_UNIT)" ./...
 
 .PHONY: release-local
 release-local:
@@ -53,7 +59,7 @@ release-local:
 
 .PHONY: test-e2e
 test-e2e: generate
-	CGO_ENABLED=1 $(GO) test -timeout 1.5h -count 1 -v -tags e2e -run "$(TEST)" ./test/e2e
+	CGO_ENABLED=1 $(GO) test -timeout 1.5h -count 1 -v -tags e2e -run "$(TEST_E2E)" ./test/e2e
 
 .PHONY: test-e2e-list
 test-e2e-list: generate

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 	"time"
 
-	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
-
-	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -15,17 +12,16 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 )
 
 func Test_Reconcile(t *testing.T) {
@@ -92,8 +88,8 @@ func Test_Reconcile(t *testing.T) {
 				WithScheme(scheme).
 				WithRuntimeObjects(tc.existingObjects...).
 				Build()
-			cl := &fakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
-			ctrl := &fakeController{t, false, nil}
+			cl := &testutil.FakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+			ctrl := &testutil.FakeController{t, false, nil}
 			reconciler := &reconciler{
 				client: cl,
 				config: Config{
@@ -113,25 +109,25 @@ func Test_Reconcile(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			select {
-			case <-ctrl.startNotificationChan:
+			case <-ctrl.StartNotificationChan:
 				t.Log("Start() was called")
 			case <-ctx.Done():
 				t.Log(ctx.Err())
 			}
-			assert.Equal(t, ctrl.started, tc.expectStartCtrl, "fake controller should have been started")
+			assert.Equal(t, ctrl.Started, tc.expectStartCtrl, "fake controller should have been started")
 			cmpOpts := []cmp.Option{
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Annotations", "ResourceVersion"),
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
 				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
 			}
-			if diff := cmp.Diff(tc.expectCreate, cl.added, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expectCreate, cl.Added, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual creates: %s", diff)
 			}
-			if diff := cmp.Diff(tc.expectUpdate, cl.updated, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expectUpdate, cl.Updated, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual updates: %s", diff)
 			}
-			if diff := cmp.Diff(tc.expectDelete, cl.deleted, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expectDelete, cl.Deleted, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual deletes: %s", diff)
 			}
 		})
@@ -143,8 +139,8 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 	configv1.Install(scheme)
 	apiextensionsv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
-	cl := &fakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
-	ctrl := &fakeController{t, false, make(chan struct{})}
+	cl := &testutil.FakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+	ctrl := &testutil.FakeController{t, false, make(chan struct{})}
 	reconciler := &reconciler{
 		client: cl,
 		config: Config{
@@ -162,111 +158,22 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	select {
-	case <-ctrl.startNotificationChan:
+	case <-ctrl.StartNotificationChan:
 		t.Log("Start() was called for the first reconcile request")
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	assert.True(t, ctrl.started, "fake controller should have been started")
+	assert.True(t, ctrl.Started, "fake controller should have been started")
 
 	// Reconcile again and verify Start() isn't called again.
 	res, err = reconciler.Reconcile(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, res)
 	select {
-	case <-ctrl.startNotificationChan:
+	case <-ctrl.StartNotificationChan:
 		t.Error("Start() was called again for the second reconcile request")
 	case <-ctx.Done():
 		t.Log(ctx.Err())
 	}
-	assert.True(t, ctrl.started, "fake controller should have been started")
-}
-
-type fakeCache struct {
-	cache.Informers
-	client.Reader
-}
-
-type fakeClientRecorder struct {
-	client.Client
-	*testing.T
-
-	added   []client.Object
-	updated []client.Object
-	deleted []client.Object
-}
-
-func (c *fakeClientRecorder) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	return c.Client.Get(ctx, key, obj, opts...)
-}
-
-func (c *fakeClientRecorder) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
-	return c.Client.List(ctx, obj, opts...)
-}
-
-func (c *fakeClientRecorder) Scheme() *runtime.Scheme {
-	return c.Client.Scheme()
-}
-
-func (c *fakeClientRecorder) RESTMapper() meta.RESTMapper {
-	return c.Client.RESTMapper()
-}
-
-func (c *fakeClientRecorder) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	c.added = append(c.added, obj)
-	return c.Client.Create(ctx, obj, opts...)
-}
-
-func (c *fakeClientRecorder) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	c.deleted = append(c.deleted, obj)
-	return c.Client.Delete(ctx, obj, opts...)
-}
-
-func (c *fakeClientRecorder) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	return c.Client.DeleteAllOf(ctx, obj, opts...)
-}
-
-func (c *fakeClientRecorder) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	c.updated = append(c.updated, obj)
-	return c.Client.Update(ctx, obj, opts...)
-}
-
-func (c *fakeClientRecorder) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	return c.Client.Patch(ctx, obj, patch, opts...)
-}
-
-func (c *fakeClientRecorder) Status() client.StatusWriter {
-	return c.Client.Status()
-}
-
-type fakeController struct {
-	*testing.T
-	// started indicates whether Start() has been called.
-	started bool
-	// startNotificationChan is an optional channel by which a test can
-	// receive a notification when Start() is called.
-	startNotificationChan chan struct{}
-}
-
-func (_ *fakeController) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
-	return reconcile.Result{}, nil
-}
-
-func (_ *fakeController) Watch(_ source.Source) error {
-	return nil
-}
-
-func (c *fakeController) Start(_ context.Context) error {
-	if c.started {
-		c.T.Fatal("controller was started twice!")
-	}
-	c.started = true
-	if c.startNotificationChan != nil {
-		c.startNotificationChan <- struct{}{}
-	}
-	return nil
-}
-
-func (_ *fakeController) GetLogger() logr.Logger {
-	return logf.Logger
+	assert.True(t, ctrl.Started, "fake controller should have been started")
 }

--- a/pkg/operator/controller/route-metrics/controller_test.go
+++ b/pkg/operator/controller/route-metrics/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	ctrltestutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 	"github.com/openshift/cluster-ingress-operator/test/unit"
 
 	"github.com/openshift/api/operator"
@@ -426,11 +427,6 @@ func Test_routeStatusAdmitted(t *testing.T) {
 	}
 }
 
-type fakeCache struct {
-	cache.Informers
-	client.Reader
-}
-
 // newFakeClient builds a fake client and cache for testing.
 func newFakeClient(initObjs ...client.Object) (error, client.Client, cache.Cache) {
 	// Create fake client
@@ -447,7 +443,7 @@ func newFakeClient(initObjs ...client.Object) (error, client.Client, cache.Cache
 		Scheme: client.Scheme(),
 	}
 	// Create fake cache
-	cache := fakeCache{Informers: &informer, Reader: client}
+	cache := ctrltestutil.FakeCache{Informers: &informer, Reader: client}
 
 	return nil, client, cache
 }

--- a/pkg/operator/controller/test/util/fake.go
+++ b/pkg/operator/controller/test/util/fake.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+)
+
+type FakeCache struct {
+	cache.Informers
+	client.Reader
+}
+
+type FakeClientRecorder struct {
+	client.Client
+	*testing.T
+
+	Added   []client.Object
+	Updated []client.Object
+	Deleted []client.Object
+}
+
+func (c *FakeClientRecorder) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *FakeClientRecorder) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	return c.Client.List(ctx, obj, opts...)
+}
+
+func (c *FakeClientRecorder) Scheme() *runtime.Scheme {
+	return c.Client.Scheme()
+}
+
+func (c *FakeClientRecorder) RESTMapper() meta.RESTMapper {
+	return c.Client.RESTMapper()
+}
+
+func (c *FakeClientRecorder) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.Added = append(c.Added, obj)
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *FakeClientRecorder) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.Deleted = append(c.Deleted, obj)
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c *FakeClientRecorder) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.Client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *FakeClientRecorder) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.Updated = append(c.Updated, obj)
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *FakeClientRecorder) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *FakeClientRecorder) Status() client.StatusWriter {
+	return c.Client.Status()
+}
+
+type FakeController struct {
+	*testing.T
+	// started indicates whether Start() has been called.
+	Started bool
+	// startNotificationChan is an optional channel by which a test can
+	// receive a notification when Start() is called.
+	StartNotificationChan chan struct{}
+}
+
+func (_ *FakeController) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func (_ *FakeController) Watch(_ source.Source) error {
+	return nil
+}
+
+func (c *FakeController) Start(_ context.Context) error {
+	if c.Started {
+		c.T.Fatal("controller was started twice!")
+	}
+	c.Started = true
+	if c.StartNotificationChan != nil {
+		c.StartNotificationChan <- struct{}{}
+	}
+	return nil
+}
+
+func (_ *FakeController) GetLogger() logr.Logger {
+	return logf.Logger
+}


### PR DESCRIPTION
This PR:
- extracts test helpers that were used across multiple controllers into a dedicated package: `pkg/operator/controller/test/util`. This includes `FakeCache`, `FakeController`, and `FakeClientRecorder`.
- allows `test` target to run specific unit tests using `-run` flag.