### PR TITLE
NE-1953: Add experimental Gateway API group to Validating Admission Policy

### DIFF
--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -20,7 +20,7 @@ spec:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"
       # When the operation is DELETE, the "object" variable is null.
-      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io'"
+      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io' || (request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.x-k8s.io'"
   # Validations are evaluated in the the order of their declaration.
   validations:
     # Verify that the request was sent by the ingress operator's service account.

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -109,7 +109,6 @@ func TestGatewayAPI(t *testing.T) {
 // CRDs are created.
 // It also deletes and ensure the CRDs are recreated.
 func testGatewayAPIResources(t *testing.T) {
-	t.Helper()
 	// Make sure all the *.gateway.networking.k8s.io CRDs are available since the FeatureGate is enabled.
 	ensureCRDs(t)
 
@@ -128,8 +127,6 @@ func testGatewayAPIResources(t *testing.T) {
 // - the SMCP is created successfully (OSSM 2.x).
 // - deletes SMCP and subscription and tests if it gets recreated
 func testGatewayAPIIstioInstallation(t *testing.T) {
-	t.Helper()
-
 	if err := assertSubscription(t, openshiftOperatorsNamespace, expectedSubscriptionName); err != nil {
 		t.Fatalf("failed to find expected Subscription %s: %v", expectedSubscriptionName, err)
 	}
@@ -166,8 +163,6 @@ func testGatewayAPIIstioInstallation(t *testing.T) {
 
 // testGatewayAPIObjects tests that Gateway API objects can be created successfully.
 func testGatewayAPIObjects(t *testing.T) {
-	t.Helper()
-
 	// Create a test namespace that cleans itself up and sets up its own service account and role binding.
 	ns := createNamespace(t, names.SimpleNameGenerator.GenerateName("test-e2e-gwapi-"))
 
@@ -189,8 +184,6 @@ func testGatewayAPIObjects(t *testing.T) {
 // denies admission requests attempting to modify Gateway API CRDs on behalf of a user
 // who is not the ingress operator's service account.
 func testGatewayAPIResourcesProtection(t *testing.T) {
-	t.Helper()
-
 	// Get kube client which impersonates ingress operator's service account.
 	kubeConfig, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
This PR adds `gateway.networking.x-k8s.io` to the match condition of the operator's Validating Admission Policy. This change ensures that modifications to experimental Gateway API CRDs can be made only by the ingress operator.