### PR TITLE
NE-1969: Set Degraded=True if unmanaged Gateway API CRDs exist

### DIFF
--- a/pkg/operator/controller/gateway-service-dns/controller_test.go
+++ b/pkg/operator/controller/gateway-service-dns/controller_test.go
@@ -254,7 +254,13 @@ func Test_Reconcile(t *testing.T) {
 				WithScheme(scheme).
 				WithRuntimeObjects(tc.existingObjects...).
 				Build()
-			cl := &testutil.FakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+			cl := &testutil.FakeClientRecorder{
+				Client:  fakeClient,
+				T:       t,
+				Added:   []client.Object{},
+				Updated: []client.Object{},
+				Deleted: []client.Object{},
+			}
 			informer := informertest.FakeInformers{Scheme: scheme}
 			cache := testutil.FakeCache{Informers: &informer, Reader: cl}
 			reconciler := &reconciler{

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -2,6 +2,7 @@ package gatewayapi
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,28 +38,57 @@ func Test_Reconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}
 	}
+	co := func(name string) *configv1.ClusterOperator {
+		return &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+	}
+	coWithExtension := func(name, extension string) *configv1.ClusterOperator {
+		co := co(name)
+		co.Status = configv1.ClusterOperatorStatus{
+			Extension: runtime.RawExtension{
+				Raw: []byte(extension),
+			},
+		}
+		return co
+	}
+
 	tests := []struct {
 		name                        string
 		gatewayAPIEnabled           bool
 		gatewayAPIControllerEnabled bool
 		existingObjects             []runtime.Object
-		expectCreate                []client.Object
-		expectUpdate                []client.Object
-		expectDelete                []client.Object
-		expectStartCtrl             bool
+		// existingStatusSubresource contains the original version of objects
+		// whose status will updated by Reconcile function.
+		// This field is similar to `existingObjects` but is specifically used
+		// for objects where status updates are performed using `Status().Update()` call.
+		existingStatusSubresource []client.Object
+		expectCreate              []client.Object
+		expectUpdate              []client.Object
+		expectDelete              []client.Object
+		// expectStatusUpdate contains the updated versions of objects
+		// whose status is expected to be updated by the test.
+		expectStatusUpdate []client.Object
+		expectStartCtrl    bool
 	}{
 		{
 			name:              "gateway API disabled",
 			gatewayAPIEnabled: false,
-			expectCreate:      []client.Object{},
-			expectUpdate:      []client.Object{},
-			expectDelete:      []client.Object{},
-			expectStartCtrl:   false,
+			existingObjects: []runtime.Object{
+				co("ingress"),
+			},
+			expectCreate:    []client.Object{},
+			expectUpdate:    []client.Object{},
+			expectDelete:    []client.Object{},
+			expectStartCtrl: false,
 		},
 		{
 			name:                        "gateway API enabled",
 			gatewayAPIEnabled:           true,
 			gatewayAPIControllerEnabled: true,
+			existingObjects: []runtime.Object{
+				co("ingress"),
+			},
 			expectCreate: []client.Object{
 				crd("gatewayclasses.gateway.networking.k8s.io"),
 				crd("gateways.gateway.networking.k8s.io"),
@@ -75,6 +106,9 @@ func Test_Reconcile(t *testing.T) {
 			name:                        "gateway API enabled, gateway API controller disabled",
 			gatewayAPIEnabled:           true,
 			gatewayAPIControllerEnabled: false,
+			existingObjects: []runtime.Object{
+				co("ingress"),
+			},
 			expectCreate: []client.Object{
 				crd("gatewayclasses.gateway.networking.k8s.io"),
 				crd("gateways.gateway.networking.k8s.io"),
@@ -88,6 +122,87 @@ func Test_Reconcile(t *testing.T) {
 			expectDelete:    []client.Object{},
 			expectStartCtrl: false,
 		},
+		{
+			name:                        "unmanaged gateway API CRDs created",
+			gatewayAPIEnabled:           true,
+			gatewayAPIControllerEnabled: true,
+			existingObjects: []runtime.Object{
+				co("ingress"),
+				crd("listenersets.gateway.networking.x-k8s.io"),
+				crd("backendtrafficpolicies.gateway.networking.x-k8s.io"),
+			},
+			existingStatusSubresource: []client.Object{
+				co("ingress"),
+			},
+			expectCreate: []client.Object{
+				crd("gatewayclasses.gateway.networking.k8s.io"),
+				crd("gateways.gateway.networking.k8s.io"),
+				crd("grpcroutes.gateway.networking.k8s.io"),
+				crd("httproutes.gateway.networking.k8s.io"),
+				crd("referencegrants.gateway.networking.k8s.io"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectStatusUpdate: []client.Object{
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"backendtrafficpolicies.gateway.networking.x-k8s.io,listenersets.gateway.networking.x-k8s.io"}`),
+			},
+			expectStartCtrl: true,
+		},
+		{
+			name:                        "unmanaged gateway API CRDs removed",
+			gatewayAPIEnabled:           true,
+			gatewayAPIControllerEnabled: true,
+			existingObjects: []runtime.Object{
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"listenersets.gateway.networking.x-k8s.io"}`),
+			},
+			existingStatusSubresource: []client.Object{
+				co("ingress"),
+			},
+			expectCreate: []client.Object{
+				crd("gatewayclasses.gateway.networking.k8s.io"),
+				crd("gateways.gateway.networking.k8s.io"),
+				crd("grpcroutes.gateway.networking.k8s.io"),
+				crd("httproutes.gateway.networking.k8s.io"),
+				crd("referencegrants.gateway.networking.k8s.io"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectStatusUpdate: []client.Object{
+				coWithExtension("ingress", `{}`),
+			},
+			expectStartCtrl: true,
+		},
+		{
+			name:                        "third party CRDs",
+			gatewayAPIEnabled:           true,
+			gatewayAPIControllerEnabled: true,
+			existingObjects: []runtime.Object{
+				co("ingress"),
+				crd("thirdpartycrd1.openshift.io"),
+				crd("thirdpartycrd2.openshift.io"),
+			},
+			existingStatusSubresource: []client.Object{
+				co("ingress"),
+			},
+			expectCreate: []client.Object{
+				crd("gatewayclasses.gateway.networking.k8s.io"),
+				crd("gateways.gateway.networking.k8s.io"),
+				crd("grpcroutes.gateway.networking.k8s.io"),
+				crd("httproutes.gateway.networking.k8s.io"),
+				crd("referencegrants.gateway.networking.k8s.io"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			// Third party CRDs have no impact on cluster operator status.
+			expectStatusUpdate: []client.Object{},
+			expectStartCtrl:    true,
+		},
 	}
 
 	scheme := runtime.NewScheme()
@@ -100,11 +215,31 @@ func Test_Reconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(tc.existingObjects...).
+				WithStatusSubresource(tc.existingStatusSubresource...).
+				WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
+					// Assume that all experimental CRDs are unmanaged.
+					if strings.Contains(o.GetName(), "gateway.networking.x-k8s.io") {
+						return []string{"unmanaged"}
+					}
+					return []string{}
+				})).
 				Build()
-			cl := &testutil.FakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+			cl := &testutil.FakeClientRecorder{
+				Client:  fakeClient,
+				T:       t,
+				Added:   []client.Object{},
+				Updated: []client.Object{},
+				Deleted: []client.Object{},
+				StatusWriter: &testutil.FakeStatusWriter{
+					StatusWriter: fakeClient.Status(),
+				},
+			}
 			ctrl := &testutil.FakeController{t, false, nil}
+			informer := informertest.FakeInformers{Scheme: scheme}
+			cache := &testutil.FakeCache{Informers: &informer, Reader: fakeClient}
 			reconciler := &reconciler{
 				client: cl,
+				cache:  cache,
 				config: Config{
 					GatewayAPIEnabled:           tc.gatewayAPIEnabled,
 					GatewayAPIControllerEnabled: tc.gatewayAPIControllerEnabled,
@@ -144,6 +279,9 @@ func Test_Reconcile(t *testing.T) {
 			if diff := cmp.Diff(tc.expectDelete, cl.Deleted, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual deletes: %s", diff)
 			}
+			if diff := cmp.Diff(tc.expectStatusUpdate, cl.StatusWriter.Updated, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual status updates: %s", diff)
+			}
 		})
 	}
 }
@@ -153,11 +291,30 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 	configv1.Install(scheme)
 	apiextensionsv1.AddToScheme(scheme)
 	rbacv1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
-	cl := &testutil.FakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(
+			&configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
+			}).
+		WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
+			// Assume that there are no unmanaged CRDs.
+			return []string{}
+		})).
+		Build()
+	cl := &testutil.FakeClientRecorder{
+		Client:  fakeClient,
+		T:       t,
+		Added:   []client.Object{},
+		Updated: []client.Object{},
+		Deleted: []client.Object{},
+	}
 	ctrl := &testutil.FakeController{t, false, make(chan struct{})}
+	informer := informertest.FakeInformers{Scheme: scheme}
+	cache := &testutil.FakeCache{Informers: &informer, Reader: fakeClient}
 	reconciler := &reconciler{
 		client: cl,
+		cache:  cache,
 		config: Config{
 			GatewayAPIEnabled:           true,
 			GatewayAPIControllerEnabled: true,

--- a/pkg/operator/controller/gatewayapi/status.go
+++ b/pkg/operator/controller/gatewayapi/status.go
@@ -1,0 +1,84 @@
+package gatewayapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
+)
+
+// setUnmanagedGatewayAPICRDNamesStatus sets the status of the "ingress" cluster operator
+// with the names of the unmanaged Gateway CRDs.
+func (r *reconciler) setUnmanagedGatewayAPICRDNamesStatus(ctx context.Context, crdNames []string) error {
+	return r.setClusterOperatorStatusExtension(ctx, &status.IngressOperatorStatusExtension{
+		UnmanagedGatewayAPICRDNames: strings.Join(crdNames, ","),
+	})
+}
+
+// setClusterOperatorStatusExtension attempts to ensure that the "ingress" cluster operator's status
+// is updated with the given extension. Returns an error if failed to update the status.
+func (r *reconciler) setClusterOperatorStatusExtension(ctx context.Context, desiredExtension *status.IngressOperatorStatusExtension) error {
+	have, current, err := r.currentClusterOperator(ctx, operatorcontroller.IngressClusterOperatorName())
+	if err != nil {
+		return err
+	}
+	if !have {
+		return fmt.Errorf("cluster operator %q not found", operatorcontroller.IngressClusterOperatorName().Name)
+	}
+	if _, err := r.updateClusterOperatorStatusExtension(ctx, current, desiredExtension); err != nil {
+		return err
+	}
+	return nil
+}
+
+// currentClusterOperator returns a boolean indicating whether a cluster operator
+// with the given name exists, as well as its definition if it does exist and an error value.
+func (r *reconciler) currentClusterOperator(ctx context.Context, name types.NamespacedName) (bool, *configv1.ClusterOperator, error) {
+	co := &configv1.ClusterOperator{}
+	if err := r.client.Get(ctx, name, co); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, fmt.Errorf("failed to get cluster operator %q: %w", name.Name, err)
+	}
+	return true, co, nil
+}
+
+// updateClusterOperatorStatusExtension updates a cluster operator's status extension.
+// Returns a boolean indicating whether the cluster operator was updated, and an error value.
+// If there are no unmanaged gateway CRDs, the `unmanagedGatewayAPICRDNames` field of desiredExtension will be empty
+// due to the `omitempty` tag. As a result, the `unmanagedGatewayAPICRDNames` field in the status extension of
+// the given cluster operator will be reset.
+func (r *reconciler) updateClusterOperatorStatusExtension(ctx context.Context, current *configv1.ClusterOperator, desiredExtension *status.IngressOperatorStatusExtension) (bool, error) {
+	currentExtension := &status.IngressOperatorStatusExtension{}
+	if len(current.Status.Extension.Raw) > 0 /*to avoid "unexpected end of JSON input" error*/ {
+		if err := json.Unmarshal(current.Status.Extension.Raw, currentExtension); err != nil {
+			return false, fmt.Errorf("failed to unmarshal status extension of cluster operator %q: %w", current.Name, err)
+		}
+	}
+	if currentExtension.UnmanagedGatewayAPICRDNames == desiredExtension.UnmanagedGatewayAPICRDNames {
+		return false, nil
+	}
+
+	updated := current.DeepCopy()
+	updatedExtension := *currentExtension
+	updatedExtension.UnmanagedGatewayAPICRDNames = desiredExtension.UnmanagedGatewayAPICRDNames
+	rawUpdatedExtension, err := json.Marshal(updatedExtension)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal updated status extension of cluster operator %q: %w", updated.Name, err)
+	}
+	updated.Status.Extension.Raw = rawUpdatedExtension
+	if err := r.client.Status().Update(ctx, updated); err != nil {
+		return false, fmt.Errorf("failed to update cluster operator %q: %w", updated.Name, err)
+	}
+	log.Info("Updated cluster operator", "name", updated.Name, "status.extension", string(updated.Status.Extension.Raw))
+	return true, nil
+}


### PR DESCRIPTION
Set the ingress cluster operator’s `Degraded` status to `true` if unmanaged Gateway API CRDs exist on the cluster.

An unmanaged Gateway API CRD is one with "gateway.networking.k8s.io" or "gateway.networking.x-k8s.io" in its `spec.group` field, and not managed by the gatewayapi controller.

This PR uses the cluster operator’s `status.extension` field to store the names of unmanaged CRDs. The gatewayapi controller writes to this field, while the status controller reads it and updates the ingress cluster operator’s `Degraded` status accordingly.