### PR TITLE
Enable Gateway only CA Bundles and custom CA CM name

### DIFF
--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -91,6 +91,12 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 		// "multi-network gateways".  This is an Istio feature that I
 		// haven't really found any explanation for.
 		"PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API": "false",
+		// Rename the CA Bundle CM used by the Gateway Control Plane
+		// to avoid conflicts with a User Istio Control Plane.
+		"PILOT_CA_CERT_CONFIGMAP": "openshift-gw-ca-root-cert",
+		// Only create CA Bundle CM in namespaces where there are
+		// Gateway API Gateways
+		"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY": "true",
 	}
 	return &sailv1.Istio{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Avoid conflict with a user control plane by setting a custom CA Bundle CM name for the Gateway Control plane and enable istio to only inject CA Bundle CMs in namespaces where Gateways exist to avoid poluting the whole cluster.

Two new Env variables set for the Istio control plane deployment CR;
  PILOT_CA_CERT_CONFIGMAP
  PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY

Related to [OSSM-9076](https://issues.redhat.com/browse/OSSM-9076)

Depends on
* openshift-service-mesh/istio#335 [OSSM-9076](https://issues.redhat.com/browse/OSSM-9076)
* openshift-service-mesh/istio#333 [OSSM-8206](https://issues.redhat.com/browse/OSSM-8206)