### PR TITLE
NE-2009: Move VAP to Default featureset

### DIFF
--- a/manifests/01-validating-admission-policy-binding.yaml
+++ b/manifests/01-validating-admission-policy-binding.yaml
@@ -7,7 +7,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
 spec:
   policyName: openshift-ingress-operator-gatewayapi-crd-admission
   validationActions: [Deny]

--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -7,7 +7,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: "TechPreviewNoUpgrade,CustomNoUpgrade"
 spec:
   matchConstraints:
     # Consider only requests to CRD resources.


### PR DESCRIPTION
The `openshift-ingress-operator-gatewayapi-crd-admission` Validating Admission Policy is bound to `GatewayAPI` featuregate, which has been promoted to GA (https://github.com/openshift/api/pull/2261).
This PR removes the `feature-set` annotation from manifests related to VAP, this effectively makes them part of the `Default` featureset.