### PR TITLE
dns/gcp: Update configuring custom endpoints

### DIFF
--- a/pkg/dns/gcp/provider.go
+++ b/pkg/dns/gcp/provider.go
@@ -43,20 +43,21 @@ func New(config Config) (*Provider, error) {
 		option.WithCredentialsJSON(config.CredentialsJSON),
 		option.WithUserAgent(config.UserAgent),
 	}
+
+	dnsService, err := gdnsv1.NewService(context.TODO(), options...)
+	if err != nil {
+		return nil, err
+	}
+
 	if config.GCPCustomEndpointsEnabled {
 		for _, endpoint := range config.Endpoints {
 			if endpoint.Name == configv1.GCPServiceEndpointNameDNS {
 				// There should be at most 1 endpoint override per service. If there
 				// is more than one, only use the first instance.
-				options = append(options, option.WithEndpoint(endpoint.URL))
+				dnsService.BasePath = endpoint.URL
 				break
 			}
 		}
-	}
-
-	dnsService, err := gdnsv1.NewService(context.TODO(), options...)
-	if err != nil {
-		return nil, err
 	}
 
 	provider := &Provider{


### PR DESCRIPTION
If a custom service endpoint has been configured for DNS, use it when creating the client for the Google Cloud DNS service. When this was originally completed, the option.WithEndpoint Google cloud option was used. This is the offically accepted way that is recommended by Google. However, it was discovered that when an endpoint formatted as `https://someendpoint...` is used, the client was producing 404 errors. If this same endpoint was used but set with `BasePath = endpoint` the correct endpoint was used and traffic was observed going to the endpoint.

This feature is behind the "GCPCustomAPIEndpoints" featuregate.

This commit resolves [CORS-3907](https://issues.redhat.com//browse/CORS-3907).

https://issues.redhat.com/browse/CORS-3907

* pkg/dns/gcp/provider.go (Update): Set the endpoint override using BasePath rather than options.WithEndpoint.