### PR TITLE
NE-2032: e2e: Signal service deprovisioning issues during Gateway DNS test

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1152,6 +1152,27 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 	if err := deleteWithRetryOnError(t, context.TODO(), gateway, 30*time.Second); err != nil {
 		t.Errorf("failed to delete gateway %q: %v", gateway.Name, err)
 	}
+	t.Logf("Deleted gateway %q", gateway.Name)
+
+	// The load balancer deprovisioning can take some time.
+	// Signal a long deprovisioning to help distinguish it from DNS management problems.
+	gtwSvcName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: gateway.Name + "-" + gatewayClass.Name}
+	t.Logf("Checking the deletion of service %q", gtwSvcName)
+	if err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
+		svc := &corev1.Service{}
+		if err := kclient.Get(ctx, gtwSvcName, svc); err != nil {
+			if kerrors.IsNotFound(err) {
+				t.Logf("Service %q is deleted", gtwSvcName)
+				return true, nil
+			}
+			t.Logf("Failed to get service %q: %v, retrying ...", gtwSvcName, err)
+			return false, nil
+		}
+		t.Logf("Service %q still exists, retrying ...", gtwSvcName)
+		return false, nil
+	}); err != nil {
+		t.Logf("Timed out waiting for the service %q to finalize the deletion", gtwSvcName)
+	}
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{


### PR DESCRIPTION
This PR adds a check for the service associated with a deleted gateway. The test now waits for the service to be fully removed and logs a warning if it persists beyond a specified timeout. This helps identify delays in deprovisioning of cloud load balancers backing gateway services.