### PR TITLE
OCPBUGS-55652: Removed PrivateHostedZoneAWS from component

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -111,10 +111,6 @@ type Config struct {
 	DNSRecordNamespaces          []string
 	OperatorReleaseVersion       string
 	AzureWorkloadIdentityEnabled bool
-	// PrivateHostedZoneAWSEnabled indicates whether the "SharedVPC" feature gate is
-	// enabled.
-	PrivateHostedZoneAWSEnabled bool
-
 	// GCPCustomEndpointsEnabled indicates whether the "GCPCustomAPIEndpoints"
 	// feature gate is enabled.
 	GCPCustomEndpointsEnabled bool
@@ -670,7 +666,7 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 		if dnsConfig.Spec.Platform.AWS != nil {
 			roleARN = dnsConfig.Spec.Platform.AWS.PrivateZoneIAMRole
 		}
-		if roleARN != "" && r.config.PrivateHostedZoneAWSEnabled {
+		if roleARN != "" {
 			cfg := cfg
 			cfg.RoleARN = roleARN
 			privateProvider, err := awsdns.NewProvider(cfg, r.config.OperatorReleaseVersion)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,7 +131,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		return nil, err
 	}
 	azureWorkloadIdentityEnabled := featureGates.Enabled(features.FeatureGateAzureWorkloadIdentity)
-	sharedVPCEnabled := featureGates.Enabled(features.FeatureGatePrivateHostedZoneAWS)
 	gatewayAPIEnabled := featureGates.Enabled(features.FeatureGateGatewayAPI)
 	gatewayAPIControllerEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIController)
 	routeExternalCertificateEnabled := featureGates.Enabled(features.FeatureGateRouteExternalCertificate)
@@ -258,7 +257,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		},
 		OperatorReleaseVersion:       config.OperatorReleaseVersion,
 		AzureWorkloadIdentityEnabled: azureWorkloadIdentityEnabled,
-		PrivateHostedZoneAWSEnabled:  sharedVPCEnabled,
 		GCPCustomEndpointsEnabled:    gcpCustomEndpointsEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create dns controller: %v", err)


### PR DESCRIPTION
Removed PrivateHostedZoneAWS from cluster-ingress-operator as it is no longer needed 