### PR TITLE
Bump to OSSM 3.0.3 and Istio 1.24.4

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -34,7 +34,7 @@ const (
 	// that is mounted from configmap openshift-ingress-operator/trusted-ca.
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	defaultGatewayAPIOperatorChannel = "stable"
-	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.0.0"
+	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.0.3"
 )
 
 type StartOptions struct {

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -53,7 +53,7 @@ spec:
         - name: GATEWAY_API_OPERATOR_CHANNEL
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION
-          value: servicemeshoperator3.v3.0.0
+          value: servicemeshoperator3.v3.0.3
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: GATEWAY_API_OPERATOR_CHANNEL
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION
-              value: servicemeshoperator3.v3.0.0
+              value: servicemeshoperator3.v3.0.3
           resources:
             requests:
               cpu: 10m

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -83,11 +83,6 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 		// then our Istiod instance might try to reconcile gateways
 		// belonging to an unrelated Istiod instance.
 		"PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS_NAME": controller.OpenShiftDefaultGatewayClassName,
-		// Watch Gateway API and Kubernetes resources in all namespaces,
-		// but ignore Istio resources that don't match our label
-		// selector.  (We do not specify the label selector, so this
-		// causes Istio to ignore all Istio resources.)
-		"PILOT_ENABLE_GATEWAY_CONTROLLER_MODE": "true",
 		// Only reconcile resources that are associated with
 		// gatewayclasses that have our controller name.
 		"PILOT_GATEWAY_API_CONTROLLER_NAME": controller.OpenShiftGatewayClassControllerName,

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -148,7 +148,7 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 					IngressControllerMode: sailv1.MeshConfigIngressControllerModeOff,
 				},
 			},
-			Version: "v1.24.3",
+			Version: "v1.24.4",
 		},
 	}
 }

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -101,6 +101,13 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 		// Only create CA Bundle CM in namespaces where there are
 		// Gateway API Gateways
 		"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY": "true",
+		// Don't copy labels or annotations from gateways to resources
+		// that Istiod creates for that gateway.  This is an Istio-
+		// specific behavior which might not be supported by other
+		// Gateway API implementations and that could allow the end-user
+		// to inject unsupported configuration, for example using
+		// service annotations.
+		"PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS": "false",
 	}
 	return &sailv1.Istio{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -95,6 +95,12 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 		// "multi-network gateways".  This is an Istio feature that I
 		// haven't really found any explanation for.
 		"PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API": "false",
+		// Rename the CA Bundle CM used by the Gateway Control Plane
+		// to avoid conflicts with a User Istio Control Plane.
+		"PILOT_CA_CERT_CONFIGMAP": "openshift-gw-ca-root-cert",
+		// Only create CA Bundle CM in namespaces where there are
+		// Gateway API Gateways
+		"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY": "true",
 	}
 	return &sailv1.Istio{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -1035,7 +1035,7 @@ func assertDNSRecord(t *testing.T, recordName types.NamespacedName) error {
 	t.Helper()
 	dnsRecord := &v1.DNSRecord{}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(context context.Context) (bool, error) {
 		if err := kclient.Get(context, recordName, dnsRecord); err != nil {
 			t.Logf("Failed to get DNSRecord %v: %v; retrying...", recordName, err)
 			return false, nil


### PR DESCRIPTION
#### Bump to OSSM 3.0.3 and Istio 1.24.4

Bump from OSSM v3.0.0 to v3.0.3 and from Istio v1.24.3 to v1.24.4.  


#### Enable Gateway only CA Bundles and custom CA CM name

Avoid conflict with a user control plane by setting a custom CA Bundle CM name for the Gateway Control plane and enable Istio to only inject CA Bundle CMs in namespaces where Gateways exist to avoid polluting the whole cluster.

Two new environment variables are set for the Istio control plane deployment CR:

    PILOT_CA_CERT_CONFIGMAP
    PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY

This change is related to [OSSM-9076](https://issues.redhat.com/browse/OSSM-9076).

This change incorporates #1209.  

#### Don't copy labels or annotations

Configure Istiod not to copy annotations or labels from gateways onto associated resources, such as the proxy deployment and load-balancer service for a gateway.

This copying behavior is Istio-specific, not part of the Gateway API spec, and could be used to inject unsupported configuration.  For example, an end-user could set a service annotation on the gateway in order to configure a load-balancer.  Setting annotations on the gateway to configure the load-balancer would not be portable to other Gateway API implementations and would complicate product support.

One new environment variable is set:

    PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS

This change is related to [OSSM-8989](https://issues.redhat.com/browse/OSSM-8989).


#### Delete old controller-mode setting

Delete the obsolete `PILOT_ENABLE_GATEWAY_CONTROLLER_MODE` environment variable from the Istiod configuration.  This environment variable is no longer recognized in OSSM 3, and the variable has been superseded by EnhancedResourceScoping.

#### `assertDNSRecord`: Increase timeout to 10m

Increase the timeout in `assertDNSRecord` for polling for the DNSRecord CR from 1 minute to 10 minutes.

The cloud provider can easily take over a minute to provision the load balancer, and the operator cannot create the DNSRecord CR before the load balancer has been provisioned and assigned a host name or address.  Consequently, the polling loop could easily reach the 1-minute timeout just on account of the time that it takes to provision the load balancer.

#### `testGatewayAPIManualDeployment`: Increase timeout

Increase the timeout for polling the gateway, and dump the gateway if the test fails.