### PR TITLE
OCPBUGS-58358: desiredIstio: Do not enable a default PDB

### DIFF
--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -109,6 +109,9 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 			},
 			Values: &sailv1.Values{
 				Global: &sailv1.GlobalConfig{
+					DefaultPodDisruptionBudget: &sailv1.DefaultPodDisruptionBudgetConfig{
+						Enabled: ptr.To(false),
+					},
 					IstioNamespace:    ptr.To(controller.DefaultOperandNamespace),
 					PriorityClassName: ptr.To(systemClusterCriticalPriorityClassName),
 				},


### PR DESCRIPTION
Turn off the default PodDisruptionBudget for the Istio control plane in order to prevent the PDB from blocking upgrades.

We only have 1 pod replica by default, and the PDB was blocking the pod from being evicted, which blocked upgrades.