### PR TITLE
OCPBUGS-55673: Remove IngressControllerLBSubnetsAWS featuregate

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -208,7 +208,6 @@ type Config struct {
 	Namespace                                 string
 	IngressControllerImage                    string
 	RouteExternalCertificateEnabled           bool
-	IngressControllerLBSubnetsAWSEnabled      bool
 	IngressControllerEIPAllocationsAWSEnabled bool
 	IngressControllerDCMEnabled               bool
 }

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -824,7 +824,6 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 		ic                       *operatorv1.IngressController
 		service                  *corev1.Service
 		platformStatus           *configv1.PlatformStatus
-		awsSubnetsEnabled        bool
 		awsEIPAllocationsEnabled bool
 
 		expectStatus                operatorv1.ConditionStatus
@@ -935,10 +934,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				nil,
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets nil spec and empty status",
@@ -947,24 +945,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				&operatorv1.AWSSubnets{},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
-		},
-		{
-			name: "NLB LoadBalancerService, AWS Subnets spec with names and nil status, but feature gate disabled",
-			ic: loadBalancerIngressControllerWithAWSSubnets(
-				operatorv1.AWSNetworkLoadBalancer,
-				&operatorv1.AWSSubnets{
-					Names: []operatorv1.AWSSubnetName{"name-12345"},
-				},
-				nil,
-			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: false,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets spec with names and nil status",
@@ -975,10 +958,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				},
 				nil,
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets nil spec and status with ids",
@@ -989,10 +971,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					IDs: []operatorv1.AWSSubnetID{"subnet-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets spec and status are equal",
@@ -1007,10 +988,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets spec and status are NOT equal",
@@ -1025,10 +1005,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets spec and status are equal with different order",
@@ -1043,10 +1022,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890", "name-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS Subnets spec and status have extra items",
@@ -1061,10 +1039,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890", "name-12345", "name-54321"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets nil spec and nil status",
@@ -1073,10 +1050,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				nil,
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets nil spec and empty status",
@@ -1085,10 +1061,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				&operatorv1.AWSSubnets{},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets spec with names and nil status",
@@ -1099,10 +1074,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				},
 				nil,
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets nil spec and status with ids",
@@ -1113,10 +1087,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					IDs: []operatorv1.AWSSubnetID{"subnet-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets spec and status are equal",
@@ -1131,10 +1104,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets spec and status are NOT equal",
@@ -1149,10 +1121,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets spec and status are equal with different order",
@@ -1167,10 +1138,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890", "name-12345"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "CLB LoadBalancerService, AWS Subnets spec and status have extra items",
@@ -1185,10 +1155,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 					Names: []operatorv1.AWSSubnetName{"name-67890", "name-12345", "name-54321"},
 				},
 			),
-			service:           &corev1.Service{},
-			awsSubnetsEnabled: true,
-			platformStatus:    awsPlatformStatus,
-			expectStatus:      operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations nil spec and nil status",
@@ -1292,7 +1261,7 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := computeLoadBalancerProgressingStatus(test.ic, test.service, test.platformStatus, test.awsSubnetsEnabled, test.awsEIPAllocationsEnabled)
+			actual := computeLoadBalancerProgressingStatus(test.ic, test.service, test.platformStatus, test.awsEIPAllocationsEnabled)
 			if actual.Status != test.expectStatus {
 				t.Errorf("expected status to be %s, got %s", test.expectStatus, actual.Status)
 			}
@@ -3175,7 +3144,7 @@ func Test_computeIngressUpgradeableCondition(t *testing.T) {
 					},
 				},
 			}
-			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true, true)
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true)
 			if err != nil {
 				t.Errorf("unexpected error from desiredLoadBalancerService: %v", err)
 				return
@@ -3197,7 +3166,7 @@ func Test_computeIngressUpgradeableCondition(t *testing.T) {
 				expectedStatus = operatorv1.ConditionTrue
 			}
 
-			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret, true, true)
+			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret, true)
 			if actual.Status != expectedStatus {
 				t.Errorf("expected Upgradeable to be %q, got %q", expectedStatus, actual.Status)
 			}
@@ -3285,7 +3254,7 @@ func Test_computeIngressEvaluationConditionsDetectedCondition(t *testing.T) {
 				},
 			}
 
-			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true, true)
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true)
 			if err != nil {
 				t.Fatalf("unexpected error from desiredLoadBalancerService: %v", err)
 			}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -135,7 +135,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	gatewayAPIEnabled := featureGates.Enabled(features.FeatureGateGatewayAPI)
 	gatewayAPIControllerEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIController)
 	routeExternalCertificateEnabled := featureGates.Enabled(features.FeatureGateRouteExternalCertificate)
-	ingressControllerLBSubnetsAWSEnabled := featureGates.Enabled(features.FeatureGateIngressControllerLBSubnetsAWS)
 	ingressControllerEIPAllocationsAWSEnabled := featureGates.Enabled(features.FeatureGateSetEIPForNLBIngressController)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
 	gcpCustomEndpointsEnabled := featureGates.Enabled(features.FeatureGateGCPCustomAPIEndpoints)
@@ -186,7 +185,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		Namespace:                                 config.Namespace,
 		IngressControllerImage:                    config.IngressControllerImage,
 		RouteExternalCertificateEnabled:           routeExternalCertificateEnabled,
-		IngressControllerLBSubnetsAWSEnabled:      ingressControllerLBSubnetsAWSEnabled,
 		IngressControllerEIPAllocationsAWSEnabled: ingressControllerEIPAllocationsAWSEnabled,
 		IngressControllerDCMEnabled:               ingressControllerDCMEnabled,
 	}); err != nil {

--- a/test/e2e/lb_subnets_test.go
+++ b/test/e2e/lb_subnets_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -42,11 +41,6 @@ func TestAWSLBSubnets(t *testing.T) {
 	}
 	if infraConfig.Status.PlatformStatus.Type != configv1.AWSPlatformType {
 		t.Skipf("test skipped on platform %q", infraConfig.Status.PlatformStatus.Type)
-	}
-	if enabled, err := isFeatureGateEnabled(features.FeatureGateIngressControllerLBSubnetsAWS); err != nil {
-		t.Fatalf("failed to get feature gate: %v", err)
-	} else if !enabled {
-		t.Skipf("test skipped because %q feature gate is not enabled", features.FeatureGateIngressControllerLBSubnetsAWS)
 	}
 
 	// First, let's get the list of public subnets to use for the LB.
@@ -191,11 +185,6 @@ func TestUnmanagedAWSLBSubnets(t *testing.T) {
 	}
 	if infraConfig.Status.PlatformStatus.Type != configv1.AWSPlatformType {
 		t.Skipf("test skipped on platform %q", infraConfig.Status.PlatformStatus.Type)
-	}
-	if enabled, err := isFeatureGateEnabled(features.FeatureGateIngressControllerLBSubnetsAWS); err != nil {
-		t.Fatalf("failed to get feature gate: %v", err)
-	} else if !enabled {
-		t.Skipf("test skipped because %q feature gate is not enabled", features.FeatureGateIngressControllerLBSubnetsAWS)
 	}
 
 	// First, let's get the list of public subnets to use for the LB.


### PR DESCRIPTION
The IngressControllerLBSubnetsAWS feature gate was at first introduced as TPNU in OpenShift 4.17 and was promoted to Default in the same release. The feature gate has been enabled by default for 3 releases, so it is scheduled to be removed imminently.

The feature itself (ability to choose AWS subnets for LoadBalancer Service) remains, only the feature gate check is removed.

Follow-up to the commit which introduced the feature gate: https://github.com/openshift/cluster-ingress-operator/pull/1046/commits/26dfe2c2f030cd6af33f94c8c958bbfcb733ba18

Feature was added as TPNU in: https://github.com/openshift/api/pull/1841
Feature was promoted to Default (GA) in: https://github.com/openshift/api/pull/1966

- pkg/operator/controller/ingress/controller.go: Remove IngressControllerLBSubnetsAWSEnabled from Config.
- pkg/operator/controller/ingress/load_balancer_service.go:
    - (desiredLoadBalancerService): Remove subnetsAWSEnabled featuregate checks and the redundant function parameter.
    - (loadBalancerServiceIsUpgradeable): Remove featuregate check from the LB Service upgradeability calculation.
    - (loadBalancerServiceIsProgressing): Remove featuregate check from LB Service progressing calculation.
- pkg/operator/controller/ingress/load_balancer_service_test.go: Update desiredLoadBalancerService function calls after removing the subnetsAWSEnabled parameter.
- pkg/operator/controller/ingress/status.go:
    - (syncIngressControllerStatus): Remove LBSubnetsAWS featuregate check from the IC status computation.
    - (computeIngressUpgradeableCondition): Remove subnetsAWSEnabled featuregate check.
    - (computeLoadBalancerProgressingStatus): Remove subnetsAWSEnabled from the LB progressing status computation.
- pkg/operator/controller/ingress/status_test.go
    - (Test_computeLoadBalancerProgressingStatus): Remove test case with the LBSubnetsAWS featuregate disabled. Remove awsSubnetsEnabled boolean since it is not needed anymore.
    - (Test_computeIngressUpgradeableCondition): Update function calls after the featuregate check paramter was removed.
    - (Test_computeIngressEvaluationConditionsDetectedCondition): Update function calls after the featuregate check parameter was removed.
- pkg/operator/operator.go:
    - (New): Remove ingressControllerLBSubnetsAWSEnabled featuregate check.
- test/e2e/lb_subnets_test.go:
    - (TestAWSLBSubnets): Remove featuregate check.
    - (TestUnmanagedAWSLBSubnets): Remove featuregate check.