### PR TITLE
OCPBUGS-59839: desiredIstio: Delete trustBundleName

### DIFF
--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -124,7 +124,6 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference) *sa
 					},
 					IstioNamespace:    ptr.To(controller.DefaultOperandNamespace),
 					PriorityClassName: ptr.To(systemClusterCriticalPriorityClassName),
-					TrustBundleName:   ptr.To(controller.OpenShiftGatewayCARootCertName),
 				},
 				Pilot: &sailv1.PilotConfig{
 					Cni: &sailv1.CNIUsageConfig{


### PR DESCRIPTION
Change `desiredIstio` not to set `trustBundleName`, which requires OSSM 3.1.

Trying to set `trustBundleName` caused the operator to log the following error and reconcile repeatedly:

    unknown field "spec.values.global.trustBundleName"

Once we bump to OSSM 3.1, we can add this field back.

Follow-up to #1227, specifically https://github.com/openshift/cluster-ingress-operator/pull/1227/commits/41d7addc3975ea0ca12ada2c368ef58311298921.