### PR TITLE
NE-2108: Add OSSM channel and version override annotations

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -35,6 +35,7 @@ const (
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	defaultGatewayAPIOperatorChannel = "stable"
 	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.0.1"
+	defaultIstioVersion              = "v1.24.4"
 )
 
 type StartOptions struct {
@@ -57,6 +58,8 @@ type StartOptions struct {
 	GatewayAPIOperatorChannel string
 	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
 	GatewayAPIOperatorVersion string
+	// IstioVersion is the version Istio to install.
+	IstioVersion string
 }
 
 func NewStartCommand() *cobra.Command {
@@ -82,6 +85,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.ShutdownFile, "shutdown-file", "s", defaultTrustedCABundle, "if provided, shut down the operator when this file changes")
 	cmd.Flags().StringVarP(&options.GatewayAPIOperatorChannel, "gateway-api-operator-channel", "", defaultGatewayAPIOperatorChannel, "release channel of the Gateway API implementation to install")
 	cmd.Flags().StringVarP(&options.GatewayAPIOperatorVersion, "gateway-api-operator-version", "", defaultGatewayAPIOperatorVersion, "name and release of the Gateway API implementation to install")
+	cmd.Flags().StringVarP(&options.IstioVersion, "istio-version", "", defaultIstioVersion, "version Istio to install")
 
 	if err := cmd.MarkFlagRequired("namespace"); err != nil {
 		panic(err)
@@ -132,6 +136,7 @@ func start(opts *StartOptions) error {
 		CanaryImage:               opts.CanaryImage,
 		GatewayAPIOperatorChannel: opts.GatewayAPIOperatorChannel,
 		GatewayAPIOperatorVersion: opts.GatewayAPIOperatorVersion,
+		IstioVersion:              opts.IstioVersion,
 	}
 
 	// Start operator metrics.

--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -33,6 +33,7 @@ const (
 	// defaultTrustedCABundle is the fully qualified path of the trusted CA bundle
 	// that is mounted from configmap openshift-ingress-operator/trusted-ca.
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	defaultGatewayAPIOperatorCatalog = "redhat-operators"
 	defaultGatewayAPIOperatorChannel = "stable"
 	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.0.1"
 	defaultIstioVersion              = "v1.24.4"
@@ -54,6 +55,8 @@ type StartOptions struct {
 	CanaryImage string
 	// ReleaseVersion is the cluster version which the operator will converge to.
 	ReleaseVersion string
+	// GatewayAPIOperatorCatalog is the catalog source to use to install the Gateway API implementation.
+	GatewayAPIOperatorCatalog string
 	// GatewayAPIOperatorChannel is the release channel of the Gateway API implementation to install.
 	GatewayAPIOperatorChannel string
 	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
@@ -83,6 +86,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&options.ReleaseVersion, "release-version", "", statuscontroller.UnknownVersionValue, "the release version the operator should converge to (required)")
 	cmd.Flags().StringVarP(&options.MetricsListenAddr, "metrics-listen-addr", "", "127.0.0.1:60000", "metrics endpoint listen address (required)")
 	cmd.Flags().StringVarP(&options.ShutdownFile, "shutdown-file", "s", defaultTrustedCABundle, "if provided, shut down the operator when this file changes")
+	cmd.Flags().StringVarP(&options.GatewayAPIOperatorCatalog, "gateway-api-operator-catalog", "", defaultGatewayAPIOperatorCatalog, "catalog source for the Gateway API implementation to install")
 	cmd.Flags().StringVarP(&options.GatewayAPIOperatorChannel, "gateway-api-operator-channel", "", defaultGatewayAPIOperatorChannel, "release channel of the Gateway API implementation to install")
 	cmd.Flags().StringVarP(&options.GatewayAPIOperatorVersion, "gateway-api-operator-version", "", defaultGatewayAPIOperatorVersion, "name and release of the Gateway API implementation to install")
 	cmd.Flags().StringVarP(&options.IstioVersion, "istio-version", "", defaultIstioVersion, "version Istio to install")
@@ -134,6 +138,7 @@ func start(opts *StartOptions) error {
 		Namespace:                 opts.OperatorNamespace,
 		IngressControllerImage:    opts.IngressControllerImage,
 		CanaryImage:               opts.CanaryImage,
+		GatewayAPIOperatorCatalog: opts.GatewayAPIOperatorCatalog,
 		GatewayAPIOperatorChannel: opts.GatewayAPIOperatorChannel,
 		GatewayAPIOperatorVersion: opts.GatewayAPIOperatorVersion,
 		IstioVersion:              opts.IstioVersion,

--- a/hack/ossm-overrides.md
+++ b/hack/ossm-overrides.md
@@ -1,0 +1,39 @@
+# OSSM Subscription and Istio Version Overrides
+
+Ingress Operator implements Gateway API through OpenShift Service Mesh, which is
+based on Istio and Envoy (see the [gateway-api-with-cluster-ingress-operator](https://github.com/openshift/enhancements/blob/master/enhancements/ingress/gateway-api-with-cluster-ingress-operator.md)
+enhancement proposal).  When Gateway API is enabled on a cluster, Ingress
+Operator creates an OLM subscription to install OSSM.  In usual operation, the
+source catalog, channel, and version that Ingress Operator specifies on the OSSM
+subscription come from [the Ingress Operator deployment manifest](../manifests/02-deployment.yaml).  However,
+Ingress Operator provides a set of **unsupported** annotations by which the
+source catalog, channel, and version for the OSSM subscription and version of
+Istio can be overridden.
+
+**Note: These annotations are only intended for use by OpenShift developers.
+Use of these annotations is unsupported**
+
+To use these annotations, specify them when creating the GatewayClass:
+
+``` shell
+oc create -f -<<'EOF'
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+  annotations:
+    unsupported.do-not-use.openshift.io/ossm-catalog: redhat-operators
+    unsupported.do-not-use.openshift.io/ossm-channel: stable
+    unsupported.do-not-use.openshift.io/ossm-version: servicemeshoperator3.v3.1.0
+    unsupported.do-not-use.openshift.io/istio-version: 1.26-latest
+spec:
+  controllerName: openshift.io/gateway-controller/v1
+EOF
+```
+
+**Note: The OSSM override annotations are intended to be used when initially
+creating the GatewayClass CR and associated Subscription CR.**  If you set the
+annotations *after* the Subscription has already been created, then Ingress
+Operator will update the Subscription, but OLM might ignore the change or report
+an error.  In particular, OLM does not allow downgrading, and OLM typically only
+allows upgrading to the next version after the currently installed version.

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -39,6 +39,8 @@ spec:
         - $(GATEWAY_API_OPERATOR_CHANNEL)
         - --gateway-api-operator-version
         - $(GATEWAY_API_OPERATOR_VERSION)
+        - --istio-version
+        - $(ISTIO_VERSION)
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
@@ -54,6 +56,8 @@ spec:
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION
           value: servicemeshoperator3.v3.0.1
+        - name: ISTIO_VERSION
+          value: v1.24.4
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -35,6 +35,8 @@ spec:
         - $(CANARY_IMAGE)
         - --release-version
         - $(RELEASE_VERSION)
+        - --gateway-api-operator-catalog
+        - $(GATEWAY_API_OPERATOR_CATALOG)
         - --gateway-api-operator-channel
         - $(GATEWAY_API_OPERATOR_CHANNEL)
         - --gateway-api-operator-version
@@ -52,6 +54,8 @@ spec:
           value: openshift/origin-haproxy-router:v4.0
         - name: CANARY_IMAGE
           value: openshift/origin-cluster-ingress-operator:latest
+        - name: GATEWAY_API_OPERATOR_CATALOG
+          value: redhat-operators
         - name: GATEWAY_API_OPERATOR_CHANNEL
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -64,6 +64,8 @@ spec:
           - "$(CANARY_IMAGE)"
           - --release-version
           - "$(RELEASE_VERSION)"
+          - --gateway-api-operator-catalog
+          - "$(GATEWAY_API_OPERATOR_CATALOG)"
           - --gateway-api-operator-channel
           - "$(GATEWAY_API_OPERATOR_CHANNEL)"
           - --gateway-api-operator-version
@@ -81,6 +83,8 @@ spec:
               value: openshift/origin-haproxy-router:v4.0
             - name: CANARY_IMAGE
               value: openshift/origin-cluster-ingress-operator:latest
+            - name: GATEWAY_API_OPERATOR_CATALOG
+              value: redhat-operators
             - name: GATEWAY_API_OPERATOR_CHANNEL
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -68,6 +68,8 @@ spec:
           - "$(GATEWAY_API_OPERATOR_CHANNEL)"
           - --gateway-api-operator-version
           - "$(GATEWAY_API_OPERATOR_VERSION)"
+          - --istio-version
+          - "$(ISTIO_VERSION)"
           env:
             - name: RELEASE_VERSION
               value: "0.0.1-snapshot"
@@ -83,6 +85,8 @@ spec:
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION
               value: servicemeshoperator3.v3.0.1
+            - name: ISTIO_VERSION
+              value: v1.24.4
           resources:
             requests:
               cpu: 10m

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -21,5 +21,8 @@ type Config struct {
 	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
 	GatewayAPIOperatorVersion string
 
+	// IstioVersion is the version of Istio to install.
+	IstioVersion string
+
 	Stop chan struct{}
 }

--- a/pkg/operator/config/config.go
+++ b/pkg/operator/config/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	// CanaryImage is the ingress operator image, which runs a canary command.
 	CanaryImage string
 
+	// GatewayAPIOperatorCatalog is the catalog source to use for the Gateway API implementation.
+	GatewayAPIOperatorCatalog string
+
 	// GatewayAPIOperatorChannel is the release channel of the Gateway API implementation to install.
 	GatewayAPIOperatorChannel string
 

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -130,6 +130,8 @@ type Config struct {
 	GatewayAPIOperatorChannel string
 	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.
 	GatewayAPIOperatorVersion string
+	// IstioVersion is the version of Istio to configure on the Istio CR.
+	IstioVersion string
 }
 
 // reconciler reconciles gatewayclasses.
@@ -206,7 +208,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx); err != nil {
 		errs = append(errs, err)
 	}
-	if _, _, err := r.ensureIstio(ctx, &gatewayclass); err != nil {
+	if _, _, err := r.ensureIstio(ctx, &gatewayclass, r.config.IstioVersion); err != nil {
 		errs = append(errs, err)
 	} else {
 		// The OSSM operator installs the istios.sailoperator.io CRD.

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -126,6 +126,8 @@ type Config struct {
 	OperatorNamespace string
 	// OperandNamespace is the namespace in which Istio should be deployed.
 	OperandNamespace string
+	// GatewayAPIOperatorCatalog is the catalog source to use to install the Gateway API implementation.
+	GatewayAPIOperatorCatalog string
 	// GatewayAPIOperatorChannel is the release channel of the Gateway API implementation to install.
 	GatewayAPIOperatorChannel string
 	// GatewayAPIOperatorVersion is the name and release of the Gateway API implementation to install.

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -1,0 +1,279 @@
+package gatewayclass
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
+)
+
+func Test_Reconcile(t *testing.T) {
+	req := func(name string) reconcile.Request {
+		return reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: name},
+		}
+	}
+
+	subscription := func(catalog, channel, version string) *operatorsv1alpha1.Subscription {
+		return &operatorsv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "servicemeshoperator3",
+				Namespace:   "openshift-operators",
+				Annotations: map[string]string{"ingress.operator.openshift.io/owned": ""},
+			},
+			Spec: &operatorsv1alpha1.SubscriptionSpec{
+				CatalogSource:          catalog,
+				CatalogSourceNamespace: "openshift-marketplace",
+				Package:                "servicemeshoperator3",
+				Channel:                channel,
+				StartingCSV:            version,
+				InstallPlanApproval:    "Manual",
+			},
+		}
+	}
+
+	istio := func(version string, gieEnabled bool) *sailv1.Istio {
+		ret := &sailv1.Istio{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "openshift-gateway",
+			},
+			Spec: sailv1.IstioSpec{
+				UpdateStrategy: &sailv1.IstioUpdateStrategy{
+					Type: "InPlace",
+				},
+				Namespace: "openshift-ingress",
+				Values: &sailv1.Values{
+					Global: &sailv1.GlobalConfig{
+						DefaultPodDisruptionBudget: &sailv1.DefaultPodDisruptionBudgetConfig{
+							Enabled: ptr.To(false),
+						},
+						IstioNamespace:    ptr.To("openshift-ingress"),
+						PriorityClassName: ptr.To("system-cluster-critical"),
+					},
+					Pilot: &sailv1.PilotConfig{
+						Cni: &sailv1.CNIUsageConfig{
+							Enabled: ptr.To(false),
+						},
+						Enabled: ptr.To(true),
+						Env: map[string]string{
+							"PILOT_ENABLE_GATEWAY_API":                         "true",
+							"PILOT_ENABLE_ALPHA_GATEWAY_API":                   "false",
+							"PILOT_ENABLE_GATEWAY_API_STATUS":                  "true",
+							"PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER":   "true",
+							"PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER": "false",
+							"PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS_NAME":      "openshift-default",
+							"PILOT_GATEWAY_API_CONTROLLER_NAME":                "openshift.io/gateway-controller/v1",
+							"PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API":         "false",
+							"ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT":             "false",
+							"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY":            "true",
+							"PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS": "false",
+						},
+						ExtraContainerArgs: []string{},
+						PodAnnotations: map[string]string{
+							"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+						},
+					},
+					SidecarInjectorWebhook: &sailv1.SidecarInjectorConfig{
+						EnableNamespacesByDefault: ptr.To(false),
+					},
+					MeshConfig: &sailv1.MeshConfig{
+						AccessLogFile: ptr.To("/dev/stdout"),
+						DefaultConfig: &sailv1.MeshConfigProxyConfig{
+							ProxyHeaders: &sailv1.ProxyConfigProxyHeaders{
+								Server: &sailv1.ProxyConfigProxyHeadersServer{
+									Disabled: ptr.To(true),
+								},
+								EnvoyDebugHeaders: &sailv1.ProxyConfigProxyHeadersEnvoyDebugHeaders{
+									Disabled: ptr.To(true),
+								},
+								MetadataExchangeHeaders: &sailv1.ProxyConfigProxyHeadersMetadataExchangeHeaders{
+									Mode: sailv1.ProxyConfigProxyHeadersMetadataExchangeModeInMesh,
+								},
+							},
+						},
+						IngressControllerMode: sailv1.MeshConfigIngressControllerModeOff,
+					},
+				},
+				Version: version,
+			},
+		}
+
+		if gieEnabled {
+			ret.Spec.Values.Pilot.Env["ENABLE_GATEWAY_API_INFERENCE_EXTENSION"] = "true"
+		}
+
+		return ret
+	}
+
+	tests := []struct {
+		name            string
+		request         reconcile.Request
+		existingObjects []runtime.Object
+		expectCreate    []client.Object
+		expectUpdate    []client.Object
+		expectDelete    []client.Object
+		expectError     string
+	}{
+		{
+			name:            "Nonexistent gatewayclass",
+			request:         req("openshift-default"),
+			existingObjects: []runtime.Object{},
+			expectCreate:    []client.Object{},
+			expectUpdate:    []client.Object{},
+			expectDelete:    []client.Object{},
+			expectError:     `"openshift-default" not found`,
+		},
+		{
+			name:    "Minimal gatewayclass",
+			request: req("openshift-default"),
+			existingObjects: []runtime.Object{
+				&gatewayapiv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-default",
+					},
+					Spec: gatewayapiv1.GatewayClassSpec{
+						ControllerName: gatewayapiv1.GatewayController("openshift.io/gateway-controller/v1"),
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
+				istio("v1.24.4", false),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			name:    "Minimal gatewayclass with experimental InferencePool CRD",
+			request: req("openshift-default"),
+			existingObjects: []runtime.Object{
+				&gatewayapiv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-default",
+					},
+					Spec: gatewayapiv1.GatewayClassSpec{
+						ControllerName: gatewayapiv1.GatewayController("openshift.io/gateway-controller/v1"),
+					},
+				},
+				&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "inferencepools.inference.networking.x-k8s.io",
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
+				istio("v1.24.4", true),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			name:    "Minimal gatewayclass with stable InferencePool CRD",
+			request: req("openshift-default"),
+			existingObjects: []runtime.Object{
+				&gatewayapiv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-default",
+					},
+					Spec: gatewayapiv1.GatewayClassSpec{
+						ControllerName: gatewayapiv1.GatewayController("openshift.io/gateway-controller/v1"),
+					},
+				},
+				&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "inferencepools.inference.networking.k8s.io",
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
+				istio("v1.24.4", true),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	configv1.Install(scheme)
+	gatewayapiv1.Install(scheme)
+	operatorsv1alpha1.AddToScheme(scheme)
+	sailv1.AddToScheme(scheme)
+	apiextensionsv1.AddToScheme(scheme)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.existingObjects...).
+				Build()
+			cl := &testutil.FakeClientRecorder{
+				Client:  fakeClient,
+				T:       t,
+				Added:   []client.Object{},
+				Updated: []client.Object{},
+				Deleted: []client.Object{},
+			}
+			gatewayClassController = &testutil.FakeController{
+				T:                     t,
+				Started:               false,
+				StartNotificationChan: nil,
+			}
+			informer := informertest.FakeInformers{Scheme: scheme}
+			cache := &testutil.FakeCache{Informers: &informer, Reader: fakeClient}
+			reconciler := &reconciler{
+				client: cl,
+				cache:  cache,
+				config: Config{
+					OperatorNamespace:         "openshift-ingress-operator",
+					OperandNamespace:          "openshift-ingress",
+					GatewayAPIOperatorChannel: "stable",
+					GatewayAPIOperatorVersion: "servicemeshoperator3.v3.0.1",
+				},
+			}
+			res, err := reconciler.Reconcile(context.Background(), tc.request)
+			if tc.expectError != "" {
+				assert.Contains(t, err.Error(), tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, reconcile.Result{}, res)
+			cmpOpts := []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion", "OwnerReferences"),
+				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
+				cmpopts.IgnoreFields(operatorsv1alpha1.SubscriptionSpec{}, "Config"),
+				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
+			}
+			if diff := cmp.Diff(tc.expectCreate, cl.Added, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual creates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectUpdate, cl.Updated, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual updates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectDelete, cl.Deleted, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual deletes: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -249,6 +249,7 @@ func Test_Reconcile(t *testing.T) {
 					OperandNamespace:          "openshift-ingress",
 					GatewayAPIOperatorChannel: "stable",
 					GatewayAPIOperatorVersion: "servicemeshoperator3.v3.0.1",
+					IstioVersion:              "v1.24.4",
 				},
 			}
 			res, err := reconciler.Reconcile(context.Background(), tc.request)

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -247,6 +247,7 @@ func Test_Reconcile(t *testing.T) {
 				config: Config{
 					OperatorNamespace:         "openshift-ingress-operator",
 					OperandNamespace:          "openshift-ingress",
+					GatewayAPIOperatorCatalog: "redhat-operators",
 					GatewayAPIOperatorChannel: "stable",
 					GatewayAPIOperatorVersion: "servicemeshoperator3.v3.0.1",
 					IstioVersion:              "v1.24.4",

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -212,6 +212,55 @@ func Test_Reconcile(t *testing.T) {
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
 		},
+		{
+			name:    "Gatewayclass with Istio version override",
+			request: req("openshift-default"),
+			existingObjects: []runtime.Object{
+				&gatewayapiv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"unsupported.do-not-use.openshift.io/istio-version": "v1.24-latest",
+						},
+						Name: "openshift-default",
+					},
+					Spec: gatewayapiv1.GatewayClassSpec{
+						ControllerName: gatewayapiv1.GatewayController("openshift.io/gateway-controller/v1"),
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
+				istio("v1.24-latest", false),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			name:    "Gatewayclass with OSSM and Istio overrides",
+			request: req("openshift-default"),
+			existingObjects: []runtime.Object{
+				&gatewayapiv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"unsupported.do-not-use.openshift.io/ossm-catalog":  "foo",
+							"unsupported.do-not-use.openshift.io/ossm-channel":  "bar",
+							"unsupported.do-not-use.openshift.io/ossm-version":  "baz",
+							"unsupported.do-not-use.openshift.io/istio-version": "quux",
+						},
+						Name: "openshift-default",
+					},
+					Spec: gatewayapiv1.GatewayClassSpec{
+						ControllerName: gatewayapiv1.GatewayController("openshift.io/gateway-controller/v1"),
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				subscription("foo", "bar", "baz"),
+				istio("quux", false),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
 	}
 
 	scheme := runtime.NewScheme()

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -26,7 +26,7 @@ const systemClusterCriticalPriorityClassName = "system-cluster-critical"
 // ensureIstio attempts to ensure that an Istio CR is present and returns a
 // Boolean indicating whether it exists, the CR if it exists, and an error
 // value.
-func (r *reconciler) ensureIstio(ctx context.Context, gatewayclass *gatewayapiv1.GatewayClass) (bool, *sailv1.Istio, error) {
+func (r *reconciler) ensureIstio(ctx context.Context, gatewayclass *gatewayapiv1.GatewayClass, istioVersion string) (bool, *sailv1.Istio, error) {
 	name := controller.IstioName(r.config.OperandNamespace)
 	have, current, err := r.currentIstio(ctx, name)
 	if err != nil {
@@ -45,7 +45,7 @@ func (r *reconciler) ensureIstio(ctx context.Context, gatewayclass *gatewayapiv1
 		return have, current, err
 	}
 
-	desired := desiredIstio(name, ownerRef, enableInferenceExtension)
+	desired := desiredIstio(name, ownerRef, istioVersion, enableInferenceExtension)
 
 	switch {
 	case !have:
@@ -96,7 +96,7 @@ func (r *reconciler) crdExists(ctx context.Context, crdName string) (bool, error
 }
 
 // desiredIstio returns the desired Istio CR.
-func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, enableInferenceExtension bool) *sailv1.Istio {
+func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, istioVersion string, enableInferenceExtension bool) *sailv1.Istio {
 	pilotContainerEnv := map[string]string{
 		// Enable Gateway API.
 		"PILOT_ENABLE_GATEWAY_API": "true",
@@ -203,7 +203,7 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, ena
 					IngressControllerMode: sailv1.MeshConfigIngressControllerModeOff,
 				},
 			},
-			Version: "v1.24.4",
+			Version: istioVersion,
 		},
 	}
 }

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -41,7 +41,7 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context) 
 		return false, nil, err
 	}
 
-	desired, err := desiredSubscription(name, r.config.GatewayAPIOperatorChannel, r.config.GatewayAPIOperatorVersion)
+	desired, err := desiredSubscription(name, r.config.GatewayAPIOperatorCatalog, r.config.GatewayAPIOperatorChannel, r.config.GatewayAPIOperatorVersion)
 	if err != nil {
 		return have, current, err
 	}
@@ -63,7 +63,7 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context) 
 }
 
 // desiredSubscription returns the desired subscription.
-func desiredSubscription(name types.NamespacedName, gwapiOperatorChannel, gwapiOperatorVersion string) (*operatorsv1alpha1.Subscription, error) {
+func desiredSubscription(name types.NamespacedName, gwapiOperatorCatalog, gwapiOperatorChannel, gwapiOperatorVersion string) (*operatorsv1alpha1.Subscription, error) {
 	subscription := operatorsv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: name.Namespace,
@@ -93,7 +93,7 @@ func desiredSubscription(name types.NamespacedName, gwapiOperatorChannel, gwapiO
 			},
 			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
 			Package:                "servicemeshoperator3",
-			CatalogSource:          "redhat-operators",
+			CatalogSource:          gwapiOperatorCatalog,
 			CatalogSourceNamespace: "openshift-marketplace",
 			StartingCSV:            gwapiOperatorVersion,
 		},

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -34,14 +34,14 @@ const (
 // ensureServiceMeshOperatorSubscription attempts to ensure that a subscription
 // for servicemeshoperator is present and returns a Boolean indicating whether
 // it exists, the subscription if it exists, and an error value.
-func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context) (bool, *operatorsv1alpha1.Subscription, error) {
+func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, catalog, channel, version string) (bool, *operatorsv1alpha1.Subscription, error) {
 	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
 	have, current, err := r.currentSubscription(ctx, name)
 	if err != nil {
 		return false, nil, err
 	}
 
-	desired, err := desiredSubscription(name, r.config.GatewayAPIOperatorCatalog, r.config.GatewayAPIOperatorChannel, r.config.GatewayAPIOperatorVersion)
+	desired, err := desiredSubscription(name, catalog, channel, version)
 	if err != nil {
 		return have, current, err
 	}
@@ -154,8 +154,8 @@ func subscriptionChanged(current, expected *operatorsv1alpha1.Subscription) (boo
 
 // ensureServiceMeshOperatorInstallPlan attempts to ensure that the install plan for the appropriate OSSM operator
 // version is approved.
-func (r *reconciler) ensureServiceMeshOperatorInstallPlan(ctx context.Context) (bool, *operatorsv1alpha1.InstallPlan, error) {
-	haveInstallPlan, current, err := r.currentInstallPlan(ctx)
+func (r *reconciler) ensureServiceMeshOperatorInstallPlan(ctx context.Context, version string) (bool, *operatorsv1alpha1.InstallPlan, error) {
+	haveInstallPlan, current, err := r.currentInstallPlan(ctx, version)
 	if err != nil {
 		return false, nil, err
 	}
@@ -169,7 +169,7 @@ func (r *reconciler) ensureServiceMeshOperatorInstallPlan(ctx context.Context) (
 		if updated, err := r.updateInstallPlan(ctx, current, desired); err != nil {
 			return true, current, err
 		} else if updated {
-			return r.currentInstallPlan(ctx)
+			return r.currentInstallPlan(ctx, version)
 		}
 	}
 	return false, current, nil
@@ -177,7 +177,7 @@ func (r *reconciler) ensureServiceMeshOperatorInstallPlan(ctx context.Context) (
 
 // currentInstallPlan returns the InstallPlan that describes installing the expected version of the GatewayAPI
 // implementation, if one exists.
-func (r *reconciler) currentInstallPlan(ctx context.Context) (bool, *operatorsv1alpha1.InstallPlan, error) {
+func (r *reconciler) currentInstallPlan(ctx context.Context, version string) (bool, *operatorsv1alpha1.InstallPlan, error) {
 	_, subscription, err := r.currentSubscription(ctx, operatorcontroller.ServiceMeshOperatorSubscriptionName())
 	if err != nil {
 		return false, nil, err
@@ -210,7 +210,7 @@ func (r *reconciler) currentInstallPlan(ctx context.Context) (bool, *operatorsv1
 			continue
 		}
 		for _, csvName := range installPlan.Spec.ClusterServiceVersionNames {
-			if csvName == r.config.GatewayAPIOperatorVersion {
+			if csvName == version {
 				// Keep the newest InstallPlan to return at the end of the loop.
 				if currentInstallPlan == nil {
 					currentInstallPlan = &installPlan

--- a/pkg/operator/controller/gatewayclass/subscription_test.go
+++ b/pkg/operator/controller/gatewayclass/subscription_test.go
@@ -626,7 +626,7 @@ func Test_ensureServiceMeshOperatorInstallPlan(t *testing.T) {
 					GatewayAPIOperatorVersion: tc.version,
 				},
 			}
-			_, _, err := reconciler.ensureServiceMeshOperatorInstallPlan(context.Background())
+			_, _, err := reconciler.ensureServiceMeshOperatorInstallPlan(context.Background(), tc.version)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -312,6 +312,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	gatewayClassController, err := gatewayclasscontroller.NewUnmanaged(mgr, gatewayclasscontroller.Config{
 		OperatorNamespace:         config.Namespace,
 		OperandNamespace:          operatorcontroller.DefaultOperandNamespace,
+		GatewayAPIOperatorCatalog: config.GatewayAPIOperatorCatalog,
 		GatewayAPIOperatorChannel: config.GatewayAPIOperatorChannel,
 		GatewayAPIOperatorVersion: config.GatewayAPIOperatorVersion,
 		IstioVersion:              config.IstioVersion,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -314,6 +314,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		OperandNamespace:          operatorcontroller.DefaultOperandNamespace,
 		GatewayAPIOperatorChannel: config.GatewayAPIOperatorChannel,
 		GatewayAPIOperatorVersion: config.GatewayAPIOperatorVersion,
+		IstioVersion:              config.IstioVersion,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gatewayclass controller: %w", err)


### PR DESCRIPTION
Define annotations for the gatewayclass by which the channel and version for the OSSM subscription can be overridden.

When creating the subscription, the operator now checks the following annotations:

    unsupported.do-not-use.openshift.io/ossm-channel
    unsupported.do-not-use.openshift.io/ossm-version

One or both annotations may be specified to override the channel or version from the config.