### PR TITLE
OCPBUGS-59894: Update GatewayAPI test to check if deployment has 1 or more pod

### DIFF
--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -555,8 +555,8 @@ func assertIstiodControlPlane(t *testing.T) error {
 	if err != nil {
 		return fmt.Errorf("error finding pod for deployment %v: %v", ns, err)
 	}
-	if len(podlist.Items) > 1 {
-		return fmt.Errorf("too many pods for deployment %v: %d", ns, len(podlist.Items))
+	if len(podlist.Items) < 1 {
+		return fmt.Errorf("Insufficient amount of pods in deployment %v: %d", ns, len(podlist.Items))
 	}
 	pod := podlist.Items[0]
 	if pod.Status.Phase != corev1.PodRunning {


### PR DESCRIPTION
There was a bug where the HPA was scaling the istiod deployment up to 2 pods which caused the `testGatewayAPIIstioInstallation` test to fail.

Updated the test code to now fail if atleast one pod is not associated with the istiod deployment