### PR TITLE
NE-2108: docs - correct Istio version format in ossm-overrides.md

### DIFF
--- a/hack/ossm-overrides.md
+++ b/hack/ossm-overrides.md
@@ -25,7 +25,7 @@ metadata:
     unsupported.do-not-use.openshift.io/ossm-catalog: redhat-operators
     unsupported.do-not-use.openshift.io/ossm-channel: stable
     unsupported.do-not-use.openshift.io/ossm-version: servicemeshoperator3.v3.1.0
-    unsupported.do-not-use.openshift.io/istio-version: 1.26-latest
+    unsupported.do-not-use.openshift.io/istio-version: v1.26-latest
 spec:
   controllerName: openshift.io/gateway-controller/v1
 EOF


### PR DESCRIPTION
[Istio versions use `v` prefix](https://github.com/openshift-service-mesh/sail-operator/blob/c2c0b245714353bfb720b7cfdfe9c5dd21f64fe4/bundle/manifests/sailoperator.io_istios.yaml#L9925); without it, the Istio CRD will complain about unsupported version:

```
failed to create istioi /openshift-gateway: Istio.sailoperator.io "openshift-gateway" is invalid:
[spec.version: Unsupported value: "1.26-latest": supported values: "v1.26-latest"]
```