### PR TITLE
NE-2096: Bump to OSSM 3.1.0 and Istio 1.26.2

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -35,8 +35,8 @@ const (
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	defaultGatewayAPIOperatorCatalog = "redhat-operators"
 	defaultGatewayAPIOperatorChannel = "stable"
-	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.0.1"
-	defaultIstioVersion              = "v1.24.4"
+	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.1.0"
+	defaultIstioVersion              = "v1.26.2"
 )
 
 type StartOptions struct {

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -59,9 +59,9 @@ spec:
         - name: GATEWAY_API_OPERATOR_CHANNEL
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION
-          value: servicemeshoperator3.v3.0.1
+          value: servicemeshoperator3.v3.1.0
         - name: ISTIO_VERSION
-          value: v1.24.4
+          value: v1.26.2
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -88,9 +88,9 @@ spec:
             - name: GATEWAY_API_OPERATOR_CHANNEL
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION
-              value: servicemeshoperator3.v3.0.1
+              value: servicemeshoperator3.v3.1.0
             - name: ISTIO_VERSION
-              value: v1.24.4
+              value: v1.26.2
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
Bump from OSSM v3.0.1 to v3.1.0 and from Istio v1.24.4 to v1.26.2.