### PR TITLE
NE-1476: Added network policies for the router

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -155,6 +155,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingressclasses
+  - networkpolicies
   verbs:
   - '*'
 

--- a/manifests/01-network-policy.yaml
+++ b/manifests/01-network-policy.yaml
@@ -1,0 +1,43 @@
+# We control the namespace, deny anything we do not explicitly allow
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-operator-deny-all
+  namespace: openshift-ingress-operator
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+### Allow the operator needs to talk to the apiserver and dns,
+### but it also needs to be able to configure external DNS and the endpoints
+### are only known at run time.  So it needs wildcard egress.
+### Allow access to the metrics ports on the operators
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-operator-allow
+  namespace: openshift-ingress-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector:
+    matchLabels:
+      name: ingress-operator
+  policyTypes:
+  - Egress
+  - Ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9393

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -37,6 +37,13 @@ rules:
   - services
   verbs:
   - "*"
+
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - "*"
 ---
 # Role for the operator to delete Role and RoleBindings
 # in the openshift-config namespace.

--- a/pkg/manifests/assets/canary/networkpolicy-allow.yaml
+++ b/pkg/manifests/assets/canary/networkpolicy-allow.yaml
@@ -1,0 +1,19 @@
+# Router Pods
+#  No egress
+#  Ingress to http on port 8888 and https on port 8443 (TCP)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+# name, namespace, labels and annotations are set at runtime
+spec:
+  podSelector:
+    # matchLabels are set at runtime
+    matchLabels: {}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8888
+    - protocol: TCP
+      port: 8443
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/manifests/assets/canary/networkpolicy-deny-all.yaml
+++ b/pkg/manifests/assets/canary/networkpolicy-deny-all.yaml
@@ -1,0 +1,11 @@
+# Default deny all policy for all pods in the namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openshift-ingress-canary-deny-all
+  namespace: openshift-ingress-canary
+spec:
+ podSelector: {}
+ policyTypes:
+ - Ingress
+ - Egress

--- a/pkg/manifests/assets/gateway-api/gateway-networkpolicy-allow.yaml
+++ b/pkg/manifests/assets/gateway-api/gateway-networkpolicy-allow.yaml
@@ -1,0 +1,23 @@
+# Istio Pods for Gateway API
+#  Egress to api server and everything (routes set endpoints, so can be literally anything)
+#  Ingress need to be wildcarded as well since the ports are configurable
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: gateway-api-allow
+  namespace: openshift-ingress
+spec:
+  podSelector:
+    matchLabels:
+      istio.io/rev: "openshift-gateway"
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/manifests/assets/router/networkpolicy-allow.yaml
+++ b/pkg/manifests/assets/router/networkpolicy-allow.yaml
@@ -1,0 +1,25 @@
+# Router Pods
+#  Egress to api server and everything (routes set endpoints, so can be literally anything)
+#  Ingress to http on port 80 and https on port 443 (TCP) and to metrics (1936)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+# name, namespace,labels and annotations are set at runtime
+spec:
+  podSelector:
+    # matchLabels are set at runtime
+    matchLabels: {}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 1936
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/manifests/assets/router/networkpolicy-deny-all.yaml
+++ b/pkg/manifests/assets/router/networkpolicy-deny-all.yaml
@@ -1,0 +1,11 @@
+# Default deny all policy for all pods in the namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: openshift-ingress-deny-all
+    namespace: openshift-ingress
+spec:
+ podSelector: {}
+ policyTypes:
+ - Ingress
+ - Egress

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -13,6 +13,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -24,31 +25,36 @@ import (
 )
 
 const (
-	RouterNamespaceAsset          = "assets/router/namespace.yaml"
-	RouterServiceAccountAsset     = "assets/router/service-account.yaml"
-	RouterClusterRoleAsset        = "assets/router/cluster-role.yaml"
-	RouterClusterRoleBindingAsset = "assets/router/cluster-role-binding.yaml"
-	RouterDeploymentAsset         = "assets/router/deployment.yaml"
-	RouterServiceInternalAsset    = "assets/router/service-internal.yaml"
-	RouterServiceCloudAsset       = "assets/router/service-cloud.yaml"
+	RouterNamespaceAsset            = "assets/router/namespace.yaml"
+	RouterServiceAccountAsset       = "assets/router/service-account.yaml"
+	RouterClusterRoleAsset          = "assets/router/cluster-role.yaml"
+	RouterClusterRoleBindingAsset   = "assets/router/cluster-role-binding.yaml"
+	RouterDeploymentAsset           = "assets/router/deployment.yaml"
+	RouterServiceInternalAsset      = "assets/router/service-internal.yaml"
+	RouterServiceCloudAsset         = "assets/router/service-cloud.yaml"
+	RouterNetworkPolicyDenyAllAsset = "assets/router/networkpolicy-deny-all.yaml"
+	RouterNetworkPolicyAllowAsset   = "assets/router/networkpolicy-allow.yaml"
 
 	MetricsClusterRoleAsset        = "assets/router/metrics/cluster-role.yaml"
 	MetricsClusterRoleBindingAsset = "assets/router/metrics/cluster-role-binding.yaml"
 	MetricsRoleAsset               = "assets/router/metrics/role.yaml"
 	MetricsRoleBindingAsset        = "assets/router/metrics/role-binding.yaml"
 
-	CanaryNamespaceAsset = "assets/canary/namespace.yaml"
-	CanaryDaemonSetAsset = "assets/canary/daemonset.yaml"
-	CanaryServiceAsset   = "assets/canary/service.yaml"
-	CanaryRouteAsset     = "assets/canary/route.yaml"
+	CanaryNamespaceAsset            = "assets/canary/namespace.yaml"
+	CanaryDaemonSetAsset            = "assets/canary/daemonset.yaml"
+	CanaryServiceAsset              = "assets/canary/service.yaml"
+	CanaryRouteAsset                = "assets/canary/route.yaml"
+	CanaryNetworkPolicyDenyAllAsset = "assets/canary/networkpolicy-deny-all.yaml"
+	CanaryNetworkPolicyAllowAsset   = "assets/canary/networkpolicy-allow.yaml"
 
-	GatewayClassCRDAsset            = "assets/gateway-api/gateway.networking.k8s.io_gatewayclasses.yaml"
-	GatewayCRDAsset                 = "assets/gateway-api/gateway.networking.k8s.io_gateways.yaml"
-	GRPCRouteCRDAsset               = "assets/gateway-api/gateway.networking.k8s.io_grpcroutes.yaml"
-	HTTPRouteCRDAsset               = "assets/gateway-api/gateway.networking.k8s.io_httproutes.yaml"
-	ReferenceGrantCRDAsset          = "assets/gateway-api/gateway.networking.k8s.io_referencegrants.yaml"
-	GatewayAPIAdminClusterRoleAsset = "assets/gateway-api/aggregated-cluster-roles/admin-cluster-role.yaml"
-	GatewayAPIViewClusterRoleAsset  = "assets/gateway-api/aggregated-cluster-roles/view-cluster-role.yaml"
+	GatewayClassCRDAsset              = "assets/gateway-api/gateway.networking.k8s.io_gatewayclasses.yaml"
+	GatewayCRDAsset                   = "assets/gateway-api/gateway.networking.k8s.io_gateways.yaml"
+	GRPCRouteCRDAsset                 = "assets/gateway-api/gateway.networking.k8s.io_grpcroutes.yaml"
+	HTTPRouteCRDAsset                 = "assets/gateway-api/gateway.networking.k8s.io_httproutes.yaml"
+	ReferenceGrantCRDAsset            = "assets/gateway-api/gateway.networking.k8s.io_referencegrants.yaml"
+	GatewayAPIAdminClusterRoleAsset   = "assets/gateway-api/aggregated-cluster-roles/admin-cluster-role.yaml"
+	GatewayAPIViewClusterRoleAsset    = "assets/gateway-api/aggregated-cluster-roles/view-cluster-role.yaml"
+	GatewayAPIAllowNetworkPolicyAsset = "assets/gateway-api/gateway-networkpolicy-allow.yaml"
 
 	// Annotation used to inform the certificate generation service to
 	// generate a cluster-signed certificate and populate the secret.
@@ -258,6 +264,22 @@ func CanaryRoute() *routev1.Route {
 	return route
 }
 
+func CanaryNetworkPolicyDenyAll() *networkingv1.NetworkPolicy {
+	networkPolicy, err := NewNetworkPolicy(MustAssetReader(CanaryNetworkPolicyDenyAllAsset))
+	if err != nil {
+		panic(err)
+	}
+	return networkPolicy
+}
+
+func CanaryNetworkPolicyAllow() *networkingv1.NetworkPolicy {
+	networkPolicy, err := NewNetworkPolicy(MustAssetReader(CanaryNetworkPolicyAllowAsset))
+	if err != nil {
+		panic(err)
+	}
+	return networkPolicy
+}
+
 func GatewayClassCRD() *apiextensionsv1.CustomResourceDefinition {
 	crd, err := NewCustomResourceDefinition(MustAssetReader(GatewayClassCRDAsset))
 	if err != nil {
@@ -312,6 +334,30 @@ func GatewayAPIViewClusterRole() *rbacv1.ClusterRole {
 		panic(err)
 	}
 	return clusterRole
+}
+
+func GatewayAPIAllowNetworkPolicy() *networkingv1.NetworkPolicy {
+	networkPolicy, err := NewNetworkPolicy(MustAssetReader(GatewayAPIAllowNetworkPolicyAsset))
+	if err != nil {
+		panic(err)
+	}
+	return networkPolicy
+}
+
+func RouterNetworkPolicyDenyAll() *networkingv1.NetworkPolicy {
+	networkPolicy, err := NewNetworkPolicy(MustAssetReader(RouterNetworkPolicyDenyAllAsset))
+	if err != nil {
+		panic(err)
+	}
+	return networkPolicy
+}
+
+func RouterNetworkPolicyAllow() *networkingv1.NetworkPolicy {
+	networkPolicy, err := NewNetworkPolicy(MustAssetReader(RouterNetworkPolicyAllowAsset))
+	if err != nil {
+		panic(err)
+	}
+	return networkPolicy
 }
 
 func NewServiceAccount(manifest io.Reader) (*corev1.ServiceAccount, error) {
@@ -397,6 +443,15 @@ func NewDaemonSet(manifest io.Reader) (*appsv1.DaemonSet, error) {
 
 func NewRoute(manifest io.Reader) (*routev1.Route, error) {
 	o := routev1.Route{}
+	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&o); err != nil {
+		return nil, err
+	}
+
+	return &o, nil
+}
+
+func NewNetworkPolicy(manifest io.Reader) (*networkingv1.NetworkPolicy, error) {
+	o := networkingv1.NetworkPolicy{}
 	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&o); err != nil {
 		return nil, err
 	}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -35,7 +35,8 @@ func TestManifests(t *testing.T) {
 	RouterClusterRole()
 	RouterClusterRoleBinding()
 	RouterStatsSecret(ci)
-
+	RouterNetworkPolicyDenyAll()
+	RouterNetworkPolicyAllow()
 	MetricsClusterRole()
 	MetricsClusterRoleBinding()
 	MetricsRole()
@@ -51,6 +52,14 @@ func TestManifests(t *testing.T) {
 	GRPCRouteCRD()
 	HTTPRouteCRD()
 	ReferenceGrantCRD()
+	GatewayAPIAllowNetworkPolicy()
+
+	CanaryNamespace()
+	CanaryDaemonSet()
+	CanaryService()
+	CanaryRoute()
+	CanaryNetworkPolicyDenyAll()
+	CanaryNetworkPolicyAllow()
 
 	adminOnlyVerbs := []string{"create", "update", "patch", "delete", "deletecollection"}
 	GatewayAPIAdminClusterRole()

--- a/pkg/operator/controller/canary/networkpolicy.go
+++ b/pkg/operator/controller/canary/networkpolicy.go
@@ -1,0 +1,118 @@
+package canary
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	controller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ensureCanaryNetworkPolicy ensures the canary NetworkPolicy that allows ingress to
+// the canary pods exists and is up to date.
+func (r *reconciler) ensureCanaryNetworkPolicy() (bool, *networkingv1.NetworkPolicy, error) {
+	desired := desiredCanaryNetworkPolicy()
+
+	have, current, err := r.currentCanaryNetworkPolicy()
+	if err != nil {
+		return false, nil, err
+	}
+
+	switch {
+	case !have:
+		if err := r.client.Create(context.TODO(), desired); err != nil {
+			return false, nil, fmt.Errorf("failed to create canary network policy: %v", err)
+		}
+		log.Info("created canary network policy", "networkpolicy", desired)
+		return r.currentCanaryNetworkPolicy()
+	default:
+		if updated, err := r.updateCanaryNetworkPolicy(current, desired); err != nil {
+			return true, current, fmt.Errorf("failed to update canary network policy: %v", err)
+		} else if updated {
+			return r.currentCanaryNetworkPolicy()
+		}
+	}
+
+	return true, current, nil
+}
+
+// desiredCanaryNetworkPolicy returns the desired canary NetworkPolicy.
+func desiredCanaryNetworkPolicy() *networkingv1.NetworkPolicy {
+	np := manifests.CanaryNetworkPolicyAllow()
+
+	name := controller.CanaryNetworkPolicyName()
+	np.Namespace = name.Namespace
+	np.Name = name.Name
+
+	if np.Labels == nil {
+		np.Labels = map[string]string{}
+	}
+	np.Labels[manifests.OwningIngressCanaryCheckLabel] = canaryControllerName
+
+	// Select canary pods managed by the canary daemonset.
+	np.Spec.PodSelector = *controller.CanaryDaemonSetPodSelector(canaryControllerName)
+
+	return np
+}
+
+// currentCanaryNetworkPolicy returns the current canary NetworkPolicy, if it exists.
+func (r *reconciler) currentCanaryNetworkPolicy() (bool, *networkingv1.NetworkPolicy, error) {
+	current := &networkingv1.NetworkPolicy{}
+	if err := r.client.Get(context.TODO(), controller.CanaryNetworkPolicyName(), current); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, current, nil
+}
+
+// updateCanaryNetworkPolicy updates the canary NetworkPolicy if it differs from the desired state.
+func (r *reconciler) updateCanaryNetworkPolicy(current, desired *networkingv1.NetworkPolicy) (bool, error) {
+	changed, updated := canaryNetworkPolicyChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		return false, err
+	}
+	log.Info("updated canary network policy", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+	return true, nil
+}
+
+// canaryNetworkPolicyChanged checks whether the current NetworkPolicy matches the expected
+// state and, if not, returns an updated NetworkPolicy.
+func canaryNetworkPolicyChanged(current, expected *networkingv1.NetworkPolicy) (bool, *networkingv1.NetworkPolicy) {
+	changed := false
+
+	if !cmp.Equal(current.Spec, expected.Spec, cmpopts.EquateEmpty()) {
+		changed = true
+	}
+
+	if current.Labels == nil || current.Labels[manifests.OwningIngressCanaryCheckLabel] != expected.Labels[manifests.OwningIngressCanaryCheckLabel] {
+		changed = true
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	updated := current.DeepCopy()
+	updated.Spec = expected.Spec
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[manifests.OwningIngressCanaryCheckLabel] = expected.Labels[manifests.OwningIngressCanaryCheckLabel]
+
+	return true, updated
+}

--- a/pkg/operator/controller/canary/networkpolicy_test.go
+++ b/pkg/operator/controller/canary/networkpolicy_test.go
@@ -1,0 +1,80 @@
+package canary
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test_desiredCanaryNetworkPolicy verifies the desired NetworkPolicy for canary pods.
+func Test_desiredCanaryNetworkPolicy(t *testing.T) {
+	np := desiredCanaryNetworkPolicy()
+
+	if np.Name != "ingress-canary" || np.Namespace != "openshift-ingress-canary" {
+		t.Fatalf("unexpected name/namespace: %s/%s", np.Namespace, np.Name)
+	}
+	if np.Labels["ingress.openshift.io/canary"] != canaryControllerName {
+		t.Fatalf("missing or wrong owner label: %#v", np.Labels)
+	}
+	// Ensure pod selector is set via helper.
+	if np.Spec.PodSelector.MatchLabels == nil {
+		t.Fatalf("pod selector should be set")
+	}
+	// Ensure ingress rules include ports 8888 and 8443.
+	want := map[int32]struct{}{8888: {}, 8443: {}}
+	got := map[int32]struct{}{}
+	for _, r := range np.Spec.Ingress {
+		for _, p := range r.Ports {
+			if p.Protocol != nil && *p.Protocol == corev1.ProtocolTCP && p.Port != nil && p.Port.IntVal != 0 {
+				got[p.Port.IntVal] = struct{}{}
+			}
+		}
+	}
+	for port := range want {
+		if _, ok := got[port]; !ok {
+			t.Fatalf("expected ingress port %d to be present", port)
+		}
+	}
+}
+
+// Test_canaryNetworkPolicyChanged verifies change detection and update behavior.
+func Test_canaryNetworkPolicyChanged(t *testing.T) {
+	original := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-ingress-canary",
+			Name:      "ingress-canary",
+			Labels: map[string]string{
+				"ingress.openshift.io/canary": canaryControllerName,
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"ingresscanary.operator.openshift.io/daemonset-ingresscanary": canaryControllerName}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+		},
+	}
+
+	// No change.
+	if changed, _ := canaryNetworkPolicyChanged(original, original.DeepCopy()); changed {
+		t.Fatalf("expected no change detected")
+	}
+
+	// Change in spec should be detected.
+	mutated := original.DeepCopy()
+	mutated.Spec.Ingress = append(mutated.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{})
+	if changed, _ := canaryNetworkPolicyChanged(original, mutated); !changed {
+		t.Fatalf("expected change detected for spec diff")
+	}
+
+	// Change in owner label should be detected but preserve other labels.
+	mutated = original.DeepCopy()
+	mutated.Labels["ingress.openshift.io/canary"] = "other"
+	if changed, updated := canaryNetworkPolicyChanged(original, mutated); !changed {
+		t.Fatalf("expected change detected for label diff")
+	} else if updated.Labels["ingress.openshift.io/canary"] != "other" {
+		t.Fatalf("expected owner label updated")
+	}
+}

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,6 +105,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate:    []client.Object{},
 			expectDelete:    []client.Object{},
@@ -125,6 +128,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate:    []client.Object{},
 			expectDelete:    []client.Object{},
@@ -147,6 +151,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate:    []client.Object{},
 			expectDelete:    []client.Object{},
@@ -174,6 +179,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -202,6 +208,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -232,6 +239,7 @@ func Test_Reconcile(t *testing.T) {
 				crd("referencegrants.gateway.networking.k8s.io"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+				manifests.GatewayAPIAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -245,6 +253,7 @@ func Test_Reconcile(t *testing.T) {
 	configv1.Install(scheme)
 	apiextensionsv1.AddToScheme(scheme)
 	rbacv1.AddToScheme(scheme)
+	networkingv1.AddToScheme(scheme)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -329,6 +338,7 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 	configv1.Install(scheme)
 	apiextensionsv1.AddToScheme(scheme)
 	rbacv1.AddToScheme(scheme)
+	networkingv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithRuntimeObjects(

--- a/pkg/operator/controller/gatewayapi/networkpolicy.go
+++ b/pkg/operator/controller/gatewayapi/networkpolicy.go
@@ -1,0 +1,102 @@
+package gatewayapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureGatewayAPINetworkPolicy ensures the allow NetworkPolicy for Gateway API namespace is present and correct.
+func (r *reconciler) ensureGatewayAPINetworkPolicy(ctx context.Context) (bool, *networkingv1.NetworkPolicy, error) {
+	desired := desiredGatewayAPINetworkPolicy()
+
+	have, current, err := r.currentGatewayAPINetworkPolicy(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+
+	switch {
+	case !have:
+		if err := r.client.Create(ctx, desired); err != nil {
+			return false, nil, fmt.Errorf("failed to create gateway-api network policy: %v", err)
+		}
+		log.Info("created gateway-api network policy", "networkpolicy", desired)
+		return r.currentGatewayAPINetworkPolicy(ctx)
+	default:
+		if updated, err := r.updateGatewayAPINetworkPolicy(ctx, current, desired); err != nil {
+			return true, current, fmt.Errorf("failed to update gateway-api network policy: %v", err)
+		} else if updated {
+			return r.currentGatewayAPINetworkPolicy(ctx)
+		}
+	}
+
+	return true, current, nil
+}
+
+func desiredGatewayAPINetworkPolicy() *networkingv1.NetworkPolicy {
+	np := manifests.GatewayAPIAllowNetworkPolicy()
+
+	// Set name/namespace, labels for the Gateway API controller assets.
+	// The manifest may already contain namespace/name; ensure it's correct.
+	// We use the same namespace as the openshift-ingress (operand) namespace, per asset design.
+	// Label for selection by owning controller if needed in the future.
+	if np.Labels == nil {
+		np.Labels = map[string]string{}
+	}
+	np.Labels[operatorcontroller.ControllerDeploymentLabel] = operatorcontroller.OpenShiftDefaultGatewayClassName
+
+	return np
+}
+
+func (r *reconciler) currentGatewayAPINetworkPolicy(ctx context.Context) (bool, *networkingv1.NetworkPolicy, error) {
+	current := &networkingv1.NetworkPolicy{}
+	// The asset already defines the name/namespace. Use it for lookup.
+	desired := manifests.GatewayAPIAllowNetworkPolicy()
+	key := types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}
+	if err := r.client.Get(ctx, key, current); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, current, nil
+}
+
+func (r *reconciler) updateGatewayAPINetworkPolicy(ctx context.Context, current, desired *networkingv1.NetworkPolicy) (bool, error) {
+	changed, updated := gatewayAPINetworkPolicyChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, err
+	}
+	log.Info("updated gateway-api network policy", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+	return true, nil
+}
+
+func gatewayAPINetworkPolicyChanged(current, expected *networkingv1.NetworkPolicy) (bool, *networkingv1.NetworkPolicy) {
+	if cmp.Equal(current.Spec, expected.Spec, cmpopts.EquateEmpty()) && cmp.Equal(current.Labels, expected.Labels, cmpopts.EquateEmpty()) {
+		return false, nil
+	}
+	updated := current.DeepCopy()
+	updated.Spec = expected.Spec
+	// Merge/overwrite labels from expected; preserve any unrelated labels.
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	for k, v := range expected.Labels {
+		updated.Labels[k] = v
+	}
+	return true, updated
+}

--- a/pkg/operator/controller/gatewayapi/networkpolicy_test.go
+++ b/pkg/operator/controller/gatewayapi/networkpolicy_test.go
@@ -1,0 +1,92 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test_desiredGatewayAPINetworkPolicy verifies ports and labels on the desired policy.
+func Test_desiredGatewayAPINetworkPolicy(t *testing.T) {
+	np := desiredGatewayAPINetworkPolicy()
+
+	// Pod selector must target the Istio gateway pods.
+	if np.Spec.PodSelector.MatchLabels == nil || np.Spec.PodSelector.MatchLabels["istio.io/rev"] != "openshift-gateway" {
+		t.Fatalf("pod selector should match istio.io/rev=openshift-gateway, got: %#v", np.Spec.PodSelector.MatchLabels)
+	}
+
+	// Ingress should allow from 0.0.0.0/0
+	hasIngressIPBlock := false
+	for _, r := range np.Spec.Ingress {
+		for _, f := range r.From {
+			if f.IPBlock != nil && f.IPBlock.CIDR == "0.0.0.0/0" {
+				hasIngressIPBlock = true
+			}
+		}
+	}
+	if !hasIngressIPBlock {
+		t.Fatalf("expected ingress from 0.0.0.0/0")
+	}
+
+	// Egress should allow to 0.0.0.0/0
+	hasEgressIPBlock := false
+	for _, r := range np.Spec.Egress {
+		for _, to := range r.To {
+			if to.IPBlock != nil && to.IPBlock.CIDR == "0.0.0.0/0" {
+				hasEgressIPBlock = true
+			}
+		}
+	}
+	if !hasEgressIPBlock {
+		t.Fatalf("expected egress to 0.0.0.0/0")
+	}
+
+	// PolicyTypes should include Ingress and Egress
+	hasIngress, hasEgress := false, false
+	for _, pt := range np.Spec.PolicyTypes {
+		if pt == networkingv1.PolicyTypeIngress {
+			hasIngress = true
+		}
+		if pt == networkingv1.PolicyTypeEgress {
+			hasEgress = true
+		}
+	}
+	if !(hasIngress && hasEgress) {
+		t.Fatalf("expected policyTypes to include Ingress and Egress, got: %#v", np.Spec.PolicyTypes)
+	}
+}
+
+func Test_gatewayAPINetworkPolicyChanged(t *testing.T) {
+	// Minimal synthetic current/expected with different rules
+	current := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-ingress",
+			Name:      "gateway-api-allow",
+			Labels:    map[string]string{"a": "1"},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+	expected := current.DeepCopy()
+	expected.Spec.Ingress = append(expected.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{})
+	expected.Labels = map[string]string{"a": "2"}
+
+	if changed, updated := gatewayAPINetworkPolicyChanged(current, expected); !changed {
+		t.Fatalf("expected change detected")
+	} else {
+		if len(updated.Spec.Ingress) != len(expected.Spec.Ingress) {
+			t.Fatalf("expected spec to be updated")
+		}
+		if updated.Labels["a"] != "2" {
+			t.Fatalf("expected labels to be merged/updated")
+		}
+		if changedAgain, _ := gatewayAPINetworkPolicyChanged(updated, expected); changedAgain {
+			t.Fatalf("function should be idempotent once updated")
+		}
+	}
+}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	"k8s.io/client-go/tools/record"
 
@@ -112,6 +113,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		return nil, err
 	}
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &corev1.Service{}, enqueueRequestForOwningIngressController(config.Namespace))); err != nil {
+		return nil, err
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &networkingv1.NetworkPolicy{}, enqueueRequestForOwningIngressController(config.Namespace))); err != nil {
 		return nil, err
 	}
 	// Add watch for deleted pods specifically for ensuring ingress deletion.
@@ -1078,12 +1082,20 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		return fmt.Errorf("failed to ensure namespace: %v", err)
 	}
 
+	if _, _, err := r.ensureRouterNamespaceNetworkPolicy(ci); err != nil {
+		return fmt.Errorf("failed to ensure default namespacenetwork policy: %v", err)
+	}
+
 	if err := r.ensureRouterServiceAccount(); err != nil {
 		return fmt.Errorf("failed to ensure service account: %v", err)
 	}
 
 	if err := r.ensureRouterClusterRoleBinding(); err != nil {
 		return fmt.Errorf("failed to ensure cluster role binding: %v", err)
+	}
+
+	if err := r.ensureRouterNetworkPolicy(ci); err != nil {
+		return fmt.Errorf("failed to ensure network policy: %v", err)
 	}
 
 	var errs []error

--- a/pkg/operator/controller/ingress/networkpolicy.go
+++ b/pkg/operator/controller/ingress/networkpolicy.go
@@ -1,0 +1,121 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	controller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ensureRouterNetworkPolicy ensures the per-ingresscontroller NetworkPolicy that
+// allows ingress to router pods and egress to the network exists and is up to date.
+func (r *reconciler) ensureRouterNetworkPolicy(ic *operatorv1.IngressController) error {
+	desired := desiredRouterNetworkPolicy(ic)
+
+	have, current, err := r.currentRouterNetworkPolicy(ic)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case !have:
+		if err := r.client.Create(context.TODO(), desired); err != nil {
+			return fmt.Errorf("failed to create router network policy: %v", err)
+		}
+		log.Info("created router network policy", "networkpolicy", desired)
+		return nil
+	default:
+		if updated, err := r.updateRouterNetworkPolicy(current, desired); err != nil {
+			return fmt.Errorf("failed to update router network policy: %v", err)
+		} else if updated {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// desiredRouterNetworkPolicy returns the desired per-ingresscontroller NetworkPolicy.
+func desiredRouterNetworkPolicy(ic *operatorv1.IngressController) *networkingv1.NetworkPolicy {
+	np := manifests.RouterNetworkPolicyAllow()
+
+	name := controller.RouterNetworkPolicyName(ic)
+	np.Namespace = name.Namespace
+	np.Name = name.Name
+
+	if np.Labels == nil {
+		np.Labels = map[string]string{}
+	}
+	np.Labels[manifests.OwningIngressControllerLabel] = ic.Name
+
+	// Select router pods for this ingresscontroller.
+	np.Spec.PodSelector = *controller.IngressControllerDeploymentPodSelector(ic)
+
+	return np
+}
+
+// currentRouterNetworkPolicy returns the current per-ingresscontroller NetworkPolicy, if it exists.
+func (r *reconciler) currentRouterNetworkPolicy(ic *operatorv1.IngressController) (bool, *networkingv1.NetworkPolicy, error) {
+	current := &networkingv1.NetworkPolicy{}
+	if err := r.client.Get(context.TODO(), controller.RouterNetworkPolicyName(ic), current); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, current, nil
+}
+
+// updateRouterNetworkPolicy updates the NetworkPolicy if it differs from the desired state.
+func (r *reconciler) updateRouterNetworkPolicy(current, desired *networkingv1.NetworkPolicy) (bool, error) {
+	changed, updated := routerNetworkPolicyChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		return false, err
+	}
+	log.Info("updated router network policy", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+	return true, nil
+}
+
+// routerNetworkPolicyChanged checks whether the current NetworkPolicy matches the expected
+// state and, if not, returns an updated NetworkPolicy.
+func routerNetworkPolicyChanged(current, expected *networkingv1.NetworkPolicy) (bool, *networkingv1.NetworkPolicy) {
+	changed := false
+
+	if !cmp.Equal(current.Spec, expected.Spec, cmpopts.EquateEmpty()) {
+		changed = true
+	}
+
+	// Ensure the owning-ingresscontroller label value is as expected while preserving other labels.
+	if current.Labels == nil || current.Labels[manifests.OwningIngressControllerLabel] != expected.Labels[manifests.OwningIngressControllerLabel] {
+		changed = true
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	updated := current.DeepCopy()
+	updated.Spec = expected.Spec
+
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[manifests.OwningIngressControllerLabel] = expected.Labels[manifests.OwningIngressControllerLabel]
+
+	return true, updated
+}

--- a/pkg/operator/controller/ingress/networkpolicy_test.go
+++ b/pkg/operator/controller/ingress/networkpolicy_test.go
@@ -1,0 +1,84 @@
+package ingress
+
+import (
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test_desiredRouterNetworkPolicy verifies the desired NetworkPolicy for a router.
+func Test_desiredRouterNetworkPolicy(t *testing.T) {
+	ic := &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+	np := desiredRouterNetworkPolicy(ic)
+
+	if np.Name != "router-default" || np.Namespace != "openshift-ingress" {
+		t.Fatalf("unexpected name/namespace: %s/%s", np.Namespace, np.Name)
+	}
+	if np.Labels["ingresscontroller.operator.openshift.io/owning-ingresscontroller"] != "default" {
+		t.Fatalf("missing or wrong owner label: %#v", np.Labels)
+	}
+	// Ensure pod selector is set via helper.
+	if np.Spec.PodSelector.MatchLabels == nil {
+		t.Fatalf("pod selector should be set")
+	}
+	// Ensure ingress rules include ports 80, 443, 1936.
+	want := map[int32]struct{}{80: {}, 443: {}, 1936: {}}
+	got := map[int32]struct{}{}
+	for _, r := range np.Spec.Ingress {
+		for _, p := range r.Ports {
+			if p.Protocol != nil && *p.Protocol == corev1.ProtocolTCP && p.Port != nil && p.Port.IntVal != 0 {
+				got[p.Port.IntVal] = struct{}{}
+			}
+		}
+	}
+	for port := range want {
+		if _, ok := got[port]; !ok {
+			t.Fatalf("expected ingress port %d to be present", port)
+		}
+	}
+}
+
+// Test_routerNetworkPolicyChanged verifies change detection and update behavior.
+func Test_routerNetworkPolicyChanged(t *testing.T) {
+	original := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-ingress",
+			Name:      "router-default",
+			Labels: map[string]string{
+				"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default",
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+		},
+	}
+
+	// No change.
+	if changed, _ := routerNetworkPolicyChanged(original, original.DeepCopy()); changed {
+		t.Fatalf("expected no change detected")
+	}
+
+	// Change in spec should be detected.
+	mutated := original.DeepCopy()
+	mutated.Spec.Ingress = append(mutated.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{})
+	if changed, _ := routerNetworkPolicyChanged(original, mutated); !changed {
+		t.Fatalf("expected change detected for spec diff")
+	}
+
+	// Change in owner label should be detected but preserve other labels.
+	mutated = original.DeepCopy()
+	mutated.Labels["ingresscontroller.operator.openshift.io/owning-ingresscontroller"] = "other"
+	if changed, updated := routerNetworkPolicyChanged(original, mutated); !changed {
+		t.Fatalf("expected change detected for label diff")
+	} else if updated.Labels["ingresscontroller.operator.openshift.io/owning-ingresscontroller"] != "other" {
+		t.Fatalf("expected owner label updated")
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -118,6 +118,14 @@ func RouterDeploymentName(ci *operatorv1.IngressController) types.NamespacedName
 	}
 }
 
+// RouterNetworkPolicyName returns the namespaced name for the router network policy.
+func RouterNetworkPolicyName(ci *operatorv1.IngressController) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: DefaultOperandNamespace,
+		Name:      "router-" + ci.Name,
+	}
+}
+
 // RouterCASecretName returns the namespaced name for the router CA secret.
 // This secret holds the CA certificate that the operator will use to create
 // default certificates for ingresscontrollers.
@@ -287,6 +295,13 @@ func CanaryRouteName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: DefaultCanaryNamespace,
 		Name:      "canary",
+	}
+}
+
+func CanaryNetworkPolicyName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: DefaultCanaryNamespace,
+		Name:      "ingress-canary",
 	}
 }
 


### PR DESCRIPTION
Added the framework for network policies for the router.

The operator has a deny all network policy that for the openshift-ingress-operator namespace and an allow policy for egress to the apiserver and dns ports at any IP.

The operator installs a deny all network policy for the openshift-ingress namespace.

Then for each ingresscontroller that it manages it installs an allow policy for ingress for http and https traffic and metrics.

It has to allow ingress from the router pods to any IP because the route endpoints can be at any ip or pod.

It also needs access to the api server, but that is covered by the wildcard allow policy.

https://issues.redhat.com/browse/NE-1476