### PR TITLE
OCPBUGS-60302:  e2e - Reduce flakiness in testGatewayAPIResourcesProtection

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -381,7 +381,7 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Verify that GatewayAPI CRD creation is forbidden.
 			for i := range testCRDs {
-				if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+				if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 					if err := tc.kclient.Create(ctx, testCRDs[i]); err != nil {
 						if kerrors.IsAlreadyExists(err) {
 							// VAP was disabled and re-enabled at the beginning of the test.

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -391,6 +391,12 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 							t.Logf("Failed to create CRD %q: %v; retrying...", testCRDs[i].Name, err)
 							return false, nil
 						}
+						if isNetworkError(err) {
+							// Retry if the creation of CRD failed due to networking
+							// problems with the api server.
+							t.Logf("Failed to create CRD %q due to network error: %v, retrying", testCRDs[i].Name, err)
+							return false, nil
+						}
 						if !strings.Contains(err.Error(), tc.expectedErrMsg) {
 							return false, fmt.Errorf("unexpected error received while creating CRD %q: %v", testCRDs[i].Name, err)
 						}

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -1061,7 +1061,9 @@ func assertDNSRecord(t *testing.T, recordName types.NamespacedName) error {
 func assertVAP(t *testing.T, name string) error {
 	t.Helper()
 	vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
+	// Re-creation of VAP can take some time especially after CVO is scaled back up.
+	// Use a large timeout of 5 minutes to avoid flakes.
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
 		if err := kclient.Get(context, types.NamespacedName{Name: name}, vap); err != nil {
 			t.Logf("failed to get vap %q: %v, retrying...", name, err)
 			return false, nil
@@ -1076,7 +1078,7 @@ func scaleDeployment(t *testing.T, namespace, name string, replicas int32) error
 	t.Helper()
 
 	nsName := types.NamespacedName{Namespace: namespace, Name: name}
-	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 120*time.Second, false, func(context context.Context) (bool, error) {
 		depl := &appsv1.Deployment{}
 		if err := kclient.Get(context, nsName, depl); err != nil {
 			t.Logf("failed to get deployment %q: %v, retrying...", nsName, err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	goerrors "errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1210,4 +1211,17 @@ func getIngressControllerLBAddress(t *testing.T, ic *operatorv1.IngressControlle
 		t.Fatalf("error getting IngressController's service address: %v", err)
 	}
 	return lbAddress
+}
+
+func isNetworkError(err error) bool {
+	var (
+		netErr net.Error
+		opErr  *net.OpError
+		msg    = err.Error()
+	)
+	return goerrors.As(err, &netErr) ||
+		goerrors.As(err, &opErr) ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "read tcp")
 }


### PR DESCRIPTION
This PR reduces flakiness in the `TestGatewayAPI/testGatewayAPIResourcesProtection` e2e test by:
- Increasing timeouts for CVO scale up/down operations and VAP assertions.
- Retrying Gateway CRD VAP creation when network errors occur.

These changes help mitigate failures caused by temporary API server network issues and slow CVO reconciliation.
