### PR TITLE
OCPBUGS-53432: deflake TestIngressControllerCustomEndpoints by proper waiting for CCM to be ready

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -125,6 +125,7 @@ var (
 	operandNamespace  = operatorcontroller.DefaultOperandNamespace
 	defaultName       = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.DefaultIngressControllerName}
 	clusterConfigName = types.NamespacedName{Namespace: operatorNamespace, Name: manifests.ClusterIngressConfigName}
+	ccmDeploymentName = types.NamespacedName{Namespace: "openshift-cloud-controller-manager", Name: "aws-cloud-controller-manager"}
 
 	// Platforms that need a DNS "warmup" period for internal (inside the test cluster) DNS resolution.
 	// The warmup period is a period of delay before the first query is executed to avoid negative caching.
@@ -142,6 +143,13 @@ const (
 	// cluster (which may be on different platforms) and any negative caching along the way. As of writing this, AWS
 	// typically resolves within ~1 minute (see OCPBUGS-14966), while IBMCloud takes ~7 minutes (see OCPBUGS-48780).
 	dnsResolutionTimeout = 10 * time.Minute
+
+	// ccmConfigAnnotation is an annotation that exists on CloudControllerManager
+	// and contains a hash of the current infrastructure configuration.
+	// It is used to signal to CCM deployment a configuration change that needs
+	// a rollout update, and can be used by tests to also detect changes on CCM
+	// deployment
+	ccmConfigAnnotation = "operator.openshift.io/config-hash"
 )
 
 func init() {
@@ -2596,110 +2604,84 @@ func TestContainerLoggingMinLength(t *testing.T) {
 }
 
 func TestIngressControllerCustomEndpoints(t *testing.T) {
+	if infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		t.Skipf("skipping TestIngressControllerCustomEndpoints test due to controlplanetopology: %v", infraConfig.Status.ControlPlaneTopology)
+	}
 	platform := infraConfig.Status.PlatformStatus
 	if platform == nil {
 		t.Fatalf("platform status is missing for infrastructure %s", infraConfig.Name)
 	}
-	switch platform.Type {
-	case configv1.AWSPlatformType:
-		switch {
-		case platform.AWS == nil:
-			t.Fatalf("aws platform status is missing for infrastructure %s", infraConfig.Name)
-		case len(platform.AWS.ServiceEndpoints) != 0:
-			t.Skipf("custom endpoints detected for infrastructure %s, skipping TestIngressControllerCustomEndpoints",
-				infraConfig.Name)
-		case len(platform.AWS.Region) == 0:
-			t.Fatalf("region is missing from aws platform status for infrastructure %s", infraConfig.Name)
-		case platform.AWS.Region == endpoints.CnNorth1RegionID || platform.AWS.Region == endpoints.CnNorthwest1RegionID:
-			t.Skipf("region %s or %s detected for infrastructure %s, skipping TestIngressControllerCustomEndpoints",
-				endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID, infraConfig.Name)
-		}
-		route53Endpoint := configv1.AWSServiceEndpoint{
-			Name: "route53",
-			// AWS Route 53 is a non-regionalized service, so the endpoint URL
-			// does not include a region.
-			URL: "https://route53.amazonaws.com",
-		}
-		taggingEndpoint := configv1.AWSServiceEndpoint{
-			Name: "tagging",
-			// us-east-1 region is required to get hosted zone resources
-			// since route 53 is a non-regionalized service.
-			URL: "https://tagging.us-east-1.amazonaws.com",
-		}
-		elbEndpoint := configv1.AWSServiceEndpoint{
-			Name: "elasticloadbalancing",
-			URL:  fmt.Sprintf("https://elasticloadbalancing.%s.amazonaws.com", platform.AWS.Region),
-		}
 
-		ccmDeploymentName := types.NamespacedName{Namespace: "openshift-cloud-controller-manager", Name: "aws-cloud-controller-manager"}
-		oldCCMDeployment, err := retrieveDeployment(ccmDeploymentName)
-		if err != nil {
-			t.Fatalf("error getting CCM deployment: %v\n", err)
-		}
-		oldConfigHash := retrieveCCMConfigurationHash(oldCCMDeployment)
-		if oldConfigHash == "" {
-			t.Fatalf("CCM does not have a config hash, this should never happen: %v\n", oldCCMDeployment)
-		}
-
-		if err := updateInfrastructureConfigSpecWithRetryOnConflict(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
-			spec.PlatformSpec.AWS = &configv1.AWSPlatformSpec{
-				ServiceEndpoints: []configv1.AWSServiceEndpoint{
-					route53Endpoint,
-					taggingEndpoint,
-					elbEndpoint,
-				},
-			}
-		}); err != nil {
-			t.Fatalf("failed to update infrastructure config: %v\n", err)
-		}
-		defer func() {
-			// Remove the custom endpoints from the infrastructure config.
-			if err := updateInfrastructureConfigSpecWithRetryOnConflict(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
-				spec.PlatformSpec.AWS = nil
-			}); err != nil {
-				t.Fatalf("failed to update infrastructure config: %v", err)
-			}
-		}()
-
-		// Wait for infrastructure status to update with custom endpoints,
-		// for CCM deploy to get a new configuration hash and for pods to be scheduled
-		// and available
-		// This configuration change and replicas available may take up to 5 minutes, depending on
-		// the environment load
-		if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 5*time.Minute, false, func(ctx context.Context) (done bool, err error) {
-			if err := kclient.Get(ctx, types.NamespacedName{Name: "cluster"}, &infraConfig); err != nil {
-				t.Logf("failed to get infrastructure config: %v\n", err)
-				return false, err
-			}
-			if len(infraConfig.Status.PlatformStatus.AWS.ServiceEndpoints) == 0 {
-				return false, nil
-			}
-
-			currentCCMDeployment, err := retrieveDeployment(ccmDeploymentName)
-			if err != nil {
-				t.Logf("error getting CCM deployment: %v\n", err)
-				return false, err
-			}
-			currentConfigHash := retrieveCCMConfigurationHash(currentCCMDeployment)
-			if oldConfigHash == currentConfigHash {
-				t.Log("new config hash not yet applied to CCM deployment")
-				return false, nil
-			}
-
-			if currentCCMDeployment.Generation == currentCCMDeployment.Status.ObservedGeneration &&
-				currentCCMDeployment.Status.Replicas == currentCCMDeployment.Status.ReadyReplicas &&
-				currentCCMDeployment.Status.Replicas == currentCCMDeployment.Status.UpdatedReplicas &&
-				currentCCMDeployment.Status.UnavailableReplicas == 0 {
-				return true, nil
-			}
-			return false, nil
-
-		}); err != nil {
-			t.Fatalf("failed to observe status update for infrastructure config %s", infraConfig.Name)
-		}
-	default:
+	if platform.Type != configv1.AWSPlatformType {
 		t.Skipf("skipping TestIngressControllerCustomEndpoints test due to platform type: %s", platform.Type)
 	}
+
+	switch {
+	case platform.AWS == nil:
+		t.Fatalf("aws platform status is missing for infrastructure %s", infraConfig.Name)
+	case len(platform.AWS.ServiceEndpoints) != 0:
+		t.Skipf("custom endpoints detected for infrastructure %s, skipping TestIngressControllerCustomEndpoints",
+			infraConfig.Name)
+	case len(platform.AWS.Region) == 0:
+		t.Fatalf("region is missing from aws platform status for infrastructure %s", infraConfig.Name)
+	case platform.AWS.Region == endpoints.CnNorth1RegionID || platform.AWS.Region == endpoints.CnNorthwest1RegionID:
+		t.Skipf("region %s or %s detected for infrastructure %s, skipping TestIngressControllerCustomEndpoints",
+			endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID, infraConfig.Name)
+	}
+
+	route53Endpoint := configv1.AWSServiceEndpoint{
+		Name: "route53",
+		// AWS Route 53 is a non-regionalized service, so the endpoint URL
+		// does not include a region.
+		URL: "https://route53.amazonaws.com",
+	}
+	taggingEndpoint := configv1.AWSServiceEndpoint{
+		Name: "tagging",
+		// us-east-1 region is required to get hosted zone resources
+		// since route 53 is a non-regionalized service.
+		URL: "https://tagging.us-east-1.amazonaws.com",
+	}
+	elbEndpoint := configv1.AWSServiceEndpoint{
+		Name: "elasticloadbalancing",
+		URL:  fmt.Sprintf("https://elasticloadbalancing.%s.amazonaws.com", platform.AWS.Region),
+	}
+
+	oldCCMDeployment := waitForCCMReadiness(t, 5*time.Minute, "")
+	oldConfigHash := retrieveCCMConfigurationHash(oldCCMDeployment)
+	if oldConfigHash == "" {
+		t.Fatalf("CCM does not have a config hash, this should never happen: %v", oldCCMDeployment)
+	}
+
+	if err := updateInfrastructureConfigWithRetryOnConflict(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
+		spec.PlatformSpec.AWS = &configv1.AWSPlatformSpec{
+			ServiceEndpoints: []configv1.AWSServiceEndpoint{
+				route53Endpoint,
+				taggingEndpoint,
+				elbEndpoint,
+			},
+		}
+	}); err != nil {
+		t.Fatalf("failed to update infrastructure config: %v", err)
+	}
+	defer func() {
+		// Remove the custom endpoints from the infrastructure config.
+		if err := updateInfrastructureConfigWithRetryOnConflict(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
+			spec.PlatformSpec.AWS = nil
+		}); err != nil {
+			t.Fatalf("failed to update infrastructure config: %v", err)
+		}
+	}()
+
+	// Wait for infrastructure status to update with custom endpoints,
+	// for CCM deploy to get a new configuration hash and for pods to be scheduled
+	// and available
+	// This configuration change and replicas available may take up to 5 minutes, depending on
+	// the environment load
+
+	// Wait for CCM to be ready with the new configuration, so we can guarantee that
+	// the LoadBalancer will be created correctly
+	_ = waitForCCMReadiness(t, 5*time.Minute, oldConfigHash)
+
 	// The default ingresscontroller should surface the expected status conditions.
 	if err := waitForIngressControllerCondition(t, kclient, 30*time.Second, defaultName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
 		t.Fatalf("did not get expected ingress controller conditions: %v", err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -647,6 +647,26 @@ func updateInfrastructureConfigSpecWithRetryOnConflict(t *testing.T, name types.
 	})
 }
 
+// retrieveDeployment is used to retrieve a full deployment resource
+func retrieveDeployment(name types.NamespacedName) (appsv1.Deployment, error) {
+	ccmDeployment := appsv1.Deployment{}
+	err := kclient.Get(context.TODO(), name, &ccmDeployment)
+	return ccmDeployment, err
+}
+
+// retrieveCCMConfigurationHash fetches the config-hash used on CCM deployment
+// and present on the annotation operator.openshift.io/config-hash
+// this information can be used to signal that a required infrastructure change
+// was successfully applied on CCM and forces CCM to do a rollout update.
+func retrieveCCMConfigurationHash(ccmDeployment appsv1.Deployment) string {
+	ccmConfigAnnotation := "operator.openshift.io/config-hash"
+	annotations := ccmDeployment.Spec.Template.GetAnnotations()
+	if cfghash, ok := annotations[ccmConfigAnnotation]; ok {
+		return cfghash
+	}
+	return ""
+}
+
 // updateInfrastructureStatus updates the Infrastructure status by applying
 // the given update function to the current Infrastructure object.
 // If there is a conflict error on update then the complete operation

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -623,15 +623,15 @@ func updateIngressConfigSpecWithRetryOnConflict(t *testing.T, name types.Namespa
 	})
 }
 
-// updateInfrastructureConfigWithRetryOnConflict gets a fresh copy
+// updateAndVerifyInfrastructureConfigWithRetry gets a fresh copy
 // of the named infrastructure object, calls updateSpecFn() where
 // callers can modify fields of the spec, and then updates the infrastructure
 // config object. If there is a conflict error on update then the
 // complete operation of get, mutate, and update is retried until
 // timeout is reached.
 // After updating, it will check if the desired spec.Endpoints where applied to
-// the infraconfig
-func updateInfrastructureConfigWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*configv1.InfrastructureSpec)) error {
+// the infrastructure config
+func updateAndVerifyInfrastructureConfigWithRetry(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*configv1.InfrastructureSpec)) error {
 	infraConfig := configv1.Infrastructure{}
 	// First we apply the configuration
 	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(ctx context.Context) (done bool, err error) {
@@ -680,17 +680,11 @@ func updateInfrastructureConfigWithRetryOnConflict(t *testing.T, name types.Name
 	})
 }
 
-// waitForCCMReadiness waits for Cloud Controller Manager to be ready.
-//
-//	for infrastructure status to update with custom endpoints,
-//
-// for CCM deploy to get a new configuration hash and for pods to be scheduled
-// and available
-// This configuration change and replicas available may take up to 5 minutes, depending on
-// the environment load
+// waitForCCMAvailableAndUpdated waits for Cloud Controller Manager Deployment
+// to be reported as ready.
 // If oldConfigurationHash is not empty it will additionally verify that the configuration hash
 // is different between the deployments
-func waitForCCMReadiness(t *testing.T, timeout time.Duration, oldConfigurationHash string) appsv1.Deployment {
+func waitForCCMAvailableAndUpdated(t *testing.T, timeout time.Duration, oldConfigurationHash string) appsv1.Deployment {
 	// The pooler below will never return an error, and instead it will log and try until it fails.
 	// This avoids errors that are network errors to cause a failure on the test, and instead retries until it
 	// is successful


### PR DESCRIPTION
Changing `infrastructures.config.openshift.io` causes Cloud controller manager to rollout/restart, to read the new configurations.

This happens at:
```
updateInfrastructureConfigSpecWithRetryOnConflict()
```

This restart can take at least 3 minutes due to controller-runtime leader election, + the required time to re-schedule the Pod on the node.

This may not be enough to ensure a LoadBalancer creation, causing the test to timeout when CCM has been restarted but is not yet available to reconcile the new LoadBalancer request.