### PR TITLE
NE-2066: Set degraded=true when OSSM 3 can't be installed

### DIFF
--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -283,6 +283,7 @@ func Test_Reconcile(t *testing.T) {
 					OperatorLifecycleManagerEnabled: tc.olmEnabled,
 					DependentControllers:            []controller.Controller{ctrl},
 				},
+				fieldIndexer: FakeIndexer{},
 			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -360,6 +361,7 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 			OperatorLifecycleManagerEnabled: true,
 			DependentControllers:            []controller.Controller{ctrl},
 		},
+		fieldIndexer: FakeIndexer{},
 	}
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "cluster"}}
 
@@ -388,4 +390,10 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 		t.Log(ctx.Err())
 	}
 	assert.True(t, ctrl.Started, "fake controller should have been started")
+}
+
+type FakeIndexer struct{}
+
+func (indexer FakeIndexer) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return nil
 }

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -76,6 +76,8 @@ const (
 	// IstioRevLabelKey is the key for the gateway label that Istio checks
 	// for to determine whether it should reconcile that gateway.
 	IstioRevLabelKey = "istio.io/rev"
+
+	GatewayClassIndexFieldName = "gatewayclassController"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -180,7 +180,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to create operator manager: %v", err)
 	}
-
 	// Create and register the ingress controller with the operator manager.
 	if _, err := ingresscontroller.New(mgr, ingresscontroller.Config{
 		Namespace:                                 config.Namespace,
@@ -227,6 +226,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		GatewayAPIControllerEnabled:     gatewayAPIControllerEnabled,
 		MarketplaceEnabled:              marketplaceEnabled,
 		OperatorLifecycleManagerEnabled: olmEnabled,
+		GatewayAPIOperatorVersion:       config.GatewayAPIOperatorVersion,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create status controller: %v", err)
 	}


### PR DESCRIPTION
Detect subscriptions that would prevent the Ingress Operator from installing OSSM 3, and set the operator's degraded condition to true when any of those subscriptions are present.

This is the implementation of [NE-2066](https://issues.redhat.com//browse/NE-2066)