### PR TITLE
OCPBUGS-60492: Gateway service DNS: Add check for nil DNS Public and Private DNS zones

### DIFF
--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -199,6 +199,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
+	if dnsConfig.Spec.PublicZone == nil && dnsConfig.Spec.PrivateZone == nil {
+		log.Info("DNS Public and Private zones not present; no public records should be created; reconciliation will be skipped")
+		return reconcile.Result{}, nil
+	}
+
 	domains := getGatewayHostnames(&gateway)
 	var errs []error
 	errs = append(errs, r.ensureDNSRecordsForGateway(ctx, &gateway, &service, domains.List(), infraConfig, dnsConfig)...)


### PR DESCRIPTION
Reconcile logic for Gateway Service Controller should check for non-nil Public and Private Zones as per the DNS API specification.