### PR TITLE
OCPBUGS-59139: Increase assertExpectedDNSRecords timeouts

### DIFF
--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -732,14 +732,15 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]b
 
 	var expectationsMet bool
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
 		haveExpectNotPresent := false
 		// expectationsMet starts true and gets set to false when some expectation is not met.
 		expectationsMet = true
 
 		dnsRecords := &v1.DNSRecordList{}
 		if err := kclient.List(context, dnsRecords, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
-			return false, fmt.Errorf("failed to list DNSRecords: %v", err)
+			t.Logf("failed to list DNSRecords: %v, retrying...", err)
+			return false, nil
 		}
 
 		// Iterate over all expectations.


### PR DESCRIPTION
Increase the timeout value for the `assertExpectedDNSRecords` test/e2e/util_gatewayapi_test function to 2 minutes to give the DNSRecords more time to be cleaned up in the e2e test cases that check for the record deletion. This is to avoid CI flakes.

Also increase the polling interval from 1s to 5s to avoid unnecessary polls and reduce the noise in the logs.

The changes are expected to increase the overall test run time by 3 minutes in total.