### PR TITLE
OCPBUGS-60859: Fix logic on gatewayapi test cleanup

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -603,6 +603,11 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		{name: "http-listener2", hostname: ptr.To("bar." + domain)},
 	})
 
+	if err != nil {
+		t.Fatalf("failed to create gateway with multiple listeners: %v", err)
+	}
+	t.Logf("Created gateway %s with multiple hostnames", gateway.Name)
+
 	t.Cleanup(func() {
 		if err := kclient.Delete(context.TODO(), gateway); err != nil {
 			if errors.IsNotFound(err) {
@@ -611,11 +616,6 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 			t.Errorf("failed to delete gateway %q: %v", gateway.Name, err)
 		}
 	})
-
-	if err != nil {
-		t.Fatalf("failed to create gateway with multiple listeners: %v", err)
-	}
-	t.Logf("Created gateway %s with multiple hostnames", gateway.Name)
 
 	gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-gateway-update")
 	if err != nil {

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -651,7 +651,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 	if err := updateGatewaySpecWithRetry(t, gatewayNSName, timeout, func(spec *gatewayapiv1.GatewaySpec) {
 		spec.Listeners = spec.Listeners[0 : len(gateway.Spec.Listeners)-1]
 	}); err != nil {
-		t.Fatalf("failed to update gateway listener: %v", err)
+		t.Fatalf("failed to delete gateway listener: %v", err)
 	}
 	t.Logf("Deleted listener %s from gateway %s.", "http-listener2", gateway.Name)
 

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -185,7 +185,7 @@ func testGatewayAPIObjects(t *testing.T) {
 	ns := createNamespace(t, names.SimpleNameGenerator.GenerateName("test-e2e-gwapi-"))
 
 	// Validate that Gateway API objects can be created.
-	if err := ensureGatewayObjectCreation(ns); err != nil {
+	if err := ensureGatewayObjectCreation(t, ns); err != nil {
 		t.Fatalf("failed to create one or more gateway object/s: %v", err)
 	}
 
@@ -219,7 +219,7 @@ func testGatewayAPIObjects(t *testing.T) {
 // gateway ("automated deployment"), even if the gateway specifies some existing
 // service in spec.addresses.
 func testGatewayAPIManualDeployment(t *testing.T) {
-	gatewayClass, err := createGatewayClass("openshift-default", "openshift.io/gateway-controller/v1")
+	gatewayClass, err := createGatewayClass(t, "openshift-default", "openshift.io/gateway-controller/v1")
 	if err != nil {
 		t.Fatalf("Failed to create gatewayclass: %v", err)
 	}
@@ -462,7 +462,7 @@ func testGatewayAPIRBAC(t *testing.T) {
 func testGatewayAPIDNS(t *testing.T) {
 	domain := "gws." + dnsConfig.Spec.BaseDomain
 
-	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
+	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		t.Fatalf("failed to create gatewayclass: %v", err)
 	}
@@ -546,7 +546,7 @@ func testGatewayAPIDNS(t *testing.T) {
 
 			// Create gateways
 			for _, gateway := range tc.createGateways {
-				createdGateway, err := createGatewayWithListeners(gatewayClass, gateway.gatewayName, gateway.namespace, gateway.listeners)
+				createdGateway, err := createGatewayWithListeners(t, gatewayClass, gateway.gatewayName, gateway.namespace, gateway.listeners)
 				gateways = append(gateways, createdGateway)
 				if err != nil {
 					t.Fatalf("failed to create gateway %s: %v", gateway.gatewayName, err)
@@ -591,14 +591,14 @@ func testGatewayAPIDNS(t *testing.T) {
 }
 
 func testGatewayAPIDNSListenerUpdate(t *testing.T) {
-	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
+	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		t.Fatalf("failed to create gatewayclass: %v", err)
 	}
 
 	domain := "gws." + dnsConfig.Spec.BaseDomain
 
-	gateway, err := createGatewayWithListeners(gatewayClass, "test-gateway-update", operatorcontroller.DefaultOperandNamespace, []testListener{
+	gateway, err := createGatewayWithListeners(t, gatewayClass, "test-gateway-update", operatorcontroller.DefaultOperandNamespace, []testListener{
 		{name: "http-listener1", hostname: ptr.To("foo." + domain)},
 		{name: "http-listener2", hostname: ptr.To("bar." + domain)},
 	})
@@ -628,17 +628,14 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("DNSRecord %s expectations not met: %v", "foo."+domain+".", err)
 	}
 
-	// Fetch the latest version of the Gateway resource.
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: gateway.Name}, gateway); err != nil {
-		t.Fatalf("failed to get gateway resource: %v", err)
-	}
+	gatewayNSName := types.NamespacedName{Name: "test-gateway-update", Namespace: operatorcontroller.DefaultOperandNamespace}
 
 	// Modify one gateway listener hostname
-	newHostname := gatewayapiv1.Hostname("baz." + domain)
-	gateway.Spec.Listeners[0].Hostname = &newHostname
-
-	if err := kclient.Update(context.TODO(), gateway); err != nil {
-		t.Fatalf("failed to update gateway %v: %v", gateway.Name, err)
+	if err := updateGatewaySpecWithRetry(t, gatewayNSName, timeout, func(spec *gatewayapiv1.GatewaySpec) {
+		newHostname := gatewayapiv1.Hostname("baz." + domain)
+		spec.Listeners[0].Hostname = &newHostname
+	}); err != nil {
+		t.Fatalf("failed to update gateway listener: %v", err)
 	}
 	t.Logf("Modified gateway %s's listener hostname from %s to: %s", gateway.Name, "foo."+domain+".", "baz."+domain+".")
 
@@ -650,21 +647,15 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("DNSRecord %s expectations not met: %v", "baz."+domain+".", err)
 	}
 
-	// Fetch the latest version of the Gateway resource.
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: gateway.Name}, gateway); err != nil {
-		t.Fatalf("failed to get gateway resource: %v", err)
-	}
-
 	// Delete one of the listeners
-	gateway.Spec.Listeners = gateway.Spec.Listeners[0 : len(gateway.Spec.Listeners)-1]
-
-	if err := kclient.Update(context.TODO(), gateway); err != nil {
-		t.Fatalf("failed to update gateway with removed listener: %v", err)
+	if err := updateGatewaySpecWithRetry(t, gatewayNSName, timeout, func(spec *gatewayapiv1.GatewaySpec) {
+		spec.Listeners = spec.Listeners[0 : len(gateway.Spec.Listeners)-1]
+	}); err != nil {
+		t.Fatalf("failed to update gateway listener: %v", err)
 	}
 	t.Logf("Deleted listener %s from gateway %s.", "http-listener2", gateway.Name)
 
 	t.Logf("Checking that the dnsRecord for %s gets removed after removing the listener.", "bar."+domain+".")
-
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
 		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: true,
 		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: false,
@@ -672,7 +663,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
 	}
 
-	if err := kclient.Delete(context.TODO(), gateway); err != nil {
+	if err := deleteWithRetryOnError(t, context.TODO(), gateway, 30*time.Second); err != nil {
 		t.Errorf("failed to delete gateway %q: %v", gateway.Name, err)
 	}
 
@@ -686,24 +677,24 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 }
 
 func testGatewayAPIDNSListenerWithNoHostname(t *testing.T) {
-	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
+	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		t.Fatalf("failed to create gatewayclass: %v", err)
 	}
 
-	gateway, err := createGatewayWithListeners(gatewayClass, "test-nohost-gateway", operatorcontroller.DefaultOperandNamespace, []testListener{
+	gateway, err := createGatewayWithListeners(t, gatewayClass, "test-nohost-gateway", operatorcontroller.DefaultOperandNamespace, []testListener{
 		{name: "http-listener-no-host", hostname: nil},
 	})
+
+	if err != nil {
+		t.Fatalf("failed to create gateway with a listener with no hostname: %v", err)
+	}
 
 	t.Cleanup(func() {
 		if err := kclient.Delete(context.TODO(), gateway); err != nil {
 			t.Errorf("failed to delete gateway %q: %v", gateway.Name, err)
 		}
 	})
-
-	if err != nil {
-		t.Fatalf("failed to create gateway with a listener with no hostname: %v", err)
-	}
 
 	gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-nohost-gateway")
 	if err != nil {
@@ -824,10 +815,10 @@ func ensureExperimentalCRDs(t *testing.T) {
 }
 
 // ensureGatewayObjectCreation tests that gateway class, gateway, and http route objects can be created.
-func ensureGatewayObjectCreation(ns *corev1.Namespace) error {
+func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 	var domain string
 
-	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
+	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		return fmt.Errorf("feature gate was enabled, but gateway class object could not be created: %v", err)
 	}
@@ -845,7 +836,7 @@ func ensureGatewayObjectCreation(ns *corev1.Namespace) error {
 	hostname := names.SimpleNameGenerator.GenerateName("test-hostname-")
 	defaultRoutename = hostname + "." + domain
 
-	_, err = createHttpRoute(ns.Name, "test-httproute", operatorcontroller.DefaultOperandNamespace, defaultRoutename, testGatewayName+"-"+operatorcontroller.OpenShiftDefaultGatewayClassName, testGateway)
+	_, err = createHttpRoute(t, ns.Name, "test-httproute", operatorcontroller.DefaultOperandNamespace, defaultRoutename, testGatewayName+"-"+operatorcontroller.OpenShiftDefaultGatewayClassName, testGateway)
 	if err != nil {
 		return fmt.Errorf("feature gate was enabled, but http route object could not be created: %v", err)
 	}

--- a/test/e2e/idle_connection_test.go
+++ b/test/e2e/idle_connection_test.go
@@ -120,12 +120,12 @@ func idleConnectionCreateBackendService(ctx context.Context, t *testing.T, names
 		"idle-close-on-response": name,
 	}
 
-	_, err := idleConnectionCreateService(ctx, namespace, name, labels)
+	_, err := idleConnectionCreateService(t, ctx, namespace, name, labels)
 	if err != nil {
 		return fmt.Errorf("failed to create service %s/%s: %w", namespace, name, err)
 	}
 
-	rs, err := idleConnectionCreateReplicaSet(ctx, namespace, name, image, labels)
+	rs, err := idleConnectionCreateReplicaSet(t, ctx, namespace, name, image, labels)
 	if err != nil {
 		return fmt.Errorf("failed to create replicaset %s: %w", name, err)
 	}
@@ -137,7 +137,7 @@ func idleConnectionCreateBackendService(ctx context.Context, t *testing.T, names
 	return nil
 }
 
-func idleConnectionCreateService(ctx context.Context, namespace, name string, labels map[string]string) (*corev1.Service, error) {
+func idleConnectionCreateService(t *testing.T, ctx context.Context, namespace, name string, labels map[string]string) (*corev1.Service, error) {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -155,7 +155,7 @@ func idleConnectionCreateService(ctx context.Context, namespace, name string, la
 		},
 	}
 
-	if err := createWithRetryOnError(ctx, service, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, service, 2*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to create service %s/%s: %w", service.Namespace, service.Name, err)
 	}
 
@@ -239,7 +239,7 @@ func idleConnectionBuildPod(namespace, name, image string, labels map[string]str
 	}
 }
 
-func idleConnectionCreateReplicaSet(ctx context.Context, namespace, name, image string, labels map[string]string) (*appsv1.ReplicaSet, error) {
+func idleConnectionCreateReplicaSet(t *testing.T, ctx context.Context, namespace, name, image string, labels map[string]string) (*appsv1.ReplicaSet, error) {
 	pod := idleConnectionBuildPod(namespace, name, image, labels)
 	one := int32(1)
 	rs := &appsv1.ReplicaSet{
@@ -260,7 +260,7 @@ func idleConnectionCreateReplicaSet(ctx context.Context, namespace, name, image 
 			},
 		},
 	}
-	if err := createWithRetryOnError(ctx, rs, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, rs, 2*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to create replicaset %s/%s: %w", rs.Namespace, rs.Name, err)
 	}
 	return rs, nil

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -270,7 +270,7 @@ func createGatewayWithListeners(t *testing.T, gatewayClass *gatewayapiv1.Gateway
 	}
 
 	if err := createWithRetryOnError(t, context.TODO(), gateway, 2*time.Minute); err != nil {
-		return nil, fmt.Errorf("failed to craete gateway %s: %v", name, err.Error())
+		return nil, fmt.Errorf("failed to create gateway %s: %v", name, err.Error())
 	}
 
 	return gateway, nil
@@ -287,12 +287,12 @@ func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv
 		if err := kclient.Create(ctx, gatewayClass); err != nil {
 			if kerrors.IsAlreadyExists(err) {
 				if err := kclient.Get(ctx, nsName, gatewayClass); err != nil {
-					t.Logf("gatewayclass %s already exists, but get failed: %v Retrying...", nsName.Name, err)
+					t.Logf("gatewayclass %s already exists, but get failed: %v; retrying...", nsName.Name, err)
 					return false, nil
 				}
 				return true, nil
 			}
-			t.Logf("error creating gatewayclass %s: %v. Retrying...", nsName.Name, err)
+			t.Logf("error creating gatewayclass %s: %v; retrying...", nsName.Name, err)
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -182,7 +182,7 @@ func deleteExistingVAP(t *testing.T, vapName string) error {
 
 // createHttpRoute checks if the HTTPRoute can be created.
 // If it can't an error is returned.
-func createHttpRoute(namespace, routeName, parentNamespace, hostname, backendRefname string, gateway *gatewayapiv1.Gateway) (*gatewayapiv1.HTTPRoute, error) {
+func createHttpRoute(t *testing.T, namespace, routeName, parentNamespace, hostname, backendRefname string, gateway *gatewayapiv1.Gateway) (*gatewayapiv1.HTTPRoute, error) {
 	if gateway == nil {
 		return nil, errors.New("unable to create httpRoute, no gateway available")
 	}
@@ -191,12 +191,12 @@ func createHttpRoute(namespace, routeName, parentNamespace, hostname, backendRef
 	// The http route, service, and pod are cleaned up when the namespace is automatically deleted.
 	// buildEchoReplicaSet builds a replicaset which creates a pod that listens on port 8080.
 	echoRs := buildEchoReplicaSet(backendRefname, namespace)
-	if err := createWithRetryOnError(context.TODO(), echoRs, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.TODO(), echoRs, 2*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to create replicaset %s/%s: %v", namespace, echoRs.Name, err)
 	}
 	// buildEchoService builds a service that targets port 8080.
 	echoService := buildEchoService(echoRs.Name, namespace, echoRs.Spec.Template.ObjectMeta.Labels)
-	if err := createWithRetryOnError(context.TODO(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.TODO(), echoService, 2*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
@@ -233,8 +233,8 @@ func createGateway(gatewayClass *gatewayapiv1.GatewayClass, name, namespace, dom
 	return gateway, nil
 }
 
-func createGatewayWithListeners(gatewayClass *gatewayapiv1.GatewayClass, name, namespace string, listeners []testListener) (*gatewayapiv1.Gateway, error) {
-
+func createGatewayWithListeners(t *testing.T, gatewayClass *gatewayapiv1.GatewayClass, name, namespace string, listeners []testListener) (*gatewayapiv1.Gateway, error) {
+	t.Helper()
 	var gatewayListeners []gatewayapiv1.Listener
 	for _, spec := range listeners {
 		var hostname *gatewayapiv1.Hostname = nil
@@ -269,31 +269,37 @@ func createGatewayWithListeners(gatewayClass *gatewayapiv1.GatewayClass, name, n
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), gateway); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("cannot create gateway %s: %v", name, err.Error())
-		} else {
-			return nil, fmt.Errorf("failed to create gateway %s: %v", name, err.Error())
-		}
+	if err := createWithRetryOnError(t, context.TODO(), gateway, 2*time.Minute); err != nil {
+		return nil, fmt.Errorf("failed to craete gateway %s: %v", name, err.Error())
 	}
+
 	return gateway, nil
 }
 
 // createGatewayClass checks if the GatewayClass can be created.
 // If it can, it is returned.  If it can't an error is returned.
-func createGatewayClass(name, controllerName string) (*gatewayapiv1.GatewayClass, error) {
+func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv1.GatewayClass, error) {
+	t.Helper()
+
 	gatewayClass := buildGatewayClass(name, controllerName)
-	if err := kclient.Create(context.TODO(), gatewayClass); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			name := types.NamespacedName{Namespace: "", Name: name}
-			if err := kclient.Get(context.TODO(), name, gatewayClass); err != nil {
-				return nil, fmt.Errorf("gatewayclass %s already exists, but get failed: %w", name.Name, err)
+	nsName := types.NamespacedName{Namespace: "", Name: name}
+	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := kclient.Create(ctx, gatewayClass); err != nil {
+			if kerrors.IsAlreadyExists(err) {
+				if err := kclient.Get(ctx, nsName, gatewayClass); err != nil {
+					t.Logf("gatewayclass %s already exists, but get failed: %v Retrying...", nsName.Name, err)
+					return false, nil
+				}
+				return true, nil
 			}
-			return gatewayClass, nil
-		} else {
-			return nil, fmt.Errorf("failed to create gatewayclass %s: %w", gatewayClass.Name, err)
+			t.Logf("error creating gatewayclass %s: %v. Retrying...", nsName.Name, err)
+			return false, nil
 		}
+		return true, nil
+	}); err != nil {
+		return nil, err
 	}
+
 	return gatewayClass, nil
 }
 
@@ -1236,4 +1242,25 @@ func containsPolicyRules(destRules, srcRules []rbacv1.PolicyRule) bool {
 	}
 
 	return true
+}
+
+// updateGatewaySpecWithRetry gets a fresh copy
+// of the named gateway object, calls mutateSpecFn() where
+// callers can modify fields of the spec, and then updates the gateway
+// object. If there is any error during get or update, it will log
+// and retry
+func updateGatewaySpecWithRetry(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*gatewayapiv1.GatewaySpec)) error {
+	gw := gatewayapiv1.Gateway{}
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, &gw); err != nil {
+			t.Logf("error getting gateway resource %v: %v, retrying...", name, err)
+			return false, nil
+		}
+		mutateSpecFn(&gw.Spec)
+		if err := kclient.Update(ctx, &gw); err != nil {
+			t.Logf("error when updating gateway spec %v: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
 }

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -756,9 +756,24 @@ func updateInfrastructureConfigStatusWithRetryOnConflict(t *testing.T, timeout t
 
 // createWithRetryOnError creates the given object. If there is an error on create
 // apart from "AlreadyExists" then the create is retried until the timeout is reached.
-func createWithRetryOnError(ctx context.Context, obj client.Object, timeout time.Duration) error {
+func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
+	t.Helper()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		if err := kclient.Create(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+			t.Logf("error creating %s: %v, retrying...", obj.GetName(), err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// deleteWithRetryOnError will try to delete the object until timeout reaches.
+// it is mostly used to retry operations that may be flaky due to network issues
+func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
+	t.Helper()
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := kclient.Delete(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+			t.Logf("error deleting %s: %v, retrying...", obj.GetName(), err)
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -767,8 +767,8 @@ func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 	})
 }
 
-// deleteWithRetryOnError will try to delete the object until timeout reaches.
-// it is mostly used to retry operations that may be flaky due to network issues
+// deleteWithRetryOnError will try to delete the object until the timeout occurs.
+// Use for retrying operations that may be flaky due to network issues.
 func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
 	t.Helper()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
The current logic of testGatewayAPIDNSListenerUpdate adds the cleanup routine to the stack before checking if the creation of the gateway was successful.

This causes a panic during the assertGatewaySuccessful and a subsequent panic on the cleanup, was the gateway resource is null because of the previous error.

This fix moves the cleanup to happen just if there was no error when creating the gateway resource

Additionally, this fix adds retries when managing GatewayAPI resources during e2e, so flakes/network issues will be retried before failing