### PR TITLE
NE-2115: Implement httpsLogFormat and tcpLogFormat for Ingress Operator

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -52,8 +52,11 @@ const (
 	RouterLogLevelEnvName       = "ROUTER_LOG_LEVEL"
 	RouterLogMaxLengthEnvName   = "ROUTER_LOG_MAX_LENGTH"
 	RouterSyslogAddressEnvName  = "ROUTER_SYSLOG_ADDRESS"
-	RouterSyslogFormatEnvName   = "ROUTER_SYSLOG_FORMAT"
 	RouterSyslogFacilityEnvName = "ROUTER_LOG_FACILITY"
+
+        RouterTCPLogFormatEnvName   = "ROUTER_TCP_LOG_FORMAT"
+        RouterHTTPLogFormatEnvName  = "ROUTER_HTTP_LOG_FORMAT"
+        RouterHTTPSLogFormatEnvName = "ROUTER_HTTPS_LOG_FORMAT"
 
 	RouterCaptureHTTPRequestHeaders  = "ROUTER_CAPTURE_HTTP_REQUEST_HEADERS"
 	RouterCaptureHTTPResponseHeaders = "ROUTER_CAPTURE_HTTP_RESPONSE_HEADERS"
@@ -907,8 +910,14 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			)
 		}
 
+		if len(accessLogging.TcpLogFormat) > 0 {
+			env = append(env, corev1.EnvVar{Name: RouterTCPLogFormatEnvName, Value: fmt.Sprintf("%q", accessLogging.TcpLogFormat)})
+		}
 		if len(accessLogging.HttpLogFormat) > 0 {
-			env = append(env, corev1.EnvVar{Name: RouterSyslogFormatEnvName, Value: fmt.Sprintf("%q", accessLogging.HttpLogFormat)})
+			env = append(env, corev1.EnvVar{Name: RouterHTTPLogFormatEnvName, Value: fmt.Sprintf("%q", accessLogging.HttpLogFormat)})
+		}
+		if len(accessLogging.HttpsLogFormat) > 0 {
+			env = append(env, corev1.EnvVar{Name: RouterHTTPSLogFormatEnvName, Value: fmt.Sprintf("%q", accessLogging.HttpsLogFormat)})
 		}
 		if val := serializeCaptureHeaders(accessLogging.HTTPCaptureHeaders.Request); len(val) != 0 {
 			env = append(env, corev1.EnvVar{
@@ -1265,7 +1274,9 @@ func accessLoggingForIngressController(ic *operatorv1.IngressController) *operat
 				Type:      operatorv1.ContainerLoggingDestinationType,
 				Container: &containerLoggingParameters,
 			},
+			TcpLogFormat:       ic.Spec.Logging.Access.TcpLogFormat,
 			HttpLogFormat:      ic.Spec.Logging.Access.HttpLogFormat,
+			HttpsLogFormat:     ic.Spec.Logging.Access.HttpsLogFormat,
 			HTTPCaptureHeaders: ic.Spec.Logging.Access.HTTPCaptureHeaders,
 			HTTPCaptureCookies: ic.Spec.Logging.Access.HTTPCaptureCookies,
 			LogEmptyRequests:   ic.Spec.Logging.Access.LogEmptyRequests,
@@ -1282,7 +1293,9 @@ func accessLoggingForIngressController(ic *operatorv1.IngressController) *operat
 						MaxLength: ic.Spec.Logging.Access.Destination.Syslog.MaxLength,
 					},
 				},
+				TcpLogFormat:       ic.Spec.Logging.Access.TcpLogFormat,
 				HttpLogFormat:      ic.Spec.Logging.Access.HttpLogFormat,
+				HttpsLogFormat:     ic.Spec.Logging.Access.HttpsLogFormat,
 				HTTPCaptureHeaders: ic.Spec.Logging.Access.HTTPCaptureHeaders,
 				HTTPCaptureCookies: ic.Spec.Logging.Access.HTTPCaptureCookies,
 				LogEmptyRequests:   ic.Spec.Logging.Access.LogEmptyRequests,

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -630,7 +630,9 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 				Type:      operatorv1.ContainerLoggingDestinationType,
 				Container: &operatorv1.ContainerLoggingDestinationParameters{},
 			},
+			TcpLogFormat: "%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts",
 			HttpLogFormat: "%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV",
+			HttpsLogFormat: "%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV %sslv/%sslc",
 			HTTPCaptureCookies: []operatorv1.IngressControllerCaptureHTTPCookie{{
 				IngressControllerCaptureHTTPCookieUnion: operatorv1.IngressControllerCaptureHTTPCookieUnion{
 					MatchType:  "Prefix",

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2361,7 +2361,9 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 				},
 			},
 			// String with more than 8192 characters
+			TcpLogFormat: "8192" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 120),
 			HttpLogFormat: "8192" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 120),
+			HttpsLogFormat: "8192" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 120),
 		},
 	}
 	if err := kclient.Create(context.TODO(), ic); err != nil {
@@ -2503,7 +2505,9 @@ func TestContainerLoggingMinLength(t *testing.T) {
 				},
 			},
 			// String with more than 480 characters
+			TcpLogFormat: "0480" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 40),
 			HttpLogFormat: "0480" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 40),
+			HttpsLogFormat: "0480" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 40),
 		},
 	}
 	if err := kclient.Create(context.TODO(), ic); err != nil {


### PR DESCRIPTION
Add support for httpsLogFormat and tcpLogFormat. These allow users to define a custom log format for both HTTPS and TCP traffic, which configured appropriately in OpenShift Router.