### PR TITLE
OCPBUGS-55649: Remove SetEIPForNLBIngressController feature gate

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -205,11 +205,10 @@ func hasName(name string) func(o client.Object) bool {
 
 // Config holds all the things necessary for the controller to run.
 type Config struct {
-	Namespace                                 string
-	IngressControllerImage                    string
-	RouteExternalCertificateEnabled           bool
-	IngressControllerEIPAllocationsAWSEnabled bool
-	IngressControllerDCMEnabled               bool
+	Namespace                       string
+	IngressControllerImage          string
+	RouteExternalCertificateEnabled bool
+	IngressControllerDCMEnabled     bool
 }
 
 // reconciler handles the actual ingress reconciliation logic in response to

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -819,12 +819,11 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 		Type: configv1.OpenStackPlatformType,
 	}
 	tests := []struct {
-		name                     string
-		conditions               []operatorv1.OperatorCondition
-		ic                       *operatorv1.IngressController
-		service                  *corev1.Service
-		platformStatus           *configv1.PlatformStatus
-		awsEIPAllocationsEnabled bool
+		name           string
+		conditions     []operatorv1.OperatorCondition
+		ic             *operatorv1.IngressController
+		service        *corev1.Service
+		platformStatus *configv1.PlatformStatus
 
 		expectStatus                operatorv1.ConditionStatus
 		expectMessageContains       string
@@ -1165,10 +1164,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				nil,
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations nil spec and empty status",
@@ -1176,21 +1174,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				[]operatorv1.EIPAllocation{},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionFalse,
-		},
-		{
-			name: "NLB LoadBalancerService, AWS EIPAllocations spec with eipAllocations and nil status, but feature gate disabled",
-			ic: loadBalancerIngressControllerWithAWSEIPAllocations(
-				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
-				nil,
-			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: false,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations spec with eipAllocations and nil status",
@@ -1198,10 +1184,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 				nil,
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocation nil spec and status with eipAllocations",
@@ -1209,10 +1194,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				nil,
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations spec and status are equal",
@@ -1220,10 +1204,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations spec and status are NOT equal",
@@ -1231,10 +1214,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 				[]operatorv1.EIPAllocation{"eipalloc-aaaaaaaaaaaaaaaaa", "eipalloc-bbbbbbbbbbbbbbbbb"},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations spec and status are equal with different order",
@@ -1242,10 +1224,9 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy"},
 				[]operatorv1.EIPAllocation{"eipalloc-yyyyyyyyyyyyyyyyy", "eipalloc-xxxxxxxxxxxxxxxxx"},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionFalse,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionFalse,
 		},
 		{
 			name: "NLB LoadBalancerService, AWS EIPAllocations spec and status have extra items",
@@ -1253,15 +1234,14 @@ func Test_computeLoadBalancerProgressingStatus(t *testing.T) {
 				[]operatorv1.EIPAllocation{"eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-yyyyyyyyyyyyyyyyy", "eipalloc-zzzzzzzzzzzzz"},
 				[]operatorv1.EIPAllocation{"eipalloc-yyyyyyyyyyyyyyyyy", "eipalloc-xxxxxxxxxxxxxxxxx"},
 			),
-			service:                  &corev1.Service{},
-			awsEIPAllocationsEnabled: true,
-			platformStatus:           awsPlatformStatus,
-			expectStatus:             operatorv1.ConditionTrue,
+			service:        &corev1.Service{},
+			platformStatus: awsPlatformStatus,
+			expectStatus:   operatorv1.ConditionTrue,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := computeLoadBalancerProgressingStatus(test.ic, test.service, test.platformStatus, test.awsEIPAllocationsEnabled)
+			actual := computeLoadBalancerProgressingStatus(test.ic, test.service, test.platformStatus)
 			if actual.Status != test.expectStatus {
 				t.Errorf("expected status to be %s, got %s", test.expectStatus, actual.Status)
 			}
@@ -3144,7 +3124,7 @@ func Test_computeIngressUpgradeableCondition(t *testing.T) {
 					},
 				},
 			}
-			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true)
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus)
 			if err != nil {
 				t.Errorf("unexpected error from desiredLoadBalancerService: %v", err)
 				return
@@ -3166,7 +3146,7 @@ func Test_computeIngressUpgradeableCondition(t *testing.T) {
 				expectedStatus = operatorv1.ConditionTrue
 			}
 
-			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret, true)
+			actual := computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret)
 			if actual.Status != expectedStatus {
 				t.Errorf("expected Upgradeable to be %q, got %q", expectedStatus, actual.Status)
 			}
@@ -3254,7 +3234,7 @@ func Test_computeIngressEvaluationConditionsDetectedCondition(t *testing.T) {
 				},
 			}
 
-			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus, true)
+			wantSvc, service, err := desiredLoadBalancerService(ic, deploymentRef, platformStatus)
 			if err != nil {
 				t.Fatalf("unexpected error from desiredLoadBalancerService: %v", err)
 			}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -136,7 +136,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	gatewayAPIEnabled := featureGates.Enabled(features.FeatureGateGatewayAPI)
 	gatewayAPIControllerEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIController)
 	routeExternalCertificateEnabled := featureGates.Enabled(features.FeatureGateRouteExternalCertificate)
-	ingressControllerEIPAllocationsAWSEnabled := featureGates.Enabled(features.FeatureGateSetEIPForNLBIngressController)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
 	gcpCustomEndpointsEnabled := featureGates.Enabled(features.FeatureGateGCPCustomAPIEndpoints)
 
@@ -182,11 +181,10 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	}
 	// Create and register the ingress controller with the operator manager.
 	if _, err := ingresscontroller.New(mgr, ingresscontroller.Config{
-		Namespace:                                 config.Namespace,
-		IngressControllerImage:                    config.IngressControllerImage,
-		RouteExternalCertificateEnabled:           routeExternalCertificateEnabled,
-		IngressControllerEIPAllocationsAWSEnabled: ingressControllerEIPAllocationsAWSEnabled,
-		IngressControllerDCMEnabled:               ingressControllerDCMEnabled,
+		Namespace:                       config.Namespace,
+		IngressControllerImage:          config.IngressControllerImage,
+		RouteExternalCertificateEnabled: routeExternalCertificateEnabled,
+		IngressControllerDCMEnabled:     ingressControllerDCMEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create ingress controller: %v", err)
 	}

--- a/test/e2e/lb_eip_test.go
+++ b/test/e2e/lb_eip_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
@@ -42,11 +41,6 @@ func TestAWSEIPAllocationsForNLB(t *testing.T) {
 	}
 	if infraConfig.Status.PlatformStatus.Type != configv1.AWSPlatformType {
 		t.Skipf("test skipped on platform %q", infraConfig.Status.PlatformStatus.Type)
-	}
-	if enabled, err := isFeatureGateEnabled(features.FeatureGateSetEIPForNLBIngressController); err != nil {
-		t.Fatalf("failed to get feature gate: %v", err)
-	} else if !enabled {
-		t.Skipf("test skipped because %q feature gate is not enabled", features.FeatureGateSetEIPForNLBIngressController)
 	}
 
 	// Create an ingress controller with EIPs mentioned in the Ingress Controller CR.
@@ -190,11 +184,6 @@ func TestUnmanagedAWSEIPAllocations(t *testing.T) {
 	}
 	if infraConfig.Status.PlatformStatus.Type != configv1.AWSPlatformType {
 		t.Skipf("test skipped on platform: %q", infraConfig.Status.PlatformStatus.Type)
-	}
-	if enabled, err := isFeatureGateEnabled(features.FeatureGateSetEIPForNLBIngressController); err != nil {
-		t.Fatalf("failed to get feature gate: %v", err)
-	} else if !enabled {
-		t.Skipf("test skipped because %q feature gate is not enabled", features.FeatureGateSetEIPForNLBIngressController)
 	}
 
 	// Next, create a NLB IngressController.


### PR DESCRIPTION
This change removes the Feature Gate SetEIPForNLBIngressController since it is enabled on Openshift since version v4.18.0.

Additionally it fixes all of the tests to assume that there is no feature gate anymore, and removes tests that asserts that this feature gate is disabled.

This feature is now available by default to any users and does not need the Feature gate to be explicitly enabled.