### PR TITLE
OSSM-10865: set trustBundleName in Istio global values

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 )
 
@@ -69,7 +68,7 @@ func Test_Reconcile(t *testing.T) {
 						},
 						IstioNamespace:    ptr.To("openshift-ingress"),
 						PriorityClassName: ptr.To("system-cluster-critical"),
-						TrustBundleName:   ptr.To(controller.OpenShiftGatewayCARootCertName),
+						TrustBundleName:   ptr.To("openshift-gw-ca-root-cert"),
 					},
 					Pilot: &sailv1.PilotConfig{
 						Cni: &sailv1.CNIUsageConfig{

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 )
 
@@ -68,6 +69,7 @@ func Test_Reconcile(t *testing.T) {
 						},
 						IstioNamespace:    ptr.To("openshift-ingress"),
 						PriorityClassName: ptr.To("system-cluster-critical"),
+						TrustBundleName:   ptr.To(controller.OpenShiftGatewayCARootCertName),
 					},
 					Pilot: &sailv1.PilotConfig{
 						Cni: &sailv1.CNIUsageConfig{

--- a/pkg/operator/controller/gatewayclass/istio.go
+++ b/pkg/operator/controller/gatewayclass/istio.go
@@ -166,6 +166,7 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, ist
 					},
 					IstioNamespace:    ptr.To(controller.DefaultOperandNamespace),
 					PriorityClassName: ptr.To(systemClusterCriticalPriorityClassName),
+					TrustBundleName:   ptr.To(controller.OpenShiftGatewayCARootCertName),
 				},
 				Pilot: &sailv1.PilotConfig{
 					Cni: &sailv1.CNIUsageConfig{


### PR DESCRIPTION
Sets trustBundleName in order to customize the
name of the configmap containing the CA cert so
it doesn't clash with a standalone OSSM instance.

Follow-up to #1243.