### PR TITLE
OCPBUGS-62627: cluster operator ingress reported Progressing=True wit…

### DIFF
--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -47,7 +48,24 @@ type expectedCondition struct {
 	// or else the condition is not checked.
 	ifConditionsTrue []string
 	gracePeriod      time.Duration
+	// ignoreReasons specifies condition reasons that should be ignored when
+	// determining if the expected condition is met. This allows distinguishing
+	// between significant state changes (configuration rollouts) and transient
+	// infrastructure events (node reboots, pod restarts).
+	// ignoreReasons are only consulted when the condition exists and its Status
+	// differs from expected.status; they are not consulted if the condition is
+	// entirely missing.
+	ignoreReasons []string
 }
+
+const (
+	ReasonDeploymentRollingOut = "DeploymentRollingOut"
+	ReasonNotRollingOut        = "DeploymentNotRollingOut"
+	ReasonPodsStarting         = "PodsStarting"
+	ReasonReplicasStabilizing  = "ReplicasStabilizing"
+
+	deploymentNewRSAvailableReason = "NewReplicaSetAvailable"
+)
 
 // syncIngressControllerStatus computes the current status of ic and
 // updates status upon any changes since last sync.
@@ -332,7 +350,7 @@ func checkConditions(expectedConds []expectedCondition, conditions []operatorv1.
 		if !haveCondition {
 			continue
 		}
-		if condition.Status == expected.status {
+		if condition.Status == expected.status || slices.Contains(expected.ignoreReasons, condition.Reason) {
 			continue
 		}
 		failedPredicates := false
@@ -505,12 +523,13 @@ func computeDeploymentReplicasAllAvailableCondition(deployment *appsv1.Deploymen
 // of expected or available replicas.
 // See Reference: https://github.com/kubernetes/kubectl/blob/master/pkg/polymorphichelpers/rollout_status.go
 func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operatorv1.OperatorCondition {
-	// If have replicas is less than want replicas, then we are waiting for replicas to be updated.
+	// If updated replicas is less than desired replicas, then we are waiting for updated replicas to be created.
 	if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d out of %d new replica(s) have been updated...\n",
 				deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas),
@@ -518,10 +537,11 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	}
 	// If have replicas greater than updated replicas, then we are waiting for old replicas to terminate.
 	if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d old replica(s) are pending termination...\n",
 				deployment.Status.Replicas-deployment.Status.UpdatedReplicas),
@@ -529,10 +549,11 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	}
 	// If available replicas less than updated replicas, then we are waiting for updated replicas to become available.
 	if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d of %d updated replica(s) are available...\n",
 				deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas),
@@ -542,9 +563,58 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	return operatorv1.OperatorCondition{
 		Type:    IngressControllerDeploymentRollingOutConditionType,
 		Status:  operatorv1.ConditionFalse,
-		Reason:  "DeploymentNotRollingOut",
+		Reason:  ReasonNotRollingOut,
 		Message: "Deployment is not actively rolling out",
 	}
+}
+
+// computeDeploymentRollingOutReason computes the Reason for the DeploymentRollingOut
+// condition by checking the deployment's "NewReplicaSetAvailable" condition, pod
+// replica counts, and generation metadata to distinguish between an ingress
+// controller configuration rollout and an infrastructure-driven change (e.g.
+// node reboot, scale up/down).
+func computeDeploymentRollingOutReason(deployment *appsv1.Deployment) string {
+	// Check if the deployment has the "NewReplicaSetAvailable" condition.
+	// This indicates that Kubernetes has successfully completed a rollout.
+	hasNewReplicaSetAvailable := false
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing &&
+			cond.Status == corev1.ConditionTrue &&
+			cond.Reason == deploymentNewRSAvailableReason {
+			hasNewReplicaSetAvailable = true
+			break
+		}
+	}
+
+	var (
+		wantReplicas      = int32(1)
+		haveReplicas      = deployment.Status.Replicas
+		updatedReplicas   = deployment.Status.UpdatedReplicas
+		availableReplicas = deployment.Status.AvailableReplicas
+	)
+
+	if deployment.Spec.Replicas != nil {
+		wantReplicas = *deployment.Spec.Replicas
+	}
+
+	currentGen := deployment.Generation
+	observedGen := deployment.Status.ObservedGeneration
+	if hasNewReplicaSetAvailable && currentGen == observedGen && updatedReplicas == wantReplicas {
+		if haveReplicas != wantReplicas {
+			return ReasonReplicasStabilizing
+		}
+	}
+
+	// If rollout was previously completed and now only availability is lagging,
+	// treat it as infrastructure-driven pod startup.
+	if hasNewReplicaSetAvailable &&
+		currentGen == observedGen &&
+		updatedReplicas == wantReplicas &&
+		haveReplicas == wantReplicas &&
+		availableReplicas < wantReplicas {
+		return ReasonPodsStarting
+	}
+	return ReasonDeploymentRollingOut
 }
 
 // computeIngressDegradedCondition computes the ingresscontroller's "Degraded"
@@ -595,12 +665,7 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition, 
 	// Only check the default ingress controller for the canary
 	// success status condition.
 	if icName == manifests.DefaultIngressControllerName {
-		canaryCond := struct {
-			condition        string
-			status           operatorv1.ConditionStatus
-			ifConditionsTrue []string
-			gracePeriod      time.Duration
-		}{
+		canaryCond := expectedCondition{
 			condition:   IngressControllerCanaryCheckSuccessConditionType,
 			status:      operatorv1.ConditionTrue,
 			gracePeriod: time.Second * 60,
@@ -767,6 +832,12 @@ func computeIngressProgressingCondition(conditions []operatorv1.OperatorConditio
 		{
 			condition: IngressControllerDeploymentRollingOutConditionType,
 			status:    operatorv1.ConditionFalse,
+			// Ignore infrastructure-driven deployment rollouts when computing
+			// the IngressController's Progressing condition.
+			ignoreReasons: []string{
+				ReasonReplicasStabilizing, // Node reboots, pod evictions
+				ReasonPodsStarting,        // Pods restarting after infrastructure events
+			},
 		},
 	}
 

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -504,6 +504,9 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 		replicasAvailable     *int32
 		expectStatus          operatorv1.ConditionStatus
 		expectMessageContains string
+		expectReasonContains  string
+		differentGeneration   bool
+		hasNewReplicaSet      bool
 	}{
 		{
 			name:                  "Router pod replicas not rolling out",
@@ -515,7 +518,7 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 			expectMessageContains: "Deployment is not actively rolling out",
 		},
 		{
-			name:                  "Router pod replicas have/updated < want",
+			name:                  "Router pod replicas have/updated < replicasWanted",
 			expectStatus:          operatorv1.ConditionTrue,
 			replicasHave:          pointer.Int32(1),
 			replicasWanted:        pointer.Int32(4),
@@ -551,7 +554,7 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 			expectMessageContains: "1 of 4 updated replica(s) are available",
 		},
 		{
-			name:                  "Router pods replicas available < updated, but want is nil",
+			name:                  "Router pods replicas available < updated, but replicasWanted is nil",
 			expectStatus:          operatorv1.ConditionTrue,
 			replicasHave:          pointer.Int32(4),
 			replicasWanted:        nil,
@@ -560,7 +563,7 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 			expectMessageContains: "1 of 4 updated replica(s) are available",
 		},
 		{
-			name:                  "Router pods replicas equal but want is nil",
+			name:                  "Router pods replicas equal but replicasWanted is nil",
 			expectStatus:          operatorv1.ConditionFalse,
 			replicasHave:          pointer.Int32(1),
 			replicasWanted:        nil,
@@ -577,6 +580,66 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 			replicasAvailable:     pointer.Int32(2),
 			expectMessageContains: "Deployment is not actively rolling out",
 		},
+		{
+			name:                  "Router pod replicas have > updated, generation is equal to observedGeneration and NewReplicaSet created",
+			expectStatus:          operatorv1.ConditionTrue,
+			replicasHave:          pointer.Int32(3),
+			replicasWanted:        pointer.Int32(1),
+			replicasUpdated:       pointer.Int32(1),
+			replicasAvailable:     pointer.Int32(1),
+			expectMessageContains: "2 old replica(s) are pending termination",
+			expectReasonContains:  ReasonReplicasStabilizing,
+			differentGeneration:   false,
+			hasNewReplicaSet:      true,
+		},
+		{
+			name:                  "Router pod replicas have/updated < replicasWanted, generation is equal to observedGeneration and NewReplicaSet created",
+			expectStatus:          operatorv1.ConditionTrue,
+			replicasHave:          pointer.Int32(4),
+			replicasWanted:        pointer.Int32(4),
+			replicasUpdated:       pointer.Int32(4),
+			replicasAvailable:     pointer.Int32(1),
+			expectMessageContains: "Waiting for router deployment rollout to finish: 1 of 4 updated replica(s) are available...\n",
+			expectReasonContains:  ReasonPodsStarting,
+			differentGeneration:   false,
+			hasNewReplicaSet:      true,
+		},
+		{
+			name:                  "Config change rollout with old replicas still terminating and no NewReplicaSetAvailable",
+			expectStatus:          operatorv1.ConditionTrue,
+			replicasHave:          pointer.Int32(3),
+			replicasWanted:        pointer.Int32(1),
+			replicasUpdated:       pointer.Int32(1),
+			replicasAvailable:     pointer.Int32(1),
+			expectMessageContains: "2 old replica(s) are pending termination",
+			expectReasonContains:  ReasonDeploymentRollingOut,
+			differentGeneration:   false,
+			hasNewReplicaSet:      false,
+		},
+		{
+			name:                  "Config change rollout with new pods not yet available and no NewReplicaSetAvailable",
+			expectStatus:          operatorv1.ConditionTrue,
+			replicasHave:          pointer.Int32(2),
+			replicasWanted:        pointer.Int32(2),
+			replicasUpdated:       pointer.Int32(2),
+			replicasAvailable:     pointer.Int32(0),
+			expectMessageContains: "0 of 2 updated replica(s) are available",
+			expectReasonContains:  ReasonDeploymentRollingOut,
+			differentGeneration:   false,
+			hasNewReplicaSet:      false,
+		},
+		{
+			name:                  "Active config rollout with NewReplicaSetAvailable from previous rollout should still return DeploymentRollingOut",
+			expectStatus:          operatorv1.ConditionTrue,
+			replicasHave:          pointer.Int32(3),
+			replicasWanted:        pointer.Int32(1),
+			replicasUpdated:       pointer.Int32(1),
+			replicasAvailable:     pointer.Int32(1),
+			expectMessageContains: "2 old replica(s) are pending termination",
+			expectReasonContains:  ReasonDeploymentRollingOut,
+			differentGeneration:   true,
+			hasNewReplicaSet:      true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -590,12 +653,31 @@ func Test_computeDeploymentRollingOutCondition(t *testing.T) {
 					UpdatedReplicas:   *test.replicasUpdated,
 				},
 			}
+			if test.differentGeneration {
+				routerDeploy.ObjectMeta.Generation = 2
+				routerDeploy.Status.ObservedGeneration = 1
+			} else {
+				routerDeploy.ObjectMeta.Generation = 1
+				routerDeploy.Status.ObservedGeneration = 1
+			}
+			if test.hasNewReplicaSet {
+				routerDeploy.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: deploymentNewRSAvailableReason,
+					},
+				}
+			}
 			actual := computeDeploymentRollingOutCondition(routerDeploy)
 			if actual.Status != test.expectStatus {
 				t.Errorf("expected status to be %s, got %s", test.expectStatus, actual.Status)
 			}
 			if len(test.expectMessageContains) != 0 && !strings.Contains(actual.Message, test.expectMessageContains) {
 				t.Errorf("expected message to include %q, got %q", test.expectMessageContains, actual.Message)
+			}
+			if len(test.expectReasonContains) != 0 && !strings.Contains(actual.Reason, test.expectReasonContains) {
+				t.Errorf("expected reason to include %q, got %q", test.expectReasonContains, actual.Reason)
 			}
 		})
 	}
@@ -1731,6 +1813,60 @@ func Test_computeIngressProgressingCondition(t *testing.T) {
 				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionFalse},
 				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue},
 				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue},
+		},
+		{
+			description: "load balancer is not progressing, but unmanaged load balancer type and router deployment is rolling out due to node reboot (pods starting)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionFalse},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonPodsStarting},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "load balancer is progressing, but unmanaged load balancer type and router deployment is rolling out due to node reboot (pods starting)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionTrue},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonPodsStarting},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "load balancer and unmanaged load balancer are progressing, but router deployment is rolling out due to node reboot (pods starting)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionTrue},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonPodsStarting},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue},
+		},
+		{
+			description: "load balancer is not progressing, but unmanaged load balancer type and router deployment is rolling out due to node reboot (replicas stabilizing)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionFalse},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonReplicasStabilizing},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "load balancer is progressing, but unmanaged load balancer type and router deployment is rolling out due to node reboot (replicas stabilizing)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionTrue},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonReplicasStabilizing},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+			},
+			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
+		},
+		{
+			description: "load balancer and unmanaged load balancer are progressing, but router deployment is rolling out due to node reboot (replicas stabilizing)",
+			conditions: []operatorv1.OperatorCondition{
+				{Type: IngressControllerLoadBalancerProgressingConditionType, Status: operatorv1.ConditionTrue},
+				{Type: IngressControllerDeploymentRollingOutConditionType, Status: operatorv1.ConditionTrue, Reason: ReasonReplicasStabilizing},
+				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
 			},
 			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionTrue},
 		},
@@ -3935,6 +4071,108 @@ func Test_clearIngressControllerInactiveAWSLBTypeParametersStatus(t *testing.T) 
 			}
 			clearIngressControllerInactiveAWSLBTypeParametersStatus(awsPlatformStatus, ic, tc.service)
 			assert.Equal(t, tc.expectICStatus, ic.Status)
+		})
+	}
+}
+
+func Test_checkConditions(t *testing.T) {
+	type conditions struct {
+		expectedConds []expectedCondition
+		conditions    []operatorv1.OperatorCondition
+	}
+	testCases := []struct {
+		description      string
+		conditions       conditions
+		wantGrace        []*operatorv1.OperatorCondition
+		wantDegraded     []*operatorv1.OperatorCondition
+		wantRequeueAfter time.Duration
+	}{
+		// expected condition present and matches status -> no grace, no degraded
+		{
+			description: "expected condition matches existing status",
+			conditions: conditions{
+				expectedConds: []expectedCondition{
+					{condition: IngressControllerDeploymentAvailableConditionType, status: operatorv1.ConditionTrue},
+				},
+				conditions: []operatorv1.OperatorCondition{
+					{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
+				},
+			},
+		},
+		// expected condition present but reason is ignored -> no grace, no degraded
+		{
+			description: "condition differs but reason is ignored",
+			conditions: conditions{
+				expectedConds: []expectedCondition{
+					{condition: IngressControllerDeploymentAvailableConditionType, status: operatorv1.ConditionTrue, ignoreReasons: []string{"IgnoredReason"}},
+				},
+				conditions: []operatorv1.OperatorCondition{
+					{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionFalse, Reason: "IgnoredReason"},
+				},
+			},
+		},
+		// predicate not satisfied -> check skipped -> no grace, no degraded
+		{
+			description: "predicate not satisfied skips check",
+			conditions: conditions{
+				expectedConds: []expectedCondition{
+					{condition: operatorv1.DNSReadyIngressConditionType, status: operatorv1.ConditionTrue, ifConditionsTrue: []string{
+						operatorv1.LoadBalancerManagedIngressConditionType,
+						operatorv1.LoadBalancerReadyIngressConditionType,
+						operatorv1.DNSManagedIngressConditionType,
+					}},
+				},
+				conditions: []operatorv1.OperatorCondition{
+					{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionFalse},
+					{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse}, // predicate not met
+					{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+					{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
+				},
+			},
+		},
+		// expected condition not present -> skipped -> no grace, no degraded
+		{
+			description: "expected condition missing is skipped",
+			conditions: conditions{
+				expectedConds: []expectedCondition{
+					{condition: operatorv1.LoadBalancerReadyIngressConditionType, status: operatorv1.ConditionTrue, ifConditionsTrue: []string{operatorv1.LoadBalancerManagedIngressConditionType}},
+				},
+				conditions: []operatorv1.OperatorCondition{
+					{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
+				},
+			},
+		},
+		// multiple expected where all match or are skipped -> no outputs
+		{
+			description: "multiple expected, all matched or skipped",
+			conditions: conditions{
+				expectedConds: []expectedCondition{
+					{condition: IngressControllerDeploymentAvailableConditionType, status: operatorv1.ConditionTrue},
+					{condition: operatorv1.DNSReadyIngressConditionType, status: operatorv1.ConditionTrue, ifConditionsTrue: []string{operatorv1.DNSManagedIngressConditionType}},
+					{condition: operatorv1.LoadBalancerReadyIngressConditionType, status: operatorv1.ConditionTrue, ifConditionsTrue: []string{operatorv1.LoadBalancerManagedIngressConditionType}},
+				},
+				conditions: []operatorv1.OperatorCondition{
+					{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
+					{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionFalse}, // will be skipped because predicate not met
+					{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+					{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue}, // will be skipped because predicate not met
+					{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+				},
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.description, func(t *testing.T) {
+			graceConditions, degradedConditions, requeueAfter := checkConditions(tt.conditions.expectedConds, tt.conditions.conditions)
+			if diff := cmp.Diff(tt.wantGrace, graceConditions, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("graceConditions mismatch (-expected +got):\n%s\nfor checkConditions(%v, %v)", diff, tt.conditions.expectedConds, tt.conditions.conditions)
+			}
+			if diff := cmp.Diff(tt.wantDegraded, degradedConditions, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("degradedConditions mismatch (-expected +got):\n%s\nfor checkConditions(%v, %v)", diff, tt.conditions.expectedConds, tt.conditions.conditions)
+			}
+			if tt.wantRequeueAfter != requeueAfter {
+				t.Errorf("expected %v, got %v for checkConditions(%v, %v)", tt.wantRequeueAfter, requeueAfter, tt.conditions.expectedConds, tt.conditions.conditions)
+			}
 		})
 	}
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -78,6 +78,7 @@ var (
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
 		{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionFalse},
+		{Type: operatorv1.OperatorStatusTypeProgressing, Status: operatorv1.ConditionFalse},
 	}
 	availableConditionsForIngressControllerWithNodePort = []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},


### PR DESCRIPTION
…h reason=Reconciling for a node reboot

This PR will avoid Cluster Ingress Operator reporting `Progressing=True` condition if there is a node reboot or scale up as per Cluster Operator new requirement ([link](https://github.com/openshift/api/blob/61248d910ff74aef020492922d14e6dadaba598b/config/v1/types_cluster_operator.go#L163-L164)).

The Cluster Ingress Operator will continue to report `DeploymentRollingOut=true` condition with a different `Reason` if there is a node reboot or scale up and we will exclude these reasons (`ReplicasStabilizing` and `PodsStarting`) from the ones causing the operator `Progressing=True` condition.

In order to detect the a Deployment has been fully rolled out in the past we will use `Deployment` condition `Progressing` with reason `NewReplicaSetAvailable` as similarly done in library-go (see [PR](https://github.com/openshift/library-go/pull/2034))