### PR TITLE
OCPBUGS-85115, NE-2203: Add PrometheusRule for Gateway API

### DIFF
--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -85,4 +85,30 @@ spec:
             summary: Route owned by an Ingress no longer managed
             description: "This alert fires when there is a Route owned by an unmanaged Ingress."
             message: "Route {{ $labels.namespace }}/{{ $labels.name }} is owned by an unmanaged Ingress."
-
+    - name: gateway-api-telemetry.rules
+      rules:
+        - record: openshift:gateway_api_usage:count
+          expr: |
+            (
+              sum by(gateway_class_type) (
+                label_replace(
+                  (
+                    kube_customresource_gateway_info{programmed="True"}
+                    and on(gateway_class) kube_customresource_gateway_class_info{accepted="True", controller="openshift.io/gateway-controller/v1"}
+                  ),
+                  "gateway_class_type", "openshift", "", ""
+                )
+              )
+            )
+            or
+            (
+              sum by(gateway_class_type) (
+                label_replace(
+                  (
+                    kube_customresource_gateway_info{programmed="True"}
+                    and on(gateway_class) kube_customresource_gateway_class_info{accepted="True", controller!="openshift.io/gateway-controller/v1"}
+                  ),
+                  "gateway_class_type", "not-openshift", "", ""
+                )
+              )
+            )


### PR DESCRIPTION
This PR adds a PromtheusRule to collect the usage of Gateway on an Openshift cluster, based on the GatewayClass. It reduces the metric to:
* Gateways that are accepted
* Tags by the GatewayClass (openshift/not-openshift)

As the PrometheusRule can be added without any caveat to the cluster (eg.: even if no Gateway is enabled), it is being added as its own rule, but as part of CIO installation.

This should be merged after https://github.com/openshift/cluster-monitoring-operator/pull/2734