### PR TITLE
NE-1334: Enhancement to add operator channel when creating gatewayclass

### DIFF
--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -285,9 +285,11 @@ func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv
 	gatewayClass := buildGatewayClass(name, controllerName)
 	customCatalog := os.Getenv("CUSTOM_CATALOG_SOURCE")
 	ossmVersion := os.Getenv("CUSTOM_OSSM_VERSION")
-	if customCatalog != "" && ossmVersion != "" {
+	ossmChannel := os.Getenv("CUSTOM_OSSM_CHANNEL")
+	if customCatalog != "" && ossmVersion != "" && ossmChannel != "" {
 		gatewayClass.Annotations = map[string]string{
 			"unsupported.do-not-use.openshift.io/ossm-catalog": customCatalog,
+			"unsupported.do-not-use.openshift.io/ossm-channel": ossmChannel,
 			"unsupported.do-not-use.openshift.io/ossm-version": ossmVersion,
 		}
 	}


### PR DESCRIPTION
Update the ossm script to also include the ossm channel that it is found in

```
--- PASS: TestGatewayAPI (1421.80s)
    --- PASS: TestGatewayAPI/testGatewayAPIResources (49.85s)
    --- PASS: TestGatewayAPI/testGatewayAPIObjects (659.57s)
    --- PASS: TestGatewayAPI/testGatewayAPIManualDeployment (10.53s)
    --- PASS: TestGatewayAPI/testGatewayAPIIstioInstallation (14.46s)
    --- PASS: TestGatewayAPI/testGatewayAPIDNS (78.79s)
        --- PASS: TestGatewayAPI/testGatewayAPIDNS/multipleGatewaysSameListenerHostname (52.81s)
        --- PASS: TestGatewayAPI/testGatewayAPIDNS/gatewayListenersWithOverlappingHostname (25.80s)
    --- PASS: TestGatewayAPI/testGatewayAPIDNSListenerUpdate (388.98s)
    --- PASS: TestGatewayAPI/testGatewayAPIDNSListenerWithNoHostname (63.43s)
    --- PASS: TestGatewayAPI/testGatewayAPIResourcesProtection (87.57s)
        --- PASS: TestGatewayAPI/testGatewayAPIResourcesProtection/Ingress_operator_service_account_required (11.97s)
        --- PASS: TestGatewayAPI/testGatewayAPIResourcesProtection/Pod_binding_required (12.26s)
    --- PASS: TestGatewayAPI/testGatewayAPIRBAC (0.59s)
    --- PASS: TestGatewayAPI/testOperatorDegradedCondition (63.61s)
PASS
PASS github.com/openshift/cluster-ingress-operator/test/e2e	1423.645s
```