### PR TITLE
CORS-4229: Revert "dns/gcp: Allow configuring custom endpoints"

### DIFF
--- a/pkg/dns/gcp/provider.go
+++ b/pkg/dns/gcp/provider.go
@@ -31,30 +31,13 @@ type Provider struct {
 }
 
 type Config struct {
-	Project                   string
-	UserAgent                 string
-	CredentialsJSON           []byte
-	Endpoints                 []configv1.GCPServiceEndpoint
-	GCPCustomEndpointsEnabled bool
+	Project         string
+	UserAgent       string
+	CredentialsJSON []byte
 }
 
 func New(config Config) (*Provider, error) {
-	options := []option.ClientOption{
-		option.WithCredentialsJSON(config.CredentialsJSON),
-		option.WithUserAgent(config.UserAgent),
-	}
-	if config.GCPCustomEndpointsEnabled {
-		for _, endpoint := range config.Endpoints {
-			if endpoint.Name == configv1.GCPServiceEndpointNameDNS {
-				// There should be at most 1 endpoint override per service. If there
-				// is more than one, only use the first instance.
-				options = append(options, option.WithEndpoint(endpoint.URL))
-				break
-			}
-		}
-	}
-
-	dnsService, err := gdnsv1.NewService(context.TODO(), options...)
+	dnsService, err := gdnsv1.NewService(context.TODO(), option.WithCredentialsJSON(config.CredentialsJSON), option.WithUserAgent(config.UserAgent))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -111,9 +111,6 @@ type Config struct {
 	DNSRecordNamespaces          []string
 	OperatorReleaseVersion       string
 	AzureWorkloadIdentityEnabled bool
-	// GCPCustomEndpointsEnabled indicates whether the "GCPCustomAPIEndpoints"
-	// feature gate is enabled.
-	GCPCustomEndpointsEnabled bool
 }
 
 type reconciler struct {
@@ -698,11 +695,9 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 		dnsProvider = provider
 	case configv1.GCPPlatformType:
 		provider, err := gcpdns.New(gcpdns.Config{
-			Project:                   platformStatus.GCP.ProjectID,
-			CredentialsJSON:           creds.Data["service_account.json"],
-			UserAgent:                 userAgent,
-			Endpoints:                 platformStatus.GCP.ServiceEndpoints,
-			GCPCustomEndpointsEnabled: r.config.GCPCustomEndpointsEnabled,
+			Project:         platformStatus.GCP.ProjectID,
+			CredentialsJSON: creds.Data["service_account.json"],
+			UserAgent:       userAgent,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create GCP DNS provider: %v", err)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -137,7 +137,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	gatewayAPIControllerEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIController)
 	routeExternalCertificateEnabled := featureGates.Enabled(features.FeatureGateRouteExternalCertificate)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
-	gcpCustomEndpointsEnabled := featureGates.Enabled(features.FeatureGateGCPCustomAPIEndpoints)
 
 	cv, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
@@ -269,7 +268,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		},
 		OperatorReleaseVersion:       config.OperatorReleaseVersion,
 		AzureWorkloadIdentityEnabled: azureWorkloadIdentityEnabled,
-		GCPCustomEndpointsEnabled:    gcpCustomEndpointsEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create dns controller: %v", err)
 	}


### PR DESCRIPTION
This reverts commit 95b36d0270996954500ee1840203c305b66f5431.