### PR TITLE
OCPBUGS-64675: Fix variable shadowing in testGatewayAPIDNS e2e

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -547,10 +547,10 @@ func testGatewayAPIDNS(t *testing.T) {
 			// Create gateways
 			for _, gateway := range tc.createGateways {
 				createdGateway, err := createGatewayWithListeners(t, gatewayClass, gateway.gatewayName, gateway.namespace, gateway.listeners)
-				gateways = append(gateways, createdGateway)
 				if err != nil {
 					t.Fatalf("failed to create gateway %s: %v", gateway.gatewayName, err)
 				}
+				gateways = append(gateways, createdGateway)
 			}
 
 			t.Cleanup(func() {
@@ -565,9 +565,9 @@ func testGatewayAPIDNS(t *testing.T) {
 			})
 
 			for _, gateway := range gateways {
-				gateway, err := assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, gateway.Name)
+				_, err := assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, gateway.Name)
 				if err != nil {
-					t.Errorf("Failed to create %s gateway: %v", gateway.Name, err)
+					t.Fatalf("failed to accept/program gateway %s: %v", gateway.Name, err)
 				}
 			}
 


### PR DESCRIPTION
Previously `testGatewayAPIDNS` e2e test could panic with `runtime error: invalid memory address or nil pointer dereference` due to `gateway` variable shadowing.

Note: `assertGatewaySuccessful` function already retries when getting the Gateway CR.

* test/e2e/gateway_api_test.go: (testGatewayAPIDNS): Fix `gatewya` variable shadowing in the loop, which was causing a `runtime error: invalid memory address or nil pointer dereference`.