### PR TITLE
NE-2233: Bump to OSSM 3.2.0 and Istio 1.27.3

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -35,8 +35,8 @@ const (
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	defaultGatewayAPIOperatorCatalog = "redhat-operators"
 	defaultGatewayAPIOperatorChannel = "stable"
-	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.1.0"
-	defaultIstioVersion              = "v1.26.2"
+	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.2.0"
+	defaultIstioVersion              = "v1.27.3"
 )
 
 type StartOptions struct {

--- a/hack/gatewayapi-conformance.sh
+++ b/hack/gatewayapi-conformance.sh
@@ -56,9 +56,9 @@ go mod vendor
 # because the AWS ELB needs an extra ~60s for DNS propagation.  See
 # <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/best-practices-dns.html#DNS_change_propagation>.
 # Also, GRPCRouteListenerHostnameMatching tests are taking longer than 150s to converge to passing.
-sed -i -e '/MaxTimeToConsistency:/ s/30/180/' conformance/utils/config/timeout.go
+sed -i -e '/MaxTimeToConsistency:/ s/30/360/' conformance/utils/config/timeout.go
 
 SUPPORTED_FEATURES="Gateway,GRPCRoute,HTTPRoute,ReferenceGrant,GatewayPort8080,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRouteResponseHeaderModification,HTTPRoutePortRedirect,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors,HTTPRouteBackendProtocolH2C,HTTPRouteBackendProtocolWebSocket,HTTPRouteRequestPercentageMirror,HTTPRouteBackendRequestHeaderModification"
 
 echo "Start Gateway API Conformance Testing"
-go test ./conformance -v -timeout 20m -run TestConformance -args "--supported-features=${SUPPORTED_FEATURES}" "--gateway-class=${GATEWAYCLASS_NAME}"
+go test ./conformance -v -timeout 60m -run TestConformance -args "--supported-features=${SUPPORTED_FEATURES}" "--gateway-class=${GATEWAYCLASS_NAME}"

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -59,9 +59,9 @@ spec:
         - name: GATEWAY_API_OPERATOR_CHANNEL
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION
-          value: servicemeshoperator3.v3.1.0
+          value: servicemeshoperator3.v3.2.0
         - name: ISTIO_VERSION
-          value: v1.26.2
+          value: v1.27.3
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -88,9 +88,9 @@ spec:
             - name: GATEWAY_API_OPERATOR_CHANNEL
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION
-              value: servicemeshoperator3.v3.1.0
+              value: servicemeshoperator3.v3.2.0
             - name: ISTIO_VERSION
-              value: v1.26.2
+              value: v1.27.3
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
This PR bumps OSSM and istio versions to 3.2.0 and 1.27.3 respectively,

corresponding versions installed by ingress operator

```
gatewayClass
% oc get gc
NAME                CONTROLLER                           ACCEPTED   AGE
openshift-default   openshift.io/gateway-controller/v1   True       62m

OSSM operator CSV
% oc -n openshift-operators get csv                          
NAME                          DISPLAY                            VERSION   REPLACES                      PHASE
servicemeshoperator3.v3.2.0   Red Hat OpenShift Service Mesh 3   3.2.0     servicemeshoperator3.v3.1.3   Succeeded

Istio
% oc get istio
NAME                NAMESPACE           PROFILE   REVISIONS   READY   IN USE   ACTIVE REVISION     STATUS    VERSION   AGE
openshift-gateway   openshift-ingress             1           1       1        openshift-gateway   Healthy   v1.27.3   62m
```