### PR TITLE
OCPBUGS-65629: ensure canary daemon set uses its own service account.

### DIFF
--- a/pkg/manifests/assets/canary/service-account.yaml
+++ b/pkg/manifests/assets/canary/service-account.yaml
@@ -1,0 +1,11 @@
+# Account for the canary application. 
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ingress-canary
+  namespace: openshift-ingress-canary
+  annotations:
+    capability.openshift.io/name: Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -37,10 +37,11 @@ const (
 	MetricsRoleAsset               = "assets/router/metrics/role.yaml"
 	MetricsRoleBindingAsset        = "assets/router/metrics/role-binding.yaml"
 
-	CanaryNamespaceAsset = "assets/canary/namespace.yaml"
-	CanaryDaemonSetAsset = "assets/canary/daemonset.yaml"
-	CanaryServiceAsset   = "assets/canary/service.yaml"
-	CanaryRouteAsset     = "assets/canary/route.yaml"
+	CanaryNamespaceAsset      = "assets/canary/namespace.yaml"
+	CanaryDaemonSetAsset      = "assets/canary/daemonset.yaml"
+	CanaryServiceAsset        = "assets/canary/service.yaml"
+	CanaryRouteAsset          = "assets/canary/route.yaml"
+	CanaryServiceAccountAsset = "assets/canary/service-account.yaml"
 
 	GatewayClassCRDAsset            = "assets/gateway-api/gateway.networking.k8s.io_gatewayclasses.yaml"
 	GatewayCRDAsset                 = "assets/gateway-api/gateway.networking.k8s.io_gateways.yaml"
@@ -257,6 +258,14 @@ func CanaryRoute() *routev1.Route {
 		panic(err)
 	}
 	return route
+}
+
+func CanaryServiceAccount() *corev1.ServiceAccount {
+	serviceAccount, err := NewServiceAccount(MustAssetReader(CanaryServiceAccountAsset))
+	if err != nil {
+		panic(err)
+	}
+	return serviceAccount
 }
 
 func GatewayClassCRD() *apiextensionsv1.CustomResourceDefinition {

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -68,4 +68,6 @@ func TestManifests(t *testing.T) {
 
 	MustAsset(CustomResourceDefinitionManifest)
 	MustAsset(NamespaceManifest)
+
+	CanaryServiceAccount()
 }

--- a/pkg/operator/controller/canary/controller.go
+++ b/pkg/operator/controller/canary/controller.go
@@ -209,6 +209,13 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return result, fmt.Errorf("failed to get canary daemonset: %v", err)
 	}
 
+	haveSa, _, err := r.ensureCanaryServiceAccount(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to ensure canary service account: %w", err)
+	} else if !haveSa {
+		return result, fmt.Errorf("failed to get canary service account: %w", err)
+	}
+
 	trueVar := true
 	daemonsetRef := metav1.OwnerReference{
 		APIVersion: "apps/v1",

--- a/pkg/operator/controller/canary/daemonset.go
+++ b/pkg/operator/controller/canary/daemonset.go
@@ -145,6 +145,7 @@ func desiredCanaryDaemonSet(canaryImage string, certHash string) *appsv1.DaemonS
 
 	daemonset.Spec.Template.Spec.Containers[0].Image = canaryImage
 	daemonset.Spec.Template.Spec.Containers[0].Command = []string{"ingress-operator", CanaryHealthcheckCommand}
+	daemonset.Spec.Template.Spec.ServiceAccountName = controller.CanaryServiceAccountName().Name
 
 	if certHash != "" {
 		if daemonset.Spec.Template.Annotations == nil {
@@ -236,6 +237,11 @@ func canaryDaemonSetChanged(current, expected *appsv1.DaemonSet) (bool, *appsv1.
 		} else {
 			updated.Spec.Template.Annotations[CanaryServingCertHashAnnotation] = expectedHash
 		}
+		changed = true
+	}
+
+	if current.Spec.Template.Spec.ServiceAccountName != expected.Spec.Template.Spec.ServiceAccountName {
+		updated.Spec.Template.Spec.ServiceAccountName = expected.Spec.Template.Spec.ServiceAccountName
 		changed = true
 	}
 

--- a/pkg/operator/controller/canary/daemonset_test.go
+++ b/pkg/operator/controller/canary/daemonset_test.go
@@ -83,6 +83,13 @@ func Test_desiredCanaryDaemonSet(t *testing.T) {
 	if !cmp.Equal(tolerations, expectedTolerations) {
 		t.Errorf("expected daemonset tolerations to be %v, but got %v", expectedTolerations, tolerations)
 	}
+
+	serviceAccountName := daemonset.Spec.Template.Spec.ServiceAccountName
+	expectedServiceAccountName := controller.CanaryServiceAccountName()
+
+	if !cmp.Equal(serviceAccountName, expectedServiceAccountName.Name) {
+		t.Errorf("expected service account name to be %s, but got %s", serviceAccountName, expectedServiceAccountName.Name)
+	}
 }
 
 func Test_canaryDaemonsetChanged(t *testing.T) {
@@ -232,6 +239,13 @@ func Test_canaryDaemonsetChanged(t *testing.T) {
 					ds.Spec.Template.Annotations = map[string]string{}
 				}
 				ds.Spec.Template.Annotations[CanaryServingCertHashAnnotation] = "d34db33f"
+			},
+			expect: true,
+		},
+		{
+			description: "if canary service account name changes",
+			mutate: func(ds *appsv1.DaemonSet) {
+				ds.Spec.Template.Spec.ServiceAccountName = "default"
 			},
 			expect: true,
 		},

--- a/pkg/operator/controller/canary/service_account.go
+++ b/pkg/operator/controller/canary/service_account.go
@@ -1,0 +1,109 @@
+package canary
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ensureCanaryServiceAccount ensures the canary service account exists.
+func (r *reconciler) ensureCanaryServiceAccount(ctx context.Context) (bool, *corev1.ServiceAccount, error) {
+	desired := desiredCanaryServiceAccount()
+	haveSa, current, err := r.currentCanaryServiceAccount(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+
+	switch {
+	case !haveSa:
+		if err := r.createCanaryServiceAccount(ctx, desired); err != nil {
+			return false, nil, err
+		}
+		return r.currentCanaryServiceAccount(ctx)
+	case haveSa:
+		if updated, err := r.updateCanaryServiceAccount(ctx, current, desired); err != nil {
+			return true, current, err
+		} else if updated {
+			return r.currentCanaryServiceAccount(ctx)
+		}
+	}
+	return true, current, nil
+}
+
+// currentCanaryServiceAccount returns the current service account.
+func (r *reconciler) currentCanaryServiceAccount(ctx context.Context) (bool, *corev1.ServiceAccount, error) {
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := r.client.Get(ctx, controller.CanaryServiceAccountName(), serviceAccount); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, serviceAccount, nil
+}
+
+// createCanaryServiceAccount creates the given service account resource.
+func (r *reconciler) createCanaryServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount) error {
+	if err := r.client.Create(ctx, serviceAccount); err != nil {
+		return fmt.Errorf("failed to create canary service account %s/%s: %w", serviceAccount.Namespace, serviceAccount.Name, err)
+	}
+	log.Info("created canary service account", "namespace", serviceAccount.Namespace, "name", serviceAccount.Name)
+	return nil
+}
+
+// updateCanaryServiceAccount updates the canary ServiceAccount if an appropriate
+// change has been detected.
+func (r *reconciler) updateCanaryServiceAccount(ctx context.Context, current, desired *corev1.ServiceAccount) (bool, error) {
+	changed, updated := canaryServiceAccountChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(ctx, updated); err != nil {
+		return false, fmt.Errorf("failed to update canary service account %s/%s: %v", updated.Namespace, updated.Name, err)
+	}
+	log.Info("updated canary service account", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
+
+	return true, nil
+}
+
+// desiredCanaryServiceAccount returns the desired canary ServiceAccount
+// read in from manifests.
+func desiredCanaryServiceAccount() *corev1.ServiceAccount {
+	serviceAccount := manifests.CanaryServiceAccount()
+	name := controller.CanaryServiceAccountName()
+	serviceAccount.Name = name.Name
+	serviceAccount.Namespace = name.Namespace
+
+	serviceAccount.Labels = map[string]string{
+		// Associate the service account with the ingress canary controller.
+		manifests.OwningIngressCanaryCheckLabel: canaryControllerName,
+	}
+
+	return serviceAccount
+}
+
+// canaryServiceAccountChanged returns true if current and expected differ by the
+// service account's AutomountServiceAccountToken.
+func canaryServiceAccountChanged(current, expected *corev1.ServiceAccount) (bool, *corev1.ServiceAccount) {
+	if reflect.DeepEqual(current.AutomountServiceAccountToken, expected.AutomountServiceAccountToken) {
+		return false, nil
+	}
+
+	// Bring over changed field (AutomountServiceAccountToken)
+	// from expected to current.
+	// This way we do not bring over any unwanted changes.
+	currentCopy := current.DeepCopy()
+
+	currentCopy.AutomountServiceAccountToken = expected.AutomountServiceAccountToken
+
+	return true, currentCopy.DeepCopy()
+}

--- a/pkg/operator/controller/canary/service_account_test.go
+++ b/pkg/operator/controller/canary/service_account_test.go
@@ -1,0 +1,103 @@
+package canary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_desiredServiceAccount(t *testing.T) {
+	serviceAccount := desiredCanaryServiceAccount()
+
+	assert.Equal(t, serviceAccount.Name, "ingress-canary")
+
+	assert.Equal(t, serviceAccount.Namespace, "openshift-ingress-canary")
+
+	expectedLabels := map[string]string{
+		manifests.OwningIngressCanaryCheckLabel: canaryControllerName,
+	}
+
+	assert.Equal(t, serviceAccount.Labels, expectedLabels)
+}
+
+func Test_canaryServiceAccountChanged(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(*corev1.ServiceAccount)
+		expect      bool
+	}{
+		{
+			description: "if nothing changes",
+			mutate:      func(_ *corev1.ServiceAccount) {},
+			expect:      false,
+		},
+		{
+			description: "if secrets change",
+			mutate: func(sa *corev1.ServiceAccount) {
+				sa.Secrets = []corev1.ObjectReference{
+					{
+						Kind:      "foo",
+						FieldPath: "foo/bar",
+					},
+				}
+			},
+			expect: false,
+		},
+		{
+			description: "if image pull secrets change",
+			mutate: func(sa *corev1.ServiceAccount) {
+				sa.ImagePullSecrets = []corev1.LocalObjectReference{
+					{
+						Name: "foo",
+					},
+				}
+			},
+			expect: false,
+		},
+		{
+			description: "if auto mount service account token changes",
+			mutate: func(sa *corev1.ServiceAccount) {
+				val := true
+				if sa.AutomountServiceAccountToken == nil {
+					sa.AutomountServiceAccountToken = &val
+				} else {
+					val = *sa.AutomountServiceAccountToken
+					invertVal := !val
+					sa.AutomountServiceAccountToken = &invertVal
+				}
+			},
+			expect: true,
+		},
+		{
+			description: "if annotations change",
+			mutate: func(sa *corev1.ServiceAccount) {
+				sa.Annotations = map[string]string{
+					"foo": "bar",
+				}
+			},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			original := desiredCanaryServiceAccount()
+			mutated := original.DeepCopy()
+			tc.mutate(mutated)
+			if changed, updated := canaryServiceAccountChanged(original, mutated); changed != tc.expect {
+				t.Errorf("expected canaryServiceAccountChanged to be %t, but got %t", tc.expect, changed)
+			} else if changed {
+				if updatedChanged, _ := canaryServiceAccountChanged(original, updated); !updatedChanged {
+					t.Error("canaryServiceAccountChanged reported changes but did not make any update")
+				}
+				if changedAgain, _ := canaryServiceAccountChanged(mutated, updated); changedAgain {
+					t.Error("canaryServiceAccountChanged does not behave as a fixed point function")
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -303,6 +303,13 @@ func CanaryCertificateName() types.NamespacedName {
 	}
 }
 
+func CanaryServiceAccountName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: DefaultCanaryNamespace,
+		Name:      "ingress-canary",
+	}
+}
+
 func IngressClassName(ingressControllerName string) types.NamespacedName {
 	return types.NamespacedName{Name: "openshift-" + ingressControllerName}
 }


### PR DESCRIPTION
### What

- Ensure the canary daemon set uses its own service account, rather than the default service account.

### Why

- Using the default service account is a security issue. Using a bespoke service account ensures minimal permissions are given to the daemonset.

### How

- A service account has been created for the canary daemonset.
- A cluster role binding has been created which references an already existing `openshift-ingress-operator` cluster role.
- This cluster role binding is also attached to the service account for the canary daemon set.
- The reconciler now detects resource creation of the cluster role binding and service account.
- Tests have been made for the new changes.