### PR TITLE
[release-4.20] NO-JIRA: Add new NID team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ approvers:
   - Thealisyed
   - grzpiotrowski
   - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
   - knobunc
   - Miciah
@@ -22,6 +24,8 @@ reviewers:
   - Thealisyed
   - grzpiotrowski
   - rikatz
+  - davidesalerno
+  - bentito
 emeritus_approvers:
   - ironcladlou
   - pravisankar


### PR DESCRIPTION
This PR is a manual cherry pick of #1281 and #1278.

It adds the new NID team members to the OWNERS for release-4.20.