### PR TITLE
[release-4.18] NO-JIRA: Add new NID team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,9 @@ approvers:
   - gcs278
   - Thealisyed
   - grzpiotrowski
+  - rikatz
+  - davidesalerno
+  - bentito
 reviewers:
   - knobunc
   - Miciah
@@ -20,6 +23,9 @@ reviewers:
   - gcs278
   - Thealisyed
   - grzpiotrowski
+  - rikatz
+  - davidesalerno
+  - bentito
 emeritus_approvers:
   - ironcladlou
   - pravisankar


### PR DESCRIPTION
This PR is a manual cherry pick of https://github.com/openshift/cluster-ingress-operator/pull/1281, https://github.com/openshift/cluster-ingress-operator/pull/1278 and https://github.com/openshift/cluster-ingress-operator/pull/1259.

It adds the new NID team members to the OWNERS for release-4.18.