### PR TITLE
OCPBUGS-70211: Fix logging for unmanaged controllers

### DIFF
--- a/pkg/operator/controller/gateway-labeler/controller.go
+++ b/pkg/operator/controller/gateway-labeler/controller.go
@@ -50,7 +50,9 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		client:   mgr.GetClient(),
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	options := controller.Options{Reconciler: reconciler}
+	options.DefaultFromConfig(mgr.GetControllerOptions())
+	c, err := controller.NewUnmanaged(controllerName, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -61,7 +61,9 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		cache:    operatorCache,
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	options := controller.Options{Reconciler: reconciler}
+	options.DefaultFromConfig(mgr.GetControllerOptions())
+	c, err := controller.NewUnmanaged(controllerName, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -87,7 +87,9 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		cache:    operatorCache,
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	options := controller.Options{Reconciler: reconciler}
+	options.DefaultFromConfig(mgr.GetControllerOptions())
+	c, err := controller.NewUnmanaged(controllerName, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set default values, such as the logger, in the controller options for unmanaged controllers, namely the gateway-labeler, gateway-service-dns, and gatewayclass controllers.

Before controller-runtime v0.21.0, controller-runtime implicitly set default values for controller options for managed and unmanaged controllers alike.  Controller-runtime internally used the `DefaultFromConfig` method to do so.  Since controller-runtime v0.21.0, these default values are not implicitly set for unmanaged controllers (see https://github.com/kubernetes-sigs/controller-runtime/commit/d9ff283bfe844e8e3806eb2d264b2a6fa7815f66).  In particular, this means that the logger is not initialized, and so the controller initialization and any reconciliation errors are not logged.  This PR explicitly sets default values by calling `DefaultFromConfig` for unmanaged controllers.

Follow-up to #1279.  