### PR TITLE
OCPBUGS-70212: testGatewayAPIDNS: Fix nil gateway in cleanup

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -617,8 +617,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		}
 	})
 
-	gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-gateway-update")
-	if err != nil {
+	if _, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-gateway-update"); err != nil {
 		t.Fatalf("failed to accept/program gateway test-gateway-update: %v", err)
 	}
 
@@ -696,8 +695,7 @@ func testGatewayAPIDNSListenerWithNoHostname(t *testing.T) {
 		}
 	})
 
-	gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-nohost-gateway")
-	if err != nil {
+	if _, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, "test-nohost-gateway"); err != nil {
 		t.Fatalf("failed to accept/program gateway test-nohost-gateway: %v", err)
 	}
 


### PR DESCRIPTION
Don't overwrite the gateway variable's value from `createGatewayWithListeners` with a possibly nil value from `assertGatewaySuccessful`.

The gateway variable is used in a cleanup handler, which would panic if the variable had a nil value.  The gateway value from `assertGatewaySuccessful` isn't really needed, so it can be safely ignored.

Follow-up to #1213 and #1304.