### PR TITLE
OCPBUGS-70211: Add missing logger to unmanaged controllers

### DIFF
--- a/pkg/operator/controller/gateway-labeler/controller.go
+++ b/pkg/operator/controller/gateway-labeler/controller.go
@@ -50,7 +50,7 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		client:   mgr.GetClient(),
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler, Logger: log})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/gateway-service-dns/controller.go
+++ b/pkg/operator/controller/gateway-service-dns/controller.go
@@ -61,7 +61,7 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		cache:    operatorCache,
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler, Logger: log})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -87,7 +87,7 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		cache:    operatorCache,
 		recorder: mgr.GetEventRecorderFor(controllerName),
 	}
-	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler})
+	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: reconciler, Logger: log})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After bumping to newer controller-runtime the logger is not set anymore on unmanaged controllers.

This change adds the current logger from each controller back to the controller.Options, making controller-runtime use it when constructing the manager instance