### PR TITLE
NE-2376: Remove restriction of unmanaged x-k8s.io

### DIFF
--- a/manifests/01-validating-admission-policy-ibm-cloud-managed.yaml
+++ b/manifests/01-validating-admission-policy-ibm-cloud-managed.yaml
@@ -20,7 +20,7 @@ spec:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"
       # When the operation is DELETE, the "object" variable is null.
-      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io' || (request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.x-k8s.io'"
+      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io'"
   # Validations are evaluated in the the order of their declaration.
   validations:
     # Verify that the request was sent by the ingress operator's service account.

--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"
       # When the operation is DELETE, the "object" variable is null.
-      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io' || (request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.x-k8s.io'"
+      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io'"
   # Validations are evaluated in the the order of their declaration.
   validations:
     # Verify that the request was sent by the ingress operator's service account.

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	controllerName                        = "gatewayapi_controller"
-	experimentalGatewayAPIGroupName       = "gateway.networking.x-k8s.io"
 	gatewayAPICRDIndexFieldName           = "gatewayAPICRD"
 	unmanagedGatewayAPICRDIndexFieldValue = "unmanaged"
 )
@@ -68,8 +67,8 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	}
 
 	isGatewayAPICRD := func(o client.Object) bool {
-		crd := o.(*apiextensionsv1.CustomResourceDefinition)
-		return crd.Spec.Group == gatewayapiv1.GroupName || crd.Spec.Group == experimentalGatewayAPIGroupName
+		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
+		return ok && crd.Spec.Group == gatewayapiv1.GroupName
 	}
 	crdPredicate := predicate.NewPredicateFuncs(isGatewayAPICRD)
 

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -163,8 +163,8 @@ func Test_Reconcile(t *testing.T) {
 			olmEnabled:                  true,
 			existingObjects: []runtime.Object{
 				co("ingress"),
-				crd("listenersets.gateway.networking.x-k8s.io"),
-				crd("backendtrafficpolicies.gateway.networking.x-k8s.io"),
+				crd("invalid.test.gateway.networking.k8s.io"),
+				crd("another.test.gateway.networking.k8s.io"),
 			},
 			existingStatusSubresource: []client.Object{
 				co("ingress"),
@@ -182,7 +182,7 @@ func Test_Reconcile(t *testing.T) {
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
 			expectStatusUpdate: []client.Object{
-				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"backendtrafficpolicies.gateway.networking.x-k8s.io,listenersets.gateway.networking.x-k8s.io"}`),
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"another.test.gateway.networking.k8s.io,invalid.test.gateway.networking.k8s.io"}`),
 			},
 			expectStartCtrl: true,
 		},
@@ -193,7 +193,7 @@ func Test_Reconcile(t *testing.T) {
 			marketplaceEnabled:          true,
 			olmEnabled:                  true,
 			existingObjects: []runtime.Object{
-				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"listenersets.gateway.networking.x-k8s.io"}`),
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"invalid.test.gateway.networking.k8s.io"}`),
 			},
 			existingStatusSubresource: []client.Object{
 				co("ingress"),
@@ -260,7 +260,7 @@ func Test_Reconcile(t *testing.T) {
 				WithStatusSubresource(tc.existingStatusSubresource...).
 				WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
 					// Assume that all experimental CRDs are unmanaged.
-					if strings.Contains(o.GetName(), "gateway.networking.x-k8s.io") {
+					if strings.Contains(o.GetName(), "test.gateway.networking.k8s.io") {
 						return []string{"unmanaged"}
 					}
 					return []string{}

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -259,7 +259,7 @@ func Test_Reconcile(t *testing.T) {
 				WithRuntimeObjects(tc.existingObjects...).
 				WithStatusSubresource(tc.existingStatusSubresource...).
 				WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
-					// Assume that all experimental CRDs are unmanaged.
+					// Assume that test.gateway group CRD is unmanaged.
 					if strings.Contains(o.GetName(), "test.gateway.networking.k8s.io") {
 						return []string{"unmanaged"}
 					}

--- a/pkg/operator/controller/gatewayapi/crds.go
+++ b/pkg/operator/controller/gatewayapi/crds.go
@@ -84,7 +84,7 @@ func (r *reconciler) ensureGatewayAPICRDs(ctx context.Context) error {
 
 // listUnmanagedGatewayAPICRDs returns a list of unmanaged Gateway API CRDs
 // which exist in the cluster. A Gateway API CRD has "gateway.networking.k8s.io"
-// or "gateway.networking.x-k8s.io" in its "spec.group" field.
+// in its "spec.group" field.
 func (r *reconciler) listUnmanagedGatewayAPICRDs(ctx context.Context) ([]string, error) {
 	gatewayAPICRDs := &apiextensionsv1.CustomResourceDefinitionList{}
 	if err := r.cache.List(ctx, gatewayAPICRDs, client.MatchingFields{gatewayAPICRDIndexFieldName: unmanagedGatewayAPICRDIndexFieldValue}); err != nil {

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -775,13 +775,13 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				IngressControllers: []operatorv1.IngressController{
 					icWithStatus("default", false),
 				},
-				unmanagedGatewayAPICRDNames: "listenersets.gateway.networking.x-k8s.io",
+				unmanagedGatewayAPICRDNames: "notvalid.gateway.networking.k8s.io",
 			},
 			expectCondition: configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionTrue,
 				Reason:  "GatewayAPICRDsDegraded",
-				Message: "Unmanaged Gateway API CRDs found: listenersets.gateway.networking.x-k8s.io.",
+				Message: "Unmanaged Gateway API CRDs found: notvalid.gateway.networking.k8s.io.",
 			},
 		},
 		{
@@ -790,13 +790,13 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				IngressControllers: []operatorv1.IngressController{
 					icWithStatus("default", true),
 				},
-				unmanagedGatewayAPICRDNames: "listenersets.gateway.networking.x-k8s.io",
+				unmanagedGatewayAPICRDNames: "notvalid.gateway.networking.k8s.io",
 			},
 			expectCondition: configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionTrue,
 				Reason:  "IngressDegradedAndGatewayAPICRDsDegraded",
-				Message: `The "default" ingress controller reports Degraded=True: dummy: dummy.` + "\n" + `Unmanaged Gateway API CRDs found: listenersets.gateway.networking.x-k8s.io.`,
+				Message: `The "default" ingress controller reports Degraded=True: dummy: dummy.` + "\n" + `Unmanaged Gateway API CRDs found: notvalid.gateway.networking.k8s.io.`,
 			},
 		},
 		{

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -406,9 +406,9 @@ func buildGWAPICRDFromName(name string) *apiextensionsv1.CustomResourceDefinitio
 	case "referencegrants":
 		kind = "ReferenceGrant"
 		versions = []map[string]bool{{"v1beta1": true}}
-	case "listenersets":
-		kind = "ListenerSet"
-		versions = []map[string]bool{{"v1alpha1": true}}
+	case "tests":
+		kind = "Test"
+		versions = []map[string]bool{{"v1": true}}
 	case "grpcroutes":
 		kind = "GRPCRoute"
 		versions = []map[string]bool{{"v1": true}}


### PR DESCRIPTION
Previously, cluster-ingress-operator would manage and block any updates to CRDs that were from group gateway.networking.x-k8s.io.

After some analysis we identified that OSSM/Istio does filter these resources in case it does not have a flag to enable alpha APIs, which means it is safe to allow users to deploy these CRDs.

This way, this change removes any restriction on x-k8s.io group, and removes any further reconciliation from CIO on x-k8s.io group.

Original PR: https://github.com/openshift/cluster-ingress-operator/pull/1336