### PR TITLE
OCPBUGS-85148, NE-2395: Fix e2e tests to work on platforms with unmanaged DNS

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -460,6 +460,10 @@ func testGatewayAPIRBAC(t *testing.T) {
 }
 
 func testGatewayAPIDNS(t *testing.T) {
+	if !isDNSManagementSupported(t) {
+		t.Skip("this test can be executed just on platforms that support managed DNS")
+	}
+
 	domain := "gws." + dnsConfig.Spec.BaseDomain
 
 	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
@@ -591,6 +595,10 @@ func testGatewayAPIDNS(t *testing.T) {
 }
 
 func testGatewayAPIDNSListenerUpdate(t *testing.T) {
+	if !isDNSManagementSupported(t) {
+		t.Skip("this test can be executed just on platforms that support managed DNS")
+	}
+
 	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		t.Fatalf("failed to create gatewayclass: %v", err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -689,11 +689,12 @@ func isDNSManagementSupported(t *testing.T) bool {
 		Name: "cluster",
 	}
 	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(ctx context.Context) (done bool, err error) {
-		if err := kclient.Get(ctx, types.NamespacedName{Name: "cluster"}, dnsConfig); err != nil {
-			t.Logf("error getting infrastructure config %v: %v, retrying...", name, err)
+		if err := kclient.Get(ctx, name, dnsConfig); err != nil {
+			t.Logf("error getting dns config %v: %v, retrying...", name, err)
 			return false, nil
 		}
-		dnsManaged = dnsConfig.Spec.PrivateZone != nil || dnsConfig.Spec.PublicZone != nil
+		dnsManaged = (dnsConfig.Spec.PrivateZone != nil && dnsConfig.Spec.PrivateZone.ID != "") ||
+			(dnsConfig.Spec.PublicZone != nil && dnsConfig.Spec.PublicZone.ID != "")
 		return true, nil
 	})
 	if err != nil {


### PR DESCRIPTION
On on-prem platforms we cannot assure that the DNS record will always work. On some platforms the DNS controller is created with a fake controller, and DNSRecords never gets ready. In these cases, what we need is that the tests rely on the Gateway status address as a name and connect to it directly instead of trying to resolve the DNS.

This change creates a new function to verify if the test is running on a platform with unmanaged DNS, and in this case it skips verifying DNSRecord and makes the resolution of DNS records be hardcoded to use the gateway address on the http client