### PR TITLE
OCPBUGS-54702: change default timeout tunnel if using AWS NLB

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -1231,7 +1231,7 @@ func (r *reconciler) ensureIngressController(ci *operatorv1.IngressController, d
 		return utilerrors.NewAggregate(errs)
 	}
 
-	haveDepl, deployment, err := r.ensureRouterDeployment(ci, infraConfig, ingressConfig, apiConfig, networkConfig, haveClientCAConfigmap, clientCAConfigmap, clusterProxyConfig, proxyNeeded)
+	haveDepl, deployment, err := r.ensureRouterDeployment(ci, infraConfig, ingressConfig, apiConfig, networkConfig, haveClientCAConfigmap, clientCAConfigmap, clusterProxyConfig, currentLBService, proxyNeeded)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure deployment: %w", err))
 		return utilerrors.NewAggregate(errs)

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -131,12 +131,12 @@ const (
 
 // ensureRouterDeployment ensures the router deployment exists for a given
 // ingresscontroller.
-func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, clusterProxyConfig *configv1.Proxy, proxyNeeded bool) (bool, *appsv1.Deployment, error) {
+func (r *reconciler) ensureRouterDeployment(ci *operatorv1.IngressController, infraConfig *configv1.Infrastructure, ingressConfig *configv1.Ingress, apiConfig *configv1.APIServer, networkConfig *configv1.Network, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, clusterProxyConfig *configv1.Proxy, currentLBService *corev1.Service, proxyNeeded bool) (bool, *appsv1.Deployment, error) {
 	haveDepl, current, err := r.currentRouterDeployment(ci)
 	if err != nil {
 		return false, nil, err
 	}
-	desired, err := desiredRouterDeployment(ci, &r.config, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, haveClientCAConfigmap, clientCAConfigmap, clusterProxyConfig)
+	desired, err := desiredRouterDeployment(ci, &r.config, ingressConfig, infraConfig, apiConfig, networkConfig, currentLBService, proxyNeeded, haveClientCAConfigmap, clientCAConfigmap, clusterProxyConfig)
 	if err != nil {
 		return haveDepl, current, fmt.Errorf("failed to build router deployment: %v", err)
 	}
@@ -258,7 +258,7 @@ func headerValues(values []operatorv1.IngressControllerHTTPHeader) string {
 }
 
 // desiredRouterDeployment returns the desired router deployment.
-func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, ingressConfig *configv1.Ingress, infraConfig *configv1.Infrastructure, apiConfig *configv1.APIServer, networkConfig *configv1.Network, proxyNeeded bool, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, clusterProxyConfig *configv1.Proxy) (*appsv1.Deployment, error) {
+func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, ingressConfig *configv1.Ingress, infraConfig *configv1.Infrastructure, apiConfig *configv1.APIServer, networkConfig *configv1.Network, currentLBService *corev1.Service, proxyNeeded bool, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, clusterProxyConfig *configv1.Proxy) (*appsv1.Deployment, error) {
 	deployment := manifests.RouterDeployment()
 	name := controller.RouterDeploymentName(ci)
 	deployment.Name = name.Name
@@ -650,6 +650,33 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 	}
 	env = append(env, corev1.EnvVar{Name: RouterHAProxyThreadsEnvName, Value: strconv.Itoa(threads)})
 
+	// Check for AWS deployment, and if so and exposed via NLB, need to change default timeout tunnel to less than 350s
+	// https://issues.redhat.com/browse/OCPBUGS-54702
+	var tunnelTimeout *time.Duration
+	if ci.Spec.TuningOptions.TunnelTimeout != nil && ci.Spec.TuningOptions.TunnelTimeout.Duration > 0*time.Second {
+		// honor any configuration provided by the user
+		tunnelTimeout = &ci.Spec.TuningOptions.TunnelTimeout.Duration
+	} else {
+		// no config from the user, checking for NLB
+		isAWS := infraConfig.Status.PlatformStatus != nil &&
+			infraConfig.Status.PlatformStatus.Type == configv1.AWSPlatformType
+		if isAWS {
+			var lbType operatorv1.AWSLoadBalancerType
+			if currentLBService != nil {
+				lbType = getAWSLoadBalancerTypeFromServiceAnnotation(currentLBService)
+			} else {
+				lbType = getAWSLoadBalancerTypeInStatus(ci)
+			}
+			if lbType == operatorv1.AWSNetworkLoadBalancer {
+				// NLB at AWS, need to use less than 350s as the timeout
+				tunnelTimeout = ptr.To((awsNLBDefaultTunnelTimeoutSeconds - 1) * time.Second)
+			}
+		}
+	}
+	if tunnelTimeout != nil {
+		env = append(env, corev1.EnvVar{Name: "ROUTER_DEFAULT_TUNNEL_TIMEOUT", Value: durationToHAProxyTimespec(*tunnelTimeout)})
+	}
+
 	if ci.Spec.HTTPHeaders != nil && len(ci.Spec.HTTPHeaders.Actions.Response) != 0 {
 		env = append(env, corev1.EnvVar{Name: RouterHTTPResponseHeaders, Value: headerValues(ci.Spec.HTTPHeaders.Actions.Response)})
 	}
@@ -669,9 +696,6 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 	}
 	if ci.Spec.TuningOptions.ServerFinTimeout != nil && ci.Spec.TuningOptions.ServerFinTimeout.Duration > 0*time.Second {
 		env = append(env, corev1.EnvVar{Name: "ROUTER_DEFAULT_SERVER_FIN_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.ServerFinTimeout.Duration)})
-	}
-	if ci.Spec.TuningOptions.TunnelTimeout != nil && ci.Spec.TuningOptions.TunnelTimeout.Duration > 0*time.Second {
-		env = append(env, corev1.EnvVar{Name: "ROUTER_DEFAULT_TUNNEL_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.TunnelTimeout.Duration)})
 	}
 	if ci.Spec.TuningOptions.ConnectTimeout != nil && ci.Spec.TuningOptions.ConnectTimeout.Duration > 0*time.Second {
 		env = append(env, corev1.EnvVar{Name: "ROUTER_DEFAULT_CONNECT_TIMEOUT", Value: durationToHAProxyTimespec(ci.Spec.TuningOptions.ConnectTimeout.Duration)})

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -175,7 +175,7 @@ func TestTuningOptions(t *testing.T) {
 	ic.Spec.TuningOptions.ReloadInterval = metav1.Duration{Duration: 30 * time.Second}
 	ic.Spec.TuningOptions.HTTPKeepAliveTimeout = &metav1.Duration{Duration: 30 * time.Second}
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -201,11 +201,151 @@ func TestTuningOptions(t *testing.T) {
 	checkDeploymentHasEnvSorted(t, deployment)
 }
 
+func TestTuningOptionForAWSNLB(t *testing.T) {
+	awsPlatform := configv1.AWSPlatformType
+	gcpPlatform := configv1.GCPPlatformType
+	awsCLB := &operatorv1.AWSLoadBalancerParameters{Type: operatorv1.AWSClassicLoadBalancer}
+	awsNLB := &operatorv1.AWSLoadBalancerParameters{Type: operatorv1.AWSNetworkLoadBalancer}
+
+	expectedDefaultNLBTimeout := fmt.Sprintf("%ds", awsNLBDefaultTunnelTimeoutSeconds-1)
+
+	testCases := []struct {
+		name                 string
+		providerParamsType   configv1.PlatformType
+		providerParamsAWS    *operatorv1.AWSLoadBalancerParameters
+		lbService            *corev1.Service
+		userTimeoutTunnel    *time.Duration
+		expectedTimeoutValue string
+	}{
+		// missing param, being AWS or being NLB
+		{
+			name:                 "should skip timeout if missing ProviderParameters",
+			providerParamsType:   "",
+			providerParamsAWS:    nil,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using AWS as provider type and missing AWS parameters",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    nil,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using CLB on AWS parameters and missing provider type as AWS",
+			providerParamsType:   "",
+			providerParamsAWS:    awsCLB,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using NLB on AWS parameters and missing provider type as AWS",
+			providerParamsType:   "",
+			providerParamsAWS:    awsNLB,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using NLB on AWS parameters and another provider type",
+			providerParamsType:   gcpPlatform,
+			providerParamsAWS:    awsNLB,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using AWS as provider type and CLB on AWS parameters",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsCLB,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using CLB from Status, NLB from service annotation and another provider type",
+			providerParamsType:   gcpPlatform,
+			providerParamsAWS:    awsCLB, // LB service annotation should win and consider NLB, but skipping due to platform type
+			lbService:            &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AWSLBTypeAnnotation: AWSNLBAnnotation}}},
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+		{
+			name:                 "should skip timeout if using NLB from Status and CLB from service annotation",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsNLB, // LB service annotation should win, consider CLB, and skip timeout configuration
+			lbService:            &corev1.Service{},
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: "",
+		},
+
+		// NLB, with and without user config
+		{
+			name:                 "should use default timeout if using NLB without user timeout",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsNLB,
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: expectedDefaultNLBTimeout,
+		},
+		{
+			name:                 "should use custom timeout if using NLB and a lower user timeout",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsNLB,
+			userTimeoutTunnel:    ptr.To(time.Minute),
+			expectedTimeoutValue: "1m",
+		},
+		{
+			name:                 "should use custom timeout if using NLB and a higher user timeout",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsNLB,
+			userTimeoutTunnel:    ptr.To(time.Hour),
+			expectedTimeoutValue: "1h",
+		},
+		{
+			name:                 "should use default timeout if using CLB from Status and NLB from service annotation",
+			providerParamsType:   awsPlatform,
+			providerParamsAWS:    awsCLB, // LB service annotation should win and configure timeout
+			lbService:            &corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AWSLBTypeAnnotation: AWSNLBAnnotation}}},
+			userTimeoutTunnel:    nil,
+			expectedTimeoutValue: expectedDefaultNLBTimeout,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
+			ic.Status.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+				LoadBalancer: &operatorv1.LoadBalancerStrategy{
+					ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
+						Type: operatorv1.LoadBalancerProviderType(test.providerParamsType), // just for completeness, checking via infraConfig below
+						AWS:  test.providerParamsAWS,
+					},
+				},
+			}
+			infraConfig.Status.PlatformStatus.Type = test.providerParamsType
+			if test.userTimeoutTunnel != nil {
+				ic.Spec.TuningOptions.TunnelTimeout = &metav1.Duration{Duration: *test.userTimeoutTunnel}
+			}
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, test.lbService, false, false, nil, clusterProxyConfig)
+			if err != nil {
+				t.Fatalf("invalid router Deployment: %v", err)
+			}
+
+			// Verify tuning options
+			tests := []envData{
+				{"ROUTER_DEFAULT_TUNNEL_TIMEOUT", test.expectedTimeoutValue != "", test.expectedTimeoutValue},
+			}
+
+			if err := checkDeploymentEnvironment(t, deployment, tests); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 // TestClusterProxy tests that the cluster-wide proxy settings from proxies.config.openshift.io/cluster are included in the desired router deployment.
 func TestClusterProxy(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -229,7 +369,7 @@ func TestClusterProxy(t *testing.T) {
 	clusterProxyConfig.Status.HTTPSProxy = "bar"
 	clusterProxyConfig.Status.NoProxy = "baz"
 
-	deployment, err = desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err = desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -394,7 +534,7 @@ func getRouterDeploymentComponents(t *testing.T) (*operatorv1.IngressController,
 func Test_desiredRouterDeployment(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -549,7 +689,7 @@ func checkProbes(t *testing.T, container *corev1.Container, useLocalhost bool) {
 func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -690,7 +830,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -788,7 +928,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err = desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err = desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -898,7 +1038,7 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to determine infrastructure platform status for ingresscontroller %s/%s: %v", ic.Namespace, ic.Name, err)
 	}
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -1029,7 +1169,7 @@ func TestDesiredRouterDeploymentFIPS(t *testing.T) {
 		},
 	}
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1047,7 +1187,7 @@ func TestDesiredRouterDeploymentFIPS(t *testing.T) {
 
 	// Also verify non-FIPS mode leaves all ciphers intact.
 	isFIPSEnabled = false
-	deploymentNonFIPS, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deploymentNonFIPS, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("unexpected error (non-FIPS): %v", err)
 	}
@@ -1074,7 +1214,7 @@ func TestDesiredRouterDeploymentHostNetworkNil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1105,7 +1245,7 @@ func TestDesiredRouterDeploymentSingleReplica(t *testing.T) {
 		},
 	}
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -1140,7 +1280,7 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 		},
 	}
 	clientCAConfigmap := &corev1.ConfigMap{}
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, true, clientCAConfigmap, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, true, clientCAConfigmap, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router deployment: %v", err)
 	}
@@ -1341,7 +1481,7 @@ func TestDesiredRouterDeploymentDynamicConfigManager(t *testing.T) {
 				},
 			}
 
-			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage, IngressControllerDCMEnabled: tc.dcmEnabled}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, false, false, nil, &configv1.Proxy{})
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage, IngressControllerDCMEnabled: tc.dcmEnabled}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, nil, false, false, nil, &configv1.Proxy{})
 			if err != nil {
 				t.Error(err)
 			}
@@ -2642,7 +2782,7 @@ func TestDesiredRouterDeploymentDefaultPlacement(t *testing.T) {
 			// This value does not matter in the context of this test, just use a dummy value
 			dummyProxyNeeded := true
 
-			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, tc.ingressConfig, tc.infraConfig, apiConfig, networkConfig, dummyProxyNeeded, false, nil, &configv1.Proxy{})
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, tc.ingressConfig, tc.infraConfig, apiConfig, networkConfig, nil, dummyProxyNeeded, false, nil, &configv1.Proxy{})
 			if err != nil {
 				t.Error(err)
 			}
@@ -2663,7 +2803,7 @@ func TestDesiredRouterDeploymentDefaultPlacement(t *testing.T) {
 func TestDesiredRouterDeploymentRouterExternalCertificate(t *testing.T) {
 	ic, ingressConfig, infraConfig, apiConfig, networkConfig, _, clusterProxyConfig := getRouterDeploymentComponents(t)
 
-	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, false, false, nil, clusterProxyConfig)
 	if err != nil {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
@@ -2711,7 +2851,7 @@ func Test_IdleConnectionTerminationPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ic.Spec.IdleConnectionTerminationPolicy = tc.policy
 
-			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 			if err != nil {
 				t.Fatalf("failed to generate desired router Deployment: %v", err)
 			}
@@ -2762,7 +2902,7 @@ func Test_ClosedClientConnectionPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ic.Spec.ClosedClientConnectionPolicy = tc.policy
 
-			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
 			if err != nil {
 				t.Fatalf("failed to generate desired router Deployment: %v", err)
 			}
@@ -2822,7 +2962,7 @@ func TestDesiredRouterDeploymentTLSCurves(t *testing.T) {
 			// Use the temporary test case status of FIPS enablement for testing.
 			isFIPSEnabled = tc.fipsEnabled
 
-			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, false, false, nil, &configv1.Proxy{})
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, nil, false, false, nil, &configv1.Proxy{})
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -56,6 +56,11 @@ const (
 	// load balancer as being internal.
 	awsInternalLBAnnotation = "service.beta.kubernetes.io/aws-load-balancer-internal"
 
+	// awsNLBDefaultTunnelTimeoutSeconds defines the amount of time a tunnel on AWS NLB times out.
+	// This configuration is used to ensure that router times out earlier than this, having a chance to
+	// close the established connection in a clean way.
+	awsNLBDefaultTunnelTimeoutSeconds = 350
+
 	// awsLBHealthCheckIntervalAnnotation is the approximate interval, in seconds, between AWS
 	// load balancer health checks of an individual AWS instance. Defaults to 5, must be between
 	// 5 and 300.


### PR DESCRIPTION
AWS NLB has its timeout tunnel as 350s by default. Currently we don't
have a way to change this configuration, so changing instead default
timeout tunnel on the HAProxy side to 349s. This configuration avoids
TCP resets on the client side.

The LB type is being read from a Service annotation if provided,
otherwise it comes from the Status. This avoids to use a wrong type, not
applied yet, still on a pending state.

https://issues.redhat.com/browse/OCPBUGS-54702