### PR TITLE
NE-2434: E2E test for internal LoadBalancer Annotations

### DIFF
--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -252,6 +252,10 @@ func LoadBalancerServiceNameFromICName(icName string) types.NamespacedName {
 	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-" + icName}
 }
 
+func LoadBalancerServiceNameFromGatewayName(gatewayName string) types.NamespacedName {
+	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: gatewayName + "-" + OpenShiftDefaultGatewayClassName}
+}
+
 func NodePortServiceName(ic *operatorv1.IngressController) types.NamespacedName {
 	return types.NamespacedName{Namespace: DefaultOperandNamespace, Name: "router-nodeport-" + ic.Name}
 }


### PR DESCRIPTION
Tested on AWS, Azure and GCP clusters

```
  gateway_api_test.go:835: The gateway test-gateway-internal-lb, has successfully created an internal LoadBalancer service on the Azure platform.
--- PASS: TestGatewayAPI (60.69s)
    --- PASS: TestGatewayAPI/testGatewayAPIInternalLoadBalancer (56.34s)
PASS
ok  	github.com/openshift/cluster-ingress-operator/test/e2e	62.173s

    gateway_api_test.go:808: The gateway test-gateway-internal-lb, has successfully created an internal LoadBalancer service on the AWS platform.
--- PASS: TestGatewayAPI (45.67s)
    --- PASS: TestGatewayAPI/testGatewayAPIInternalLoadBalancer (41.36s)
PASS
ok  	github.com/openshift/cluster-ingress-operator/test/e2e	47.055s

    gateway_api_test.go:835: The gateway test-gateway-internal-lb, has successfully created an internal LoadBalancer service on the GCP platform.
--- PASS: TestGatewayAPI (144.97s)
    --- PASS: TestGatewayAPI/testGatewayAPIInternalLoadBalancer (140.45s)
PASS
ok  	github.com/openshift/cluster-ingress-operator/test/e2e	146.957s
```