### PR TITLE
OCPBUGS-74511: remove RouteExternalCertificate feature gate

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -205,10 +205,9 @@ func hasName(name string) func(o client.Object) bool {
 
 // Config holds all the things necessary for the controller to run.
 type Config struct {
-	Namespace                       string
-	IngressControllerImage          string
-	RouteExternalCertificateEnabled bool
-	IngressControllerDCMEnabled     bool
+	Namespace                   string
+	IngressControllerImage      string
+	IngressControllerDCMEnabled bool
 }
 
 // reconciler handles the actual ingress reconciliation logic in response to

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1178,11 +1178,9 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 	}
 
 	// Add router external certificate environment variable.
-	if config.RouteExternalCertificateEnabled {
-		env = append(env,
-			corev1.EnvVar{Name: "ROUTER_ENABLE_EXTERNAL_CERTIFICATE", Value: "true"},
-		)
-	}
+	env = append(env,
+		corev1.EnvVar{Name: "ROUTER_ENABLE_EXTERNAL_CERTIFICATE", Value: "true"},
+	)
 
 	if ci.Spec.IdleConnectionTerminationPolicy == operatorv1.IngressControllerConnectionTerminationPolicyDeferred {
 		env = append(env, corev1.EnvVar{

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -2552,22 +2552,8 @@ func TestDesiredRouterDeploymentRouterExternalCertificate(t *testing.T) {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
 
-	// Verify that router external certificate env var is not added.
-	expectedEnv := []envData{
-		{"ROUTER_ENABLE_EXTERNAL_CERTIFICATE", false, ""},
-	}
-
-	if err := checkDeploymentEnvironment(t, deployment, expectedEnv); err != nil {
-		t.Error(err)
-	}
-
-	deployment, err = desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage, RouteExternalCertificateEnabled: true}, ingressConfig, infraConfig, apiConfig, networkConfig, false, false, nil, clusterProxyConfig)
-	if err != nil {
-		t.Fatalf("invalid router Deployment: %v", err)
-	}
-
 	// Verify that router external certificate env var is set to true.
-	expectedEnv = []envData{
+	expectedEnv := []envData{
 		{"ROUTER_ENABLE_EXTERNAL_CERTIFICATE", true, "true"},
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -136,7 +136,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	azureWorkloadIdentityEnabled := featureGates.Enabled(features.FeatureGateAzureWorkloadIdentity)
 	gatewayAPIEnabled := featureGates.Enabled(features.FeatureGateGatewayAPI)
 	gatewayAPIControllerEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIController)
-	routeExternalCertificateEnabled := featureGates.Enabled(features.FeatureGateRouteExternalCertificate)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
 
 	cv, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
@@ -181,10 +180,9 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	}
 	// Create and register the ingress controller with the operator manager.
 	if _, err := ingresscontroller.New(mgr, ingresscontroller.Config{
-		Namespace:                       config.Namespace,
-		IngressControllerImage:          config.IngressControllerImage,
-		RouteExternalCertificateEnabled: routeExternalCertificateEnabled,
-		IngressControllerDCMEnabled:     ingressControllerDCMEnabled,
+		Namespace:                   config.Namespace,
+		IngressControllerImage:      config.IngressControllerImage,
+		IngressControllerDCMEnabled: ingressControllerDCMEnabled,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create ingress controller: %v", err)
 	}


### PR DESCRIPTION
RouteExternalCertificate is enabled by default, this is the first half of the change to remove it. After merging, its declaration should be removed from openshift/api as well.

Jira: https://issues.redhat.com/browse/OCPBUGS-74511