### PR TITLE
MON-4501: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -249,5 +249,6 @@ rules:
   resources:
   - endpointslices
   verbs:
+  - get
   - list
   - watch

--- a/manifests/0000_90_ingress-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_ingress-operator_00_prometheusrole.yaml
@@ -19,3 +19,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_ingress-operator_02_servicemonitor.yaml
@@ -21,3 +21,4 @@ spec:
   selector:
     matchLabels:
       name: ingress-operator
+  serviceDiscoveryRole: EndpointSlice

--- a/pkg/manifests/assets/router/metrics/role.yaml
+++ b/pkg/manifests/assets/router/metrics/role.yaml
@@ -15,3 +15,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/operator/controller/ingress/metrics.go
+++ b/pkg/operator/controller/ingress/metrics.go
@@ -139,15 +139,8 @@ func (r *reconciler) ensureMetricsIntegration(ci *operatorv1.IngressController, 
 		log.Info("created router metrics cluster role binding", "name", crb.Name)
 	}
 
-	mr := manifests.MetricsRole()
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: mr.Namespace, Name: mr.Name}, mr); err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get router metrics role %s: %v", mr.Name, err)
-		}
-		if err := r.client.Create(context.TODO(), mr); err != nil {
-			return fmt.Errorf("failed to create router metrics role %s: %v", mr.Name, err)
-		}
-		log.Info("created router metrics role", "name", mr.Name)
+	if _, _, err := r.ensureMetricsRole(); err != nil {
+		return fmt.Errorf("failed to ensure metrics role for %s: %v", ci.Name, err)
 	}
 
 	mrb := manifests.MetricsRoleBinding()

--- a/pkg/operator/controller/ingress/monitoring.go
+++ b/pkg/operator/controller/ingress/monitoring.go
@@ -15,11 +15,13 @@ import (
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ensureServiceMonitor ensures the servicemonitor exists for a given
@@ -72,6 +74,7 @@ func desiredServiceMonitor(ic *operatorv1.IngressController, svc *corev1.Service
 						manifests.OwningIngressControllerLabel: ic.Name,
 					},
 				},
+				"serviceDiscoveryRole": "EndpointSlice",
 				// It is important to use the type []interface{}
 				// for the "endpoints" field.  Using
 				// []map[string]interface{} causes at least two
@@ -151,5 +154,77 @@ func serviceMonitorChanged(current, expected *unstructured.Unstructured) (bool, 
 
 	updated := current.DeepCopy()
 	updated.Object["spec"] = expected.Object["spec"]
+	return true, updated
+}
+
+// ensureMetricsRole ensures the metrics role exists and has the correct rules.
+// Returns a Boolean indicating whether the role exists, the role if it does
+// exist, and an error value.
+func (r *reconciler) ensureMetricsRole() (bool, *rbacv1.Role, error) {
+	desired := manifests.MetricsRole()
+
+	have, current, err := r.currentMetricsRole()
+	if err != nil {
+		return false, nil, err
+	}
+
+	switch {
+	case !have:
+		if err := r.client.Create(context.TODO(), desired); err != nil {
+			return false, nil, fmt.Errorf("failed to create router metrics role %s/%s: %v", desired.GetNamespace(), desired.GetName(), err)
+		}
+		log.Info("created router metrics role", "namespace", desired.GetNamespace(), "name", desired.GetName())
+		return r.currentMetricsRole()
+	case have:
+		if updated, err := r.updateMetricsRole(current, desired); err != nil {
+			return true, current, fmt.Errorf("failed to update router metrics role %s/%s: %v", desired.GetNamespace(), desired.GetName(), err)
+		} else if updated {
+			return r.currentMetricsRole()
+		}
+	}
+
+	return true, current, nil
+}
+
+// currentMetricsRole returns the current metrics role.  Returns a Boolean
+// indicating whether the role existed, the role if it did exist, and an
+// error value.
+func (r *reconciler) currentMetricsRole() (bool, *rbacv1.Role, error) {
+	desired := manifests.MetricsRole()
+	mr := &rbacv1.Role{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: desired.GetNamespace(), Name: desired.GetName()}, mr); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, mr, nil
+}
+
+// updateMetricsRole updates the metrics role.  Returns a Boolean indicating
+// whether the role was updated, and an error value.
+func (r *reconciler) updateMetricsRole(current, desired *rbacv1.Role) (bool, error) {
+	changed, updated := metricsRoleChanged(current, desired)
+	if !changed {
+		return false, nil
+	}
+
+	// Diff before updating because the client may mutate the object.
+	diff := cmp.Diff(current, updated, cmpopts.EquateEmpty())
+	if err := r.client.Update(context.TODO(), updated); err != nil {
+		return false, err
+	}
+	log.Info("updated router metrics role", "namespace", updated.GetNamespace(), "name", updated.GetName(), "diff", diff)
+	return true, nil
+}
+
+// metricsRoleChanged checks if the current metrics role rules match the
+// expected rules and if not returns an updated role.
+func metricsRoleChanged(current, desired *rbacv1.Role) (bool, *rbacv1.Role) {
+	if reflect.DeepEqual(current.Rules, desired.Rules) {
+		return false, nil
+	}
+	updated := current.DeepCopy()
+	updated.Rules = desired.Rules
 	return true, updated
 }

--- a/pkg/operator/controller/ingress/monitoring_test.go
+++ b/pkg/operator/controller/ingress/monitoring_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,5 +50,32 @@ func Test_serviceMonitorChanged(t *testing.T) {
 		if changedAgain, _ := serviceMonitorChanged(sm2, sm3); changedAgain {
 			t.Fatal("serviceMonitorChanged does not behave as a fixed-point function")
 		}
+	}
+
+	// Verify that changing serviceDiscoveryRole is detected as a change.
+	sm4 := desiredServiceMonitor(ic, svc, deploymentRef)
+	if err := unstructured.SetNestedField(sm4.Object, "Endpoints", "spec", "serviceDiscoveryRole"); err != nil {
+		t.Fatalf("failed to mutate servicemonitor: %v", err)
+	}
+	if changed, _ := serviceMonitorChanged(sm1, sm4); !changed {
+		t.Fatal("expected changed to be true after mutating serviceDiscoveryRole")
+	}
+}
+
+func Test_metricsRoleChanged(t *testing.T) {
+	role1 := manifests.MetricsRole()
+	role2 := manifests.MetricsRole()
+	if changed, _ := metricsRoleChanged(role1, role2); changed {
+		t.Fatal("expected changed to be false for two roles with identical rules")
+	}
+	role2.Rules = append(role2.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"example.io"},
+		Resources: []string{"foos"},
+		Verbs:     []string{"get"},
+	})
+	if changed, updated := metricsRoleChanged(role1, role2); !changed {
+		t.Fatal("expected changed to be true after adding a rule")
+	} else if changedAgain, _ := metricsRoleChanged(role2, updated); changedAgain {
+		t.Fatal("metricsRoleChanged does not behave as a fixed-point function")
 	}
 }


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved ingress metrics discovery by using Kubernetes EndpointSlices.
  * Updated monitoring permissions to support reading EndpointSlices.
  * Metrics monitoring permissions are now automatically created and updated when needed.

* **Bug Fixes**
  * Improved reconciliation of monitoring roles to keep cluster permissions aligned with the configured requirements.

* **Tests**
  * Added coverage for EndpointSlice service discovery and monitoring role updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->