### PR TITLE
OCPBUGS-77457: Respect proxy configuration on gwapi provisioning

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -95,6 +96,10 @@ const (
 	istioImageZTunnel = "istio-ztunnel-rhel9"
 )
 
+type extraIstioConfig struct {
+	proxyConfig *configv1.Proxy
+}
+
 var log = logf.Logger.WithName(controllerName)
 var gatewayClassController controller.Controller
 
@@ -155,6 +160,14 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		}
 	})
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &apiextensionsv1.CustomResourceDefinition{}, reconciler.enqueueRequestForSomeGatewayClass(), isInferencepoolCrd)); err != nil {
+		return nil, err
+	}
+
+	// Watch for Proxy configuration to set the right options on Istio resource
+	isClusterProxy := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == "cluster"
+	})
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.Proxy{}, reconciler.enqueueRequestForSomeGatewayClass(), isClusterProxy)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -31,6 +31,17 @@ import (
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 )
 
+var (
+	expectedProxyConfiguration = map[string]string{
+		"HTTP_PROXY":  "http://some.proxy.tld:8080",
+		"HTTPS_PROXY": "https://another.proxy.tld",
+		"NO_PROXY":    ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14",
+		"http_proxy":  "http://some.proxy.tld:8080",
+		"https_proxy": "https://another.proxy.tld",
+		"no_proxy":    ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14",
+	}
+)
+
 func Test_Reconcile(t *testing.T) {
 	req := func(name string) reconcile.Request {
 		return reconcile.Request{
@@ -72,7 +83,18 @@ func Test_Reconcile(t *testing.T) {
 		}
 	}
 
-	istio := func(version string, gieEnabled bool) *sailv1.Istio {
+	proxyConfig := func(http, https, noproxy string) *configv1.Proxy {
+		return &configv1.Proxy{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Status: configv1.ProxyStatus{
+				HTTPProxy:  http,
+				HTTPSProxy: https,
+				NoProxy:    noproxy,
+			},
+		}
+	}
+
+	istio := func(version string, gieEnabled bool, proxyconfig map[string]string) *sailv1.Istio {
 		ret := &sailv1.Istio{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "openshift-gateway",
@@ -131,6 +153,7 @@ func Test_Reconcile(t *testing.T) {
 									Mode: sailv1.ProxyConfigProxyHeadersMetadataExchangeModeInMesh,
 								},
 							},
+							ProxyMetadata: proxyconfig,
 						},
 						IngressControllerMode: sailv1.MeshConfigIngressControllerModeOff,
 					},
@@ -201,7 +224,7 @@ func Test_Reconcile(t *testing.T) {
 		}
 	}
 
-	expectedSailLibraryOptions := func(version string, gieEnabled bool) *install.Options {
+	expectedSailLibraryOptions := func(version string, gieEnabled bool, proxyConfig map[string]string) *install.Options {
 		// Start with sail-operator's Gateway API defaults aka trust upstream defaults
 		values := install.GatewayAPIDefaults()
 
@@ -223,6 +246,11 @@ func Test_Reconcile(t *testing.T) {
 				Env: pilotEnv,
 				PodAnnotations: map[string]string{
 					"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+				},
+			},
+			MeshConfig: &sailv1.MeshConfig{
+				DefaultConfig: &sailv1.MeshConfigProxyConfig{
+					ProxyMetadata: proxyConfig,
 				},
 			},
 		}
@@ -270,7 +298,21 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", false),
+				istio("v1.24.4", false, nil),
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+		},
+		{
+			name:    "OLM mode: Minimal gatewayclass and system proxy",
+			request: req("openshift-default"),
+			existingObjects: []client.Object{
+				gatewayClass("openshift-default", false, nil, nil, false),
+				proxyConfig("http://some.proxy.tld:8080", "https://another.proxy.tld", ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14"),
+			},
+			expectCreate: []client.Object{
+				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
+				istio("v1.24.4", false, expectedProxyConfiguration),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -288,7 +330,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", true),
+				istio("v1.24.4", true, nil),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -306,7 +348,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", true),
+				istio("v1.24.4", true, nil),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -321,7 +363,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24-latest", false),
+				istio("v1.24-latest", false, nil),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -339,7 +381,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("foo", "bar", "baz"),
-				istio("quux", false),
+				istio("quux", false, nil),
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
@@ -399,11 +441,11 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: []client.Object{
 				gatewayClass("openshift-default", true, nil, nil, false),
 				istioCRD(),
-				istio("v1.24.4", true),
+				istio("v1.24.4", true, nil),
 			},
 			expectPatched: []client.Object{},
 			expectDelete: []client.Object{
-				istio("v1.24.4", true),
+				istio("v1.24.4", true, nil),
 			},
 			expectedResult: reconcile.Result{
 				RequeueAfter: 5 * time.Second,
@@ -439,7 +481,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil),
 		},
 		{
 			name:              "Sail Library: installs Istio",
@@ -451,7 +493,20 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil),
+		},
+		{
+			name:              "Sail Library: installs Istio with system proxy configuration",
+			fakeSailInstaller: &fakeSailInstaller{},
+			request:           req("openshift-default"),
+			existingObjects: []client.Object{
+				gatewayClass("openshift-default", true, nil, nil, false),
+				proxyConfig("http://some.proxy.tld:8080", "https://another.proxy.tld", ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14"),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, nil, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration),
 		},
 		{
 			name:              "Sail Library: experimental InferencePool CRD",
@@ -468,7 +523,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil),
 		},
 		{
 			name:              "Sail Library: stable InferencePool CRD",
@@ -485,7 +540,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil),
 		},
 		{
 			name:              "Sail Library: Istio version override",
@@ -501,7 +556,7 @@ func Test_Reconcile(t *testing.T) {
 					"unsupported.do-not-use.openshift.io/istio-version": "v1.24-latest",
 				}, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false, nil),
 		},
 		{
 			name:              "Sail Library: full removal of last GatewayClass",

--- a/pkg/operator/controller/gatewayclass/istio_olm.go
+++ b/pkg/operator/controller/gatewayclass/istio_olm.go
@@ -10,6 +10,7 @@ import (
 
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -45,7 +46,16 @@ func (r *reconciler) ensureIstioOLM(ctx context.Context, gatewayclass *gatewayap
 		return have, current, err
 	}
 
-	desired := desiredIstio(name, ownerRef, istioVersion, enableInferenceExtension)
+	// We can ignore the error if it is not found. It means the configuration of proxy will
+	// be null, and no proxy will be configured in this case
+	var proxyConfig configv1.Proxy
+	if err := r.cache.Get(ctx, types.NamespacedName{Name: "cluster"}, &proxyConfig); err != nil && !errors.IsNotFound(err) {
+		return have, current, fmt.Errorf("error verifying cluster proxy configuration: %w", err)
+	}
+
+	desired := desiredIstio(name, ownerRef, istioVersion, enableInferenceExtension, &extraIstioConfig{
+		proxyConfig: &proxyConfig,
+	})
 
 	switch {
 	case !have:
@@ -153,9 +163,9 @@ func gatewayAPIPilotEnv(enableInferenceExtension bool) map[string]string {
 }
 
 // desiredIstio returns the desired Istio CR.
-func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, istioVersion string, enableInferenceExtension bool) *sailv1.Istio {
+func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, istioVersion string, enableInferenceExtension bool, extraConfig *extraIstioConfig) *sailv1.Istio {
 	pilotContainerEnv := gatewayAPIPilotEnv(enableInferenceExtension)
-	return &sailv1.Istio{
+	istio := &sailv1.Istio{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       name.Namespace,
 			Name:            name.Name,
@@ -214,6 +224,14 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, ist
 			Version: istioVersion,
 		},
 	}
+
+	if extraConfig != nil {
+		if proxyMetadata := buildProxyMetadata(extraConfig.proxyConfig); proxyMetadata != nil {
+			istio.Spec.Values.MeshConfig.DefaultConfig.ProxyMetadata = proxyMetadata
+		}
+	}
+
+	return istio
 }
 
 // currentIstio returns the current istio CR.

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer.go
@@ -8,12 +8,14 @@ import (
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -122,8 +124,17 @@ func (r *reconciler) ensureIstio(ctx context.Context, istioVersion string) error
 		return fmt.Errorf("failed to check for InferencePool CRD: %w", err)
 	}
 
+	// We can ignore the error if it is not found. It means the configuration of proxy will
+	// be null, and no proxy will be configured in this case
+	var proxyConfig configv1.Proxy
+	if err := r.cache.Get(ctx, types.NamespacedName{Name: "cluster"}, &proxyConfig); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error verifying cluster proxy configuration: %w", err)
+	}
+
 	// Build options from current state
-	opts := r.buildInstallerOptions(enableInferenceExtension, istioVersion)
+	opts := r.buildInstallerOptions(enableInferenceExtension, istioVersion, &extraIstioConfig{
+		proxyConfig: &proxyConfig,
+	})
 
 	opts.OverwriteOLMManagedCRD = r.overwriteOLMManagedCRDFunc
 
@@ -137,12 +148,12 @@ func (r *reconciler) ensureIstio(ctx context.Context, istioVersion string) error
 
 // buildInstallerOptions creates Sail Library installation options by merging
 // Gateway API defaults with OpenShift-specific overrides
-func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioVersion string) install.Options {
+func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioVersion string, extraConfig *extraIstioConfig) install.Options {
 	// Start with Gateway API defaults
 	values := install.GatewayAPIDefaults()
 
 	// Apply OpenShift-specific overrides
-	openshiftOverrides := openshiftValues(enableInferenceExtension, r.config.OperandNamespace)
+	openshiftOverrides := openshiftValues(enableInferenceExtension, r.config.OperandNamespace, extraConfig)
 	values = install.MergeValues(values, openshiftOverrides)
 
 	return install.Options{
@@ -157,10 +168,10 @@ func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioV
 
 // openshiftValues returns the OpenShift-specific value overrides for Istio.
 // These values are merged on top of the gateway-api preset defaults.
-func openshiftValues(enableInferenceExtension bool, operandNamespace string) *sailv1.Values {
+func openshiftValues(enableInferenceExtension bool, operandNamespace string, extraConfig *extraIstioConfig) *sailv1.Values {
 	pilotEnv := gatewayAPIPilotEnv(enableInferenceExtension)
 
-	return &sailv1.Values{
+	val := &sailv1.Values{
 		Global: &sailv1.GlobalConfig{
 			DefaultPodDisruptionBudget: &sailv1.DefaultPodDisruptionBudgetConfig{
 				Enabled: ptr.To(false),
@@ -178,5 +189,39 @@ func openshiftValues(enableInferenceExtension bool, operandNamespace string) *sa
 				WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
 			},
 		},
+		MeshConfig: &sailv1.MeshConfig{
+			DefaultConfig: &sailv1.MeshConfigProxyConfig{},
+		},
 	}
+
+	if extraConfig != nil && extraConfig.proxyConfig != nil {
+		if proxyMetadata := buildProxyMetadata(extraConfig.proxyConfig); proxyMetadata != nil {
+			val.MeshConfig.DefaultConfig.ProxyMetadata = proxyMetadata
+		}
+	}
+	return val
+}
+
+func buildProxyMetadata(proxyConfig *configv1.Proxy) map[string]string {
+	if proxyConfig == nil {
+		return nil
+	}
+	proxyCfg := proxyConfig.Status
+	proxyMetadata := map[string]string{}
+	if proxyCfg.HTTPProxy != "" {
+		proxyMetadata["HTTP_PROXY"] = proxyCfg.HTTPProxy
+		proxyMetadata["http_proxy"] = proxyCfg.HTTPProxy
+	}
+	if proxyCfg.HTTPSProxy != "" {
+		proxyMetadata["HTTPS_PROXY"] = proxyCfg.HTTPSProxy
+		proxyMetadata["https_proxy"] = proxyCfg.HTTPSProxy
+	}
+	if proxyCfg.NoProxy != "" {
+		proxyMetadata["NO_PROXY"] = proxyCfg.NoProxy
+		proxyMetadata["no_proxy"] = proxyCfg.NoProxy
+	}
+	if len(proxyMetadata) == 0 {
+		return nil
+	}
+	return proxyMetadata
 }

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer_test.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
 
+	configv1 "github.com/openshift/api/config/v1"
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -542,6 +543,7 @@ func TestOLMAndSailLibraryValuesMatch(t *testing.T) {
 	testCases := []struct {
 		name                     string
 		enableInferenceExtension bool
+		extraconfig              *extraIstioConfig
 	}{
 		{
 			name:                     "without inference extension",
@@ -551,13 +553,25 @@ func TestOLMAndSailLibraryValuesMatch(t *testing.T) {
 			name:                     "with inference extension",
 			enableInferenceExtension: true,
 		},
+		{
+			name: "with system proxy config enabled",
+			extraconfig: &extraIstioConfig{
+				proxyConfig: &configv1.Proxy{
+					Status: configv1.ProxyStatus{
+						HTTPProxy:  "http://some.proxy.tld:8080",
+						HTTPSProxy: "http://some.proxytls.tld:8080",
+						NoProxy:    ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Get values from Sail Library path (GatewayAPIDefaults + OpenShift overrides)
 			sailValues := install.GatewayAPIDefaults()
-			openshiftOverrides := openshiftValues(tc.enableInferenceExtension, "openshift-ingress")
+			openshiftOverrides := openshiftValues(tc.enableInferenceExtension, "openshift-ingress", tc.extraconfig)
 			sailValues = install.MergeValues(sailValues, openshiftOverrides)
 
 			// Get values from OLM path
@@ -566,6 +580,7 @@ func TestOLMAndSailLibraryValuesMatch(t *testing.T) {
 				metav1.OwnerReference{},
 				"v1.24.4",
 				tc.enableInferenceExtension,
+				tc.extraconfig,
 			)
 
 			cmpOpts := []cmp.Option{


### PR DESCRIPTION
This PR adds support for global proxy configuration on Gateway API provisioning.

It mutates the Istio resource creation to pass the `*_PROXY` environment variables when deploying Istio controller, and this is passed down to Gateway instances created by users.

This configuration allows envoy proxies that rely on downloading WASMPlugins, on an air-gapped environment that enforces the usage of a network proxy, to download the artifacts using the network proxy.

## Test executed
* Deploy the current version on a running cluster
* Deploy GatewayClass and Gateway
* Gateway instance does NOT have the envvars for HTTP_PROXY
* Configure the proxy: `kubectl edit proxy cluster`
```yaml
apiVersion: config.openshift.io/v1
kind: Proxy
metadata:
  name: cluster
spec:
  httpProxy: http://some.proxy.tld:8080
  httpsProxy: http://another.proxy.tld:8080
```
* Verify the status is added to the proxy `kubectl get proxy cluster -o yaml`
```yaml
apiVersion: config.openshift.io/v1
kind: Proxy
metadata:
  name: cluster
...
status:
  httpProxy: http://some.proxy.tld:8080
  httpsProxy: http://another.proxy.tld:8080
  noProxy: .cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.ci-ln-s0bqi4k-76ef8.aws-2.ci.openshift.org,localhost
```
* The Gateway API envoy instance is re-created with the right envvars: `kubectl get pods -n openshift-ingress testcustom-openshift-default-7686989d6f-nxwmw -o jsonpath='{range .spec.containers[*].env[*]}{.name}{"="}{.value}{"\n"}{end}' |grep PROXY`
```
PROXY_CONFIG={"discoveryAddress":"istiod-openshift-gateway.openshift-ingress.svc:15012","proxyMetadata":{"HTTPS_PROXY":"http://another.proxy.tld:8080","HTTP_PROXY":"http://some.proxy.tld:8080","NO_PROXY":".cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.ci-ln-s0bqi4k-76ef8.aws-2.ci.openshift.org,localhost"},"proxyHeaders":{"server":{"disabled":true},"envoyDebugHeaders":{"disabled":true},"metadataExchangeHeaders":{"mode":"IN_MESH"}}}
HTTPS_PROXY=http://another.proxy.tld:8080
HTTP_PROXY=http://some.proxy.tld:8080
NO_PROXY=.cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,api-int.ci-ln-s0bqi4k-76ef8.aws-2.ci.openshift.org,localhost
```