### PR TITLE
WIP WIP WIP OCPBUGS-78941: Respect tlsprofiles on sail-library

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -94,6 +95,10 @@ const (
 	istioImageCNI     = "istio-cni-rhel9"
 	istioImageZTunnel = "istio-ztunnel-rhel9"
 )
+
+type extraIstioConfig struct {
+	tlsConfig *configv1.TLSProfileSpec
+}
 
 var log = logf.Logger.WithName(controllerName)
 var gatewayClassController controller.Controller
@@ -228,6 +233,16 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 			return nil, err
 		}
 		if err := c.Watch(&SailLibrarySource[client.Object]{NotifyCh: notifyCh, RequestsFunc: reconciler.requestsForAllManagedGatewayClasses}); err != nil {
+			return nil, err
+		}
+
+		// Watch the cluster APIServer config so that changes to the TLS security
+		// profile cause the canary daemonset to be reconciled.
+		apiServerPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetName() == "cluster"
+		})
+
+		if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.APIServer{}, reconciler.enqueueRequestForSomeGatewayClass(), apiServerPredicate)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer.go
@@ -9,11 +9,14 @@ import (
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -122,8 +125,27 @@ func (r *reconciler) ensureIstio(ctx context.Context, istioVersion string) error
 		return fmt.Errorf("failed to check for InferencePool CRD: %w", err)
 	}
 
+	// Read the cluster APIServer config to get the TLS security profile.
+	// If this read fails (e.g. transient API error), continue with the
+	// intermediate default profile instead of hard-failing reconcile.
+	apiConfig := &configv1.APIServer{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: "cluster"}, apiConfig); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("APIServer 'cluster' not found; falling back to intermediate TLS profile")
+		} else {
+			return fmt.Errorf("failed to get APIServer 'cluster': %w", err)
+		}
+	}
+
+	tlsProfile, err := openshifttls.GetTLSProfileSpec(apiConfig.Spec.TLSSecurityProfile)
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer 'cluster': %w", err)
+	}
+
 	// Build options from current state
-	opts := r.buildInstallerOptions(enableInferenceExtension, istioVersion)
+	opts := r.buildInstallerOptions(enableInferenceExtension, istioVersion, &extraIstioConfig{
+		tlsConfig: &tlsProfile,
+	})
 
 	opts.OverwriteOLMManagedCRD = r.overwriteOLMManagedCRDFunc
 
@@ -137,7 +159,7 @@ func (r *reconciler) ensureIstio(ctx context.Context, istioVersion string) error
 
 // buildInstallerOptions creates Sail Library installation options by merging
 // Gateway API defaults with OpenShift-specific overrides
-func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioVersion string) install.Options {
+func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioVersion string, extraConfig *extraIstioConfig) install.Options {
 	// Start with Gateway API defaults
 	values := install.GatewayAPIDefaults()
 
@@ -157,7 +179,7 @@ func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioV
 
 // openshiftValues returns the OpenShift-specific value overrides for Istio.
 // These values are merged on top of the gateway-api preset defaults.
-func openshiftValues(enableInferenceExtension bool, operandNamespace string) *sailv1.Values {
+func openshiftValues(enableInferenceExtension bool, operandNamespace string, extraConfig *extraIstioConfig) *sailv1.Values {
 	pilotEnv := gatewayAPIPilotEnv(enableInferenceExtension)
 
 	return &sailv1.Values{


### PR DESCRIPTION
This is a wip to support tlsprofile on Istio deployment when using sail library

This cannot be merged yet, we need https://github.com/istio-ecosystem/sail-operator/pull/1513/ to be available on upstream and on the fork we are using. 

Things are broken here, please do not try to merge or review yet!