### PR TITLE
OCPBUGS-76609: Do not take over OSSM subscription

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -463,7 +463,8 @@ func (r *reconciler) reconcileWithOLM(ctx context.Context, request reconcile.Req
 	if subscription == nil {
 		log.Info("No OSSM subscription available; skipping install plan enforcement")
 	} else if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
-		log.Info("Found an existing OSSM subscription with another owner; installation skipped")
+		log.Info("Found an existing OSSM subscription with another owner; installation skipped",
+			"namespace", subscription.Namespace, "name", subscription.Name)
 	} else {
 		if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx, ossmVersion); err != nil {
 			errs = append(errs, err)

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -455,12 +455,11 @@ func (r *reconciler) reconcileWithOLM(ctx context.Context, request reconcile.Req
 	if v, ok := gatewayclass.Annotations[subscriptionVersionOverrideAnnotationKey]; ok {
 		ossmVersion = v
 	}
+
 	_, subscription, err := r.ensureServiceMeshOperatorSubscription(ctx, ossmCatalog, ossmChannel, ossmVersion)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure ServiceMeshOperatorSubscription: %w", err))
-	}
-
-	if subscription == nil {
+	} else if subscription == nil {
 		log.Info("No OSSM subscription available; skipping install plan enforcement")
 	} else if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
 		log.Info("Found an existing OSSM subscription with another owner; installation skipped",

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -460,7 +460,9 @@ func (r *reconciler) reconcileWithOLM(ctx context.Context, request reconcile.Req
 		errs = append(errs, fmt.Errorf("failed to ensure ServiceMeshOperatorSubscription: %w", err))
 	}
 
-	if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
+	if subscription == nil {
+		log.Info("No OSSM subscription available; skipping install plan enforcement")
+	} else if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
 		log.Info("Found an existing OSSM subscription with another owner; installation skipped")
 	} else {
 		if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx, ossmVersion); err != nil {

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -455,14 +455,13 @@ func (r *reconciler) reconcileWithOLM(ctx context.Context, request reconcile.Req
 	if v, ok := gatewayclass.Annotations[subscriptionVersionOverrideAnnotationKey]; ok {
 		ossmVersion = v
 	}
-	//
-	exists, existingSubscription, err := r.ensureServiceMeshOperatorSubscription(ctx, ossmCatalog, ossmChannel, ossmVersion)
+	_, subscription, err := r.ensureServiceMeshOperatorSubscription(ctx, ossmCatalog, ossmChannel, ossmVersion)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure ServiceMeshOperatorSubscription: %w", err))
 	}
 
-	if exists && existingSubscription.Namespace != operatorcontroller.OpenshiftOperatorNamespace {
-		log.Info("another OSSM subscription already exists, installation will be skipped")
+	if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
+		log.Info("Found an existing OSSM subscription with another owner; installation skipped")
 	} else {
 		if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx, ossmVersion); err != nil {
 			errs = append(errs, err)

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -455,12 +455,20 @@ func (r *reconciler) reconcileWithOLM(ctx context.Context, request reconcile.Req
 	if v, ok := gatewayclass.Annotations[subscriptionVersionOverrideAnnotationKey]; ok {
 		ossmVersion = v
 	}
-	if _, _, err := r.ensureServiceMeshOperatorSubscription(ctx, ossmCatalog, ossmChannel, ossmVersion); err != nil {
+	//
+	exists, existingSubscription, err := r.ensureServiceMeshOperatorSubscription(ctx, ossmCatalog, ossmChannel, ossmVersion)
+	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to ensure ServiceMeshOperatorSubscription: %w", err))
 	}
-	if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx, ossmVersion); err != nil {
-		errs = append(errs, err)
+
+	if exists && existingSubscription.Namespace != operatorcontroller.OpenshiftOperatorNamespace {
+		log.Info("another OSSM subscription already exists, installation will be skipped")
+	} else {
+		if _, _, err := r.ensureServiceMeshOperatorInstallPlan(ctx, ossmVersion); err != nil {
+			errs = append(errs, err)
+		}
 	}
+
 	istioVersion := r.config.IstioVersion
 	if v, ok := gatewayclass.Annotations[istioVersionOverrideAnnotationKey]; ok {
 		istioVersion = v

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -35,27 +35,13 @@ const (
 // for servicemeshoperator is present and returns a Boolean indicating whether
 // it exists, the subscription if it exists, and an error value.
 func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, catalog, channel, version string) (bool, *operatorsv1alpha1.Subscription, error) {
-	var subscriptionList operatorsv1alpha1.SubscriptionList
-	// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
-	if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
-		Namespace: "",
-	}); err != nil {
+	conflictingSubscription, err := r.findConflictingSubscription(ctx)
+	if err != nil {
 		return false, nil, err
 	}
 
-	for _, subscription := range subscriptionList.Items {
-		// There is a subscription that is not owned by us. In this case we early return
-		// because we cannot support multiple existing OSSM subscriptions, so instead of
-		// trying to continue the workflow of making CIO take over the subscription
-		// the code is early returned without further update, and CIO can be marked
-		// with a degradation warning that allows the cluster admin to identify the
-		// other existing subscriptions, and decide further action.
-		// This does not block the rest of GatewayClass reconciliation, it just avoids
-		// CIO taking over subscriptions (or adding new ones) while other subscription
-		// exists.
-		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Spec.Package == "servicemeshoperator3" && !ok {
-			return true, &subscription, nil
-		}
+	if conflictingSubscription != nil {
+		return true, conflictingSubscription, nil
 	}
 
 	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
@@ -115,7 +101,7 @@ func desiredSubscription(name types.NamespacedName, gwapiOperatorCatalog, gwapiO
 				},
 			},
 			InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
-			Package:                "servicemeshoperator3",
+			Package:                operatorcontroller.ServiceMeshOperatorSubscriptionPackage,
 			CatalogSource:          gwapiOperatorCatalog,
 			CatalogSourceNamespace: "openshift-marketplace",
 			StartingCSV:            gwapiOperatorVersion,
@@ -272,6 +258,38 @@ func (r *reconciler) updateInstallPlan(ctx context.Context, current, desired *op
 	}
 	log.Info("updated InstallPlan", "namespace", updated.Namespace, "name", updated.Name, "diff", diff)
 	return true, nil
+}
+
+// findConflictingSubscription tries to find any OSSM/servicemesh subscription that may have conflicts with the one
+// that CIO will install
+func (r *reconciler) findConflictingSubscription(ctx context.Context) (*operatorsv1alpha1.Subscription, error) {
+	var subscriptionList operatorsv1alpha1.SubscriptionList
+	// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
+	if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
+		Namespace: "",
+	}); err != nil {
+		return nil, err
+	}
+
+	for i := range subscriptionList.Items {
+		// There is a subscription that is not owned by us. In this case we early return
+		// because we cannot support multiple existing OSSM subscriptions, so instead of
+		// trying to continue the workflow of making CIO take over the subscription
+		// the code is early returned without further update, and CIO can be marked
+		// with a degradation warning that allows the cluster admin to identify the
+		// other existing subscriptions, and decide further action.
+		// This does not block the rest of GatewayClass reconciliation, it just avoids
+		// CIO taking over subscriptions (or adding new ones) while other subscription
+		// exists.
+		sub := &subscriptionList.Items[i]
+		if sub.Spec != nil && sub.Spec.Package == operatorcontroller.ServiceMeshOperatorSubscriptionPackage {
+			if _, ok := sub.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; !ok {
+				return sub, nil
+			}
+		}
+	}
+	// No conflicting subscription found, return null
+	return nil, nil
 }
 
 // installPlanChanged returns a Boolean indicating whether the current InstallPlan matches the expected InstallPlan and

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -43,16 +43,16 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, 
 		return false, nil, err
 	}
 
-	// There is a subscription that is not owned by us. In this case we early return
-	// because we cannot support multiple existing OSSM subscriptions, so instead of
-	// trying to continue the workflow of making CIO take over the subscription
-	// the code is early returned without further update, and CIO can be marked
-	// with a degradation warning that allows the cluster admin to identify the
-	// other existing subscriptions, and decide further action.
-	// This does not block the rest of GatewayClass reconciliation, it just avoids
-	// CIO taking over subscriptions (or adding new ones) while other subscription
-	// exists.
 	for _, subscription := range subscriptionList.Items {
+		// There is a subscription that is not owned by us. In this case we early return
+		// because we cannot support multiple existing OSSM subscriptions, so instead of
+		// trying to continue the workflow of making CIO take over the subscription
+		// the code is early returned without further update, and CIO can be marked
+		// with a degradation warning that allows the cluster admin to identify the
+		// other existing subscriptions, and decide further action.
+		// This does not block the rest of GatewayClass reconciliation, it just avoids
+		// CIO taking over subscriptions (or adding new ones) while other subscription
+		// exists.
 		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Spec.Package == "servicemeshoperator3" && !ok {
 			return true, &subscription, nil
 		}

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -191,6 +191,9 @@ func (r *reconciler) currentInstallPlan(ctx context.Context, version string) (bo
 	if err != nil {
 		return false, nil, err
 	}
+	if subscription == nil {
+		return false, nil, nil
+	}
 	installPlans := &operatorsv1alpha1.InstallPlanList{}
 	if err := r.client.List(ctx, installPlans, client.InNamespace(operatorcontroller.OpenshiftOperatorNamespace)); err != nil {
 		return false, nil, err

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -33,15 +33,12 @@ const (
 
 // ensureServiceMeshOperatorSubscription attempts to ensure that a subscription
 // for servicemeshoperator is present and returns a Boolean indicating whether
-// it exists, another boolean indicating if the one that exists is out of our namespace (pre-existing),
-// the subscription if it exists, and an error value.
+// it exists, the subscription if it exists, and an error value.
 func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, catalog, channel, version string) (bool, *operatorsv1alpha1.Subscription, error) {
-
 	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
 
-	// TODO: check if we also can rely on a label selector to limit the List for ossm only
-	// TODO: check if we care on OSSM2 subscriptions
 	var subscriptionList operatorsv1alpha1.SubscriptionList
+	// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
 	if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
 		Namespace: "",
 	}); err != nil {
@@ -49,8 +46,8 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, 
 	}
 
 	for _, subscription := range subscriptionList.Items {
-		// The same subscription exists on a different namespace, we should not try to override it
-		if subscription.Name == name.Name && subscription.Namespace != name.Namespace {
+		// The same subscription exists on a different namespace, and is not owned by us
+		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Name == name.Name && !ok {
 			return true, &subscription, nil
 		}
 	}

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -33,9 +33,28 @@ const (
 
 // ensureServiceMeshOperatorSubscription attempts to ensure that a subscription
 // for servicemeshoperator is present and returns a Boolean indicating whether
-// it exists, the subscription if it exists, and an error value.
+// it exists, another boolean indicating if the one that exists is out of our namespace (pre-existing),
+// the subscription if it exists, and an error value.
 func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, catalog, channel, version string) (bool, *operatorsv1alpha1.Subscription, error) {
+
 	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
+
+	// TODO: check if we also can rely on a label selector to limit the List for ossm only
+	// TODO: check if we care on OSSM2 subscriptions
+	var subscriptionList operatorsv1alpha1.SubscriptionList
+	if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
+		Namespace: "",
+	}); err != nil {
+		return false, nil, err
+	}
+
+	for _, subscription := range subscriptionList.Items {
+		// The same subscription exists on a different namespace, we should not try to override it
+		if subscription.Name == name.Name && subscription.Namespace != name.Namespace {
+			return true, &subscription, nil
+		}
+	}
+
 	have, current, err := r.currentSubscription(ctx, name)
 	if err != nil {
 		return false, nil, err

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -46,7 +46,15 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, 
 	}
 
 	for _, subscription := range subscriptionList.Items {
-		// The same subscription exists on a different namespace, and is not owned by us
+		// There is a subscription that is not owned by us. In this case we early return
+		// because we cannot support multiple existing OSSM subscriptions, so instead of
+		// trying to continue the workflow of making CIO take over the subscription
+		// the code is early returned without further update, and CIO can be marked
+		// with a degradation warning that allows the cluster admin to identify the
+		// other existing subscriptions, and decide further action.
+		// This does not block the rest of GatewayClass reconciliation, it just avoids
+		// CIO taking over subscriptions (or adding new ones) while other subscription
+		// exists.
 		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Name == name.Name && !ok {
 			return true, &subscription, nil
 		}

--- a/pkg/operator/controller/gatewayclass/subscription.go
+++ b/pkg/operator/controller/gatewayclass/subscription.go
@@ -35,8 +35,6 @@ const (
 // for servicemeshoperator is present and returns a Boolean indicating whether
 // it exists, the subscription if it exists, and an error value.
 func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, catalog, channel, version string) (bool, *operatorsv1alpha1.Subscription, error) {
-	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
-
 	var subscriptionList operatorsv1alpha1.SubscriptionList
 	// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
 	if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
@@ -45,21 +43,22 @@ func (r *reconciler) ensureServiceMeshOperatorSubscription(ctx context.Context, 
 		return false, nil, err
 	}
 
+	// There is a subscription that is not owned by us. In this case we early return
+	// because we cannot support multiple existing OSSM subscriptions, so instead of
+	// trying to continue the workflow of making CIO take over the subscription
+	// the code is early returned without further update, and CIO can be marked
+	// with a degradation warning that allows the cluster admin to identify the
+	// other existing subscriptions, and decide further action.
+	// This does not block the rest of GatewayClass reconciliation, it just avoids
+	// CIO taking over subscriptions (or adding new ones) while other subscription
+	// exists.
 	for _, subscription := range subscriptionList.Items {
-		// There is a subscription that is not owned by us. In this case we early return
-		// because we cannot support multiple existing OSSM subscriptions, so instead of
-		// trying to continue the workflow of making CIO take over the subscription
-		// the code is early returned without further update, and CIO can be marked
-		// with a degradation warning that allows the cluster admin to identify the
-		// other existing subscriptions, and decide further action.
-		// This does not block the rest of GatewayClass reconciliation, it just avoids
-		// CIO taking over subscriptions (or adding new ones) while other subscription
-		// exists.
-		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Name == name.Name && !ok {
+		if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; subscription.Spec.Package == "servicemeshoperator3" && !ok {
 			return true, &subscription, nil
 		}
 	}
 
+	name := operatorcontroller.ServiceMeshOperatorSubscriptionName()
 	have, current, err := r.currentSubscription(ctx, name)
 	if err != nil {
 		return false, nil, err

--- a/pkg/operator/controller/gatewayclass/subscription_test.go
+++ b/pkg/operator/controller/gatewayclass/subscription_test.go
@@ -9,6 +9,7 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -26,16 +27,15 @@ import (
 
 func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 	tests := []struct {
-		name            string
-		catalog         string
-		channel         string
-		version         string
-		existingObjects []runtime.Object
-		expectCreate    []client.Object
-		expectUpdate    []client.Object
-		expectDelete    []client.Object
-		expectHave      bool
-		expectErr       bool
+		name               string
+		catalog            string
+		channel            string
+		version            string
+		existingObjects    []runtime.Object
+		expectCreate       []client.Object
+		expectUpdate       []client.Object
+		expectDelete       []client.Object
+		expectSubscription *operatorsv1alpha1.Subscription
 	}{
 		{
 			name:            "No subscription exists, should create one",
@@ -53,7 +53,20 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 						},
 					},
 					Spec: &operatorsv1alpha1.SubscriptionSpec{
-						Channel:                "stable",
+						Channel: "stable",
+						Config: &operatorsv1alpha1.SubscriptionConfig{
+							Resources: &corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							Annotations: map[string]string{
+								securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+								WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+							},
+						},
 						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
 						Package:                "servicemeshoperator3",
 						CatalogSource:          "redhat-operators",
@@ -64,11 +77,39 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+					Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+					Annotations: map[string]string{
+						operatorcontroller.IngressOperatorOwnedAnnotation: "",
+					},
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel: "stable",
+					Config: &operatorsv1alpha1.SubscriptionConfig{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Annotations: map[string]string{
+							securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+							WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+						},
+					},
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "redhat-operators",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.1.0",
+				},
+			},
 		},
 		{
-			name:    "Subscription exists with servicemeshoperator3 package without ingress operator annotation, should return early",
+			name:    "Subscription exists with servicemeshoperator3 package without ingress operator annotation, should not create or update the subscription",
 			catalog: "redhat-operators",
 			channel: "stable",
 			version: "servicemeshoperator3.v3.1.0",
@@ -91,8 +132,20 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			expectCreate: []client.Object{},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+					Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel:                "stable",
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "user-catalog",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.0.0",
+				},
+			},
 		},
 		{
 			name:    "Subscription exists in different namespace with servicemeshoperator3 package without annotation, should return early",
@@ -118,11 +171,23 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			expectCreate: []client.Object{},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "other-namespace",
+					Name:      "user-managed-subscription",
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel:                "stable",
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "user-catalog",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.0.0",
+				},
+			},
 		},
 		{
-			name:    "Subscription exists with servicemeshoperator3 package WITH ingress operator annotation, should proceed normally",
+			name:    "Subscription exists with servicemeshoperator3 package WITH ingress operator annotation and is consistent with the desired subscription, should do nothing",
 			catalog: "redhat-operators",
 			channel: "stable",
 			version: "servicemeshoperator3.v3.1.0",
@@ -161,8 +226,36 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			expectCreate: []client.Object{},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+					Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+					Annotations: map[string]string{
+						operatorcontroller.IngressOperatorOwnedAnnotation: "",
+					},
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel: "stable",
+					Config: &operatorsv1alpha1.SubscriptionConfig{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Annotations: map[string]string{
+							securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+							WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+						},
+					},
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "redhat-operators",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.1.0",
+				},
+			},
 		},
 		{
 			name:    "Subscription exists with DIFFERENT package name, should create CIO subscription",
@@ -195,7 +288,20 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 						},
 					},
 					Spec: &operatorsv1alpha1.SubscriptionSpec{
-						Channel:                "stable",
+						Channel: "stable",
+						Config: &operatorsv1alpha1.SubscriptionConfig{
+							Resources: &corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							Annotations: map[string]string{
+								securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+								WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+							},
+						},
 						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
 						Package:                "servicemeshoperator3",
 						CatalogSource:          "redhat-operators",
@@ -206,8 +312,36 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+					Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+					Annotations: map[string]string{
+						operatorcontroller.IngressOperatorOwnedAnnotation: "",
+					},
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel: "stable",
+					Config: &operatorsv1alpha1.SubscriptionConfig{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Annotations: map[string]string{
+							securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+							WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+						},
+					},
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "redhat-operators",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.1.0",
+				},
+			},
 		},
 		{
 			name:    "Multiple subscriptions exist, one with servicemeshoperator3 without annotation, should return early",
@@ -244,8 +378,19 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			expectCreate: []client.Object{},
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace2",
+					Name:      "subscription2",
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel:                "stable",
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "user-catalog",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.0.0",
+				},
+			},
 		},
 		{
 			name:    "CIO-owned subscription needs version update",
@@ -282,7 +427,20 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 						},
 					},
 					Spec: &operatorsv1alpha1.SubscriptionSpec{
-						Channel:                "stable",
+						Channel: "stable",
+						Config: &operatorsv1alpha1.SubscriptionConfig{
+							Resources: &corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							Annotations: map[string]string{
+								securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+								WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+							},
+						},
 						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
 						Package:                "servicemeshoperator3",
 						CatalogSource:          "redhat-operators",
@@ -292,8 +450,36 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 				},
 			},
 			expectDelete: []client.Object{},
-			expectHave:   true,
-			expectErr:    false,
+			expectSubscription: &operatorsv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+					Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+					Annotations: map[string]string{
+						operatorcontroller.IngressOperatorOwnedAnnotation: "",
+					},
+				},
+				Spec: &operatorsv1alpha1.SubscriptionSpec{
+					Channel: "stable",
+					Config: &operatorsv1alpha1.SubscriptionConfig{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Annotations: map[string]string{
+							securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+							WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+						},
+					},
+					InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+					Package:                "servicemeshoperator3",
+					CatalogSource:          "redhat-operators",
+					CatalogSourceNamespace: "openshift-marketplace",
+					StartingCSV:            "servicemeshoperator3.v3.2.0",
+				},
+			},
 		},
 	}
 
@@ -319,23 +505,12 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 					GatewayAPIOperatorVersion: tc.version,
 				},
 			}
-			have, _, err := reconciler.ensureServiceMeshOperatorSubscription(context.Background(), tc.catalog, tc.channel, tc.version)
-			if tc.expectErr && err == nil {
-				t.Fatalf("expected error, got nil")
-			}
-			if !tc.expectErr && err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if have != tc.expectHave {
-				t.Fatalf("expected have=%v, got have=%v", tc.expectHave, have)
-			}
+			_, actualSubscription, err := reconciler.ensureServiceMeshOperatorSubscription(context.Background(), tc.catalog, tc.channel, tc.version)
+			require.NoError(t, err)
 			cmpOpts := []cmp.Option{
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
-				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
-				cmpopts.IgnoreFields(operatorsv1alpha1.Subscription{}, "TypeMeta"),
-				cmpopts.IgnoreFields(operatorsv1alpha1.SubscriptionSpec{}, "Config"),
 			}
 			if diff := cmp.Diff(tc.expectCreate, cl.added, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual creates: %s", diff)
@@ -345,6 +520,14 @@ func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expectDelete, cl.deleted, cmpOpts...); diff != "" {
 				t.Fatalf("found diff between expected and actual deletes: %s", diff)
+			}
+
+			// Verify the returned subscription matches expectations
+			if tc.expectSubscription != nil {
+				require.NotNil(t, actualSubscription, "expected subscription to be returned but got nil")
+				if diff := cmp.Diff(tc.expectSubscription, actualSubscription, cmpOpts...); diff != "" {
+					t.Fatalf("found diff between expected and actual returned subscription: %s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/operator/controller/gatewayclass/subscription_test.go
+++ b/pkg/operator/controller/gatewayclass/subscription_test.go
@@ -6,9 +6,12 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,6 +23,332 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func Test_ensureServiceMeshOperatorSubscription(t *testing.T) {
+	tests := []struct {
+		name            string
+		catalog         string
+		channel         string
+		version         string
+		existingObjects []runtime.Object
+		expectCreate    []client.Object
+		expectUpdate    []client.Object
+		expectDelete    []client.Object
+		expectHave      bool
+		expectErr       bool
+	}{
+		{
+			name:            "No subscription exists, should create one",
+			catalog:         "redhat-operators",
+			channel:         "stable",
+			version:         "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{},
+			expectCreate: []client.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.1.0",
+					},
+				},
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "Subscription exists with servicemeshoperator3 package without ingress operator annotation, should return early",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "user-catalog",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.0.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "Subscription exists in different namespace with servicemeshoperator3 package without annotation, should return early",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "other-namespace",
+						Name:      "user-managed-subscription",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "user-catalog",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.0.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "Subscription exists with servicemeshoperator3 package WITH ingress operator annotation, should proceed normally",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel: "stable",
+						Config: &operatorsv1alpha1.SubscriptionConfig{
+							Resources: &corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							Annotations: map[string]string{
+								securityv1.RequiredSCCAnnotation:            RequiredSCCRestrictedV2,
+								WorkloadPartitioningManagementAnnotationKey: WorkloadPartitioningManagementPreferredScheduling,
+							},
+						},
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.1.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "Subscription exists with DIFFERENT package name, should create CIO subscription",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      "different-subscription",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "some-other-operator",
+						CatalogSource:          "user-catalog",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "some-other-operator.v1.0.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.1.0",
+					},
+				},
+			},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "Multiple subscriptions exist, one with servicemeshoperator3 without annotation, should return early",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.1.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace1",
+						Name:      "subscription1",
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Package: "some-other-package",
+					},
+				},
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace2",
+						Name:      "subscription2",
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "user-catalog",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.0.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+		{
+			name:    "CIO-owned subscription needs version update",
+			catalog: "redhat-operators",
+			channel: "stable",
+			version: "servicemeshoperator3.v3.2.0",
+			existingObjects: []runtime.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.1.0",
+					},
+				},
+			},
+			expectCreate: []client.Object{},
+			expectUpdate: []client.Object{
+				&operatorsv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorcontroller.ServiceMeshOperatorSubscriptionName().Namespace,
+						Name:      operatorcontroller.ServiceMeshOperatorSubscriptionName().Name,
+						Annotations: map[string]string{
+							operatorcontroller.IngressOperatorOwnedAnnotation: "",
+						},
+					},
+					Spec: &operatorsv1alpha1.SubscriptionSpec{
+						Channel:                "stable",
+						InstallPlanApproval:    operatorsv1alpha1.ApprovalManual,
+						Package:                "servicemeshoperator3",
+						CatalogSource:          "redhat-operators",
+						CatalogSourceNamespace: "openshift-marketplace",
+						StartingCSV:            "servicemeshoperator3.v3.2.0",
+					},
+				},
+			},
+			expectDelete: []client.Object{},
+			expectHave:   true,
+			expectErr:    false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	configv1.Install(scheme)
+	apiextensionsv1.AddToScheme(scheme)
+	operatorsv1alpha1.AddToScheme(scheme)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tc.existingObjects...).
+				Build()
+			cl := &fakeClientRecorder{fakeClient, t, []client.Object{}, []client.Object{}, []client.Object{}}
+			reconciler := &reconciler{
+				client: cl,
+				config: Config{
+					OperatorNamespace:         "",
+					OperandNamespace:          "",
+					GatewayAPIOperatorCatalog: tc.catalog,
+					GatewayAPIOperatorChannel: tc.channel,
+					GatewayAPIOperatorVersion: tc.version,
+				},
+			}
+			have, _, err := reconciler.ensureServiceMeshOperatorSubscription(context.Background(), tc.catalog, tc.channel, tc.version)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if have != tc.expectHave {
+				t.Fatalf("expected have=%v, got have=%v", tc.expectHave, have)
+			}
+			cmpOpts := []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
+				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
+				cmpopts.IgnoreFields(operatorsv1alpha1.Subscription{}, "TypeMeta"),
+				cmpopts.IgnoreFields(operatorsv1alpha1.SubscriptionSpec{}, "Config"),
+			}
+			if diff := cmp.Diff(tc.expectCreate, cl.added, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual creates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectUpdate, cl.updated, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual updates: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectDelete, cl.deleted, cmpOpts...); diff != "" {
+				t.Fatalf("found diff between expected and actual deletes: %s", diff)
+			}
+		})
+	}
+}
 
 func Test_ensureServiceMeshOperatorInstallPlan(t *testing.T) {
 	tests := []struct {

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -88,6 +88,10 @@ const (
 	// ManagedByIstioLabelKey is the key of a label that Istio adds to
 	// resources that it manages.
 	ManagedByIstioLabelKey = "gateway.istio.io/managed"
+
+	// ServiceMeshOperatorSubscriptionPackage represents the name of the package
+	// on a OLM subscription that installs OSSM
+	ServiceMeshOperatorSubscriptionPackage = "servicemeshoperator3"
 )
 
 // IngressClusterOperatorName returns the namespaced name of the ClusterOperator

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -654,7 +654,7 @@ func computeGatewayAPIInstallDegradedCondition(state operatorState) configv1.Clu
 	conflicts := []string{}
 	warnings := []string{}
 	for _, subscription := range state.ossmSubscriptions {
-		if subscription.Spec.Package == "servicemeshoperator3" {
+		if subscription.Spec.Package == operatorcontroller.ServiceMeshOperatorSubscriptionPackage {
 			if _, found := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; found {
 				// The subscription that the ingress operator creates naturally does not conflict with itself.
 				continue

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -290,13 +290,13 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			Name:     state.CanaryNamespace.Name,
 		})
 	}
-	if state.haveOSSMSubscription {
-		subscriptionName := operatorcontroller.ServiceMeshOperatorSubscriptionName()
+
+	for _, subscription := range state.ossmSubscriptions {
 		related = append(related, configv1.ObjectReference{
 			Group:     operatorsv1alpha1.GroupName,
 			Resource:  "subscriptions",
-			Namespace: subscriptionName.Namespace,
-			Name:      subscriptionName.Name,
+			Namespace: subscription.Namespace,
+			Name:      subscription.Name,
 		})
 	}
 	if state.haveIstiosResource {
@@ -391,8 +391,6 @@ type operatorState struct {
 	unmanagedGatewayAPICRDNames string
 	// useSailLibrary indicates whether the GatewayAPIWithoutOLM feature is enabled.
 	useSailLibrary bool
-	// haveOSSMSubscription means that the subscription for OSSM 3 exists.
-	haveOSSMSubscription bool
 	// haveIstiosResource means that the "istios.sailproject.io" CRD exists.
 	haveIstiosResource bool
 	// haveGatewaysResource means that the
@@ -456,16 +454,6 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 	useSailLibrary := r.config.GatewayAPIWithoutOLMEnabled
 	state.useSailLibrary = useSailLibrary
 	if useOLM || useSailLibrary {
-		var subscription operatorsv1alpha1.Subscription
-		subscriptionName := operatorcontroller.ServiceMeshOperatorSubscriptionName()
-		if err := r.cache.Get(ctx, subscriptionName, &subscription); err != nil {
-			if !errors.IsNotFound(err) {
-				return state, fmt.Errorf("failed to get subscription %q: %v", subscriptionName, err)
-			}
-		} else {
-			state.haveOSSMSubscription = true
-
-		}
 		var (
 			crd                                  apiextensionsv1.CustomResourceDefinition
 			gatewaysResourceNamespacedName       = types.NamespacedName{Name: gatewaysResourceName}
@@ -501,7 +489,9 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 		// In Sail Library mode, we don't check for subscription conflicts, so no need to list them.
 		if useOLM {
 			subscriptionList := operatorsv1alpha1.SubscriptionList{}
-			if err := r.subscriptionCache.List(ctx, &subscriptionList); err != nil {
+			if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
+				Namespace: "",
+			}); err != nil {
 				return state, fmt.Errorf("failed to get subscriptions: %w", err)
 			}
 			for _, subscription := range subscriptionList.Items {

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -489,6 +489,7 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 		// In Sail Library mode, we don't check for subscription conflicts, so no need to list them.
 		if useOLM {
 			subscriptionList := operatorsv1alpha1.SubscriptionList{}
+			// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
 			if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
 				Namespace: "",
 			}); err != nil {

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -671,13 +671,13 @@ func computeGatewayAPIInstallDegradedCondition(state operatorState) configv1.Clu
 			case versionDiff < 0:
 				// Installed version is newer than expected. Gateway API install may still work if the correct Istio
 				// version is supported. Warn the user that the installed OSSM version may be incompatible.
-				warnings = append(warnings, fmt.Sprintf("Found version %s, but operator-managed Gateway API expects version %s. Operator-managed Gateway API may not work as intended.", subscription.Status.InstalledCSV, state.expectedGatewayAPIOperatorVersion))
+				warnings = append(warnings, fmt.Sprintf("Found version %s on %s/%s, but operator-managed Gateway API expects version %s. Operator-managed Gateway API may not work as intended.", subscription.Status.InstalledCSV, subscription.Namespace, subscription.Name, state.expectedGatewayAPIOperatorVersion))
 			case versionDiff > 0:
 				// Installed version is older than expected. Gateway API install will not work, since the correct Istio
 				// version won't be supported.
 				conflicts = append(conflicts, fmt.Sprintf("Installed version %s does not support operator-managed Gateway API. Install version %s or uninstall %s/%s to enable functionality.", subscription.Status.InstalledCSV, state.expectedGatewayAPIOperatorVersion, subscription.Namespace, subscription.Name))
 			case versionDiff == 0:
-				// Installed version is exactly as expected. Nothing to do.
+				warnings = append(warnings, fmt.Sprintf("Found the expected version %s on %s/%s, but the subscription is not managed by ingress operator. Operator-managed Gateway API may not work as intended.", subscription.Status.InstalledCSV, subscription.Namespace, subscription.Name))
 			}
 		} else {
 			conflicts = append(conflicts, fmt.Sprintf("Package %s from subscription %s/%s prevents enabling operator-managed Gateway API. Uninstall %s/%s to enable functionality.", subscription.Spec.Package, subscription.Namespace, subscription.Name, subscription.Namespace, subscription.Name))

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -896,7 +896,27 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionFalse,
 				Reason:  "IngressNotDegradedAndGatewayAPIInstallWarnings",
-				Message: "The \"default\" ingress controller reports Degraded=False.\nFound version servicemeshoperator3.v3.5.0, but operator-managed Gateway API expects version servicemeshoperator3.v3.1.0. Operator-managed Gateway API may not work as intended.",
+				Message: "The \"default\" ingress controller reports Degraded=False.\nFound version servicemeshoperator3.v3.5.0 on foo/servicemeshoperator3, but operator-managed Gateway API expects version servicemeshoperator3.v3.1.0. Operator-managed Gateway API may not work as intended.",
+			},
+		},
+		{
+			description: "Gateway API Enabled, exact expected OSSM3 version but not CIO-owned",
+			modes:       olmMode,
+			state: operatorState{
+				IngressControllers: []operatorv1.IngressController{
+					icWithStatus("default", false),
+				},
+				ossmSubscriptions: []operatorsv1alpha1.Subscription{
+					sub("servicemeshoperator3", "servicemeshoperator3", "servicemeshoperator3.v3.1.0", false),
+				},
+				shouldInstallOSSM:                 true,
+				expectedGatewayAPIOperatorVersion: "servicemeshoperator3.v3.1.0",
+			},
+			expectCondition: configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorDegraded,
+				Status:  configv1.ConditionFalse,
+				Reason:  "IngressNotDegradedAndGatewayAPIInstallWarnings",
+				Message: "The \"default\" ingress controller reports Degraded=False.\nFound the expected version servicemeshoperator3.v3.1.0 on foo/servicemeshoperator3, but the subscription is not managed by ingress operator. Operator-managed Gateway API may not work as intended.",
 			},
 		},
 		{


### PR DESCRIPTION
This change implements a check if there is an OSSM subscription already on the cluster, and on a different namespace expected by CIO. In that case the OSSM installation will be skipped and a status condition will be added to the ingress controller status informing that while it is not degraded, there is a warning of Gateway API about the installed ossm version
