### PR TITLE
OCPBUGS-74497: Add UserAgent to Azure SDK client telemetry options

### DIFF
--- a/pkg/dns/azure/client/auth.go
+++ b/pkg/dns/azure/client/auth.go
@@ -57,7 +57,8 @@ func getAzureCredentials(config Config) (azcore.TokenCredential, error) {
 	var cred azcore.TokenCredential
 	if userAssignedIdentityCredentialsFilePath != "" {
 		options := azcore.ClientOptions{
-			Cloud: cloudConfig,
+			Cloud:     cloudConfig,
+			Telemetry: telemetryOptions(),
 		}
 		var err error
 		cred, err = dataplane.NewUserAssignedIdentityCredential(context.Background(), userAssignedIdentityCredentialsFilePath, dataplane.WithClientOpts(options))
@@ -67,7 +68,8 @@ func getAzureCredentials(config Config) (azcore.TokenCredential, error) {
 	} else if config.AzureWorkloadIdentityEnabled && strings.TrimSpace(config.ClientSecret) == "" {
 		options := azidentity.WorkloadIdentityCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
-				Cloud: cloudConfig,
+				Cloud:     cloudConfig,
+				Telemetry: telemetryOptions(),
 			},
 			ClientID:      config.ClientID,
 			TenantID:      config.TenantID,
@@ -81,7 +83,8 @@ func getAzureCredentials(config Config) (azcore.TokenCredential, error) {
 	} else {
 		options := azidentity.ClientSecretCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
-				Cloud: cloudConfig,
+				Cloud:     cloudConfig,
+				Telemetry: telemetryOptions(),
 			},
 		}
 		var err error

--- a/pkg/dns/azure/client/client.go
+++ b/pkg/dns/azure/client/client.go
@@ -12,6 +12,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// userAgent is the User-Agent identifier for the Cluster Ingress Operator.
+// Azure SDK has a 24-character limit for ApplicationID, and spaces are replaced with '/'.
+const userAgent = "cluster-ingress-operator"
+
+func telemetryOptions() policy.TelemetryOptions {
+	return policy.TelemetryOptions{
+		ApplicationID: userAgent,
+	}
+}
+
 type DNSClient interface {
 	Put(ctx context.Context, zone Zone, arec ARecord, metadata map[string]*string) error
 	Delete(ctx context.Context, zone Zone, arec ARecord) error
@@ -106,7 +116,8 @@ func newRecordSetClient(config Config, credential azcore.TokenCredential) (*reco
 	cloudConfig := ParseCloudEnvironment(config)
 	options := &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
-			Cloud: cloudConfig,
+			Cloud:     cloudConfig,
+			Telemetry: telemetryOptions(),
 		},
 	}
 
@@ -150,7 +161,8 @@ func newPrivateRecordSetClient(config Config, credential azcore.TokenCredential)
 	cloudConfig := ParseCloudEnvironment(config)
 	options := &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
-			Cloud: cloudConfig,
+			Cloud:     cloudConfig,
+			Telemetry: telemetryOptions(),
 		},
 	}
 

--- a/pkg/dns/azure/client/client_test.go
+++ b/pkg/dns/azure/client/client_test.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelemetryOptions(t *testing.T) {
+	opts := telemetryOptions()
+
+	assert.Equal(t, "cluster-ingress-operator", opts.ApplicationID, "unexpected ApplicationID in telemetry options")
+	assert.LessOrEqual(t, len(opts.ApplicationID), 24, "ApplicationID exceeds the Azure SDK 24-character limit")
+	assert.NotContains(t, opts.ApplicationID, " ", "ApplicationID must not contain spaces; the Azure SDK replaces them with '/'")
+}


### PR DESCRIPTION
## What this PR does / why we need it

The Cluster Ingress Operator is not setting the ApplicationID in the Azure SDK
TelemetryOptions when creating Azure ARM SDK clients and credential clients.
This means Azure API requests from CIO do not include proper application
identification in the User-Agent header for request tracing and telemetry purposes.

This PR adds `policy.TelemetryOptions` with `ApplicationID` to:
- ARM dns `RecordSetsClient`
- ARM dns `PrivateRecordSetsClient`
- Azure credential clients (`UserAssignedIdentityCredential`, `WorkloadIdentityCredential`, `ClientSecretCredential`)

## Which issue(s) this PR fixes

Fixes https://issues.redhat.com/browse/OCPBUGS-74497

## Special notes for your reviewer

- The `ApplicationID` value is set to `cluster-ingress-operator`, defined as a package-level constant with a helper function `telemetryOptions()`, consistent with other OpenShift operators (hypershift, cluster-image-registry-operator, cloud-network-config-controller). The Azure SDK enforces a maximum of 24 characters with no spaces for this field.
- The Jira issue only mentions the ARM DNS clients, but the same problem exists in the credential clients (`auth.go`). This PR fixes both.

## Checklist

- [x] Subject and description added to both the commit and PR
- [x] Relevant issues referenced
- [x] Unit tests included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced telemetry collection for Azure DNS operations to improve system observability and diagnostics.
  * Implemented standardized telemetry tracking across all Azure credential authentication methods: managed identity, workload identity, and client secret authentication.
  * Added comprehensive validation testing to ensure telemetry configuration meets requirements and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->