### PR TITLE
OCPBUGS-80966: Fix malformed PEM bundle when tls.crt lacks trailing newline

### DIFF
--- a/pkg/operator/controller/certificate-publisher/publish_certs.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs.go
@@ -227,7 +227,7 @@ func validatePEMBundle(bundle []byte) error {
 		decoded++
 	}
 	if decoded < 2 {
-		return fmt.Errorf("expected at least certificate and key PEM blocks, got %d", decoded)
+		return fmt.Errorf("expected at least 2 PEM blocks, got %d", decoded)
 	}
 	return nil
 }

--- a/pkg/operator/controller/certificate-publisher/publish_certs.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs.go
@@ -3,6 +3,7 @@ package certificatepublisher
 import (
 	"bytes"
 	"context"
+	"encoding/pem"
 	"fmt"
 	"reflect"
 
@@ -85,16 +86,17 @@ func desiredRouterCertsGlobalSecret(secrets []corev1.Secret, ingresses []operato
 		}
 
 		globalCertName := controller.RouterCertsGlobalSecretName()
+		bundle := joinPEMBlocks(cert.Data["tls.crt"], cert.Data["tls.key"])
+		if err := validatePEMBundle(bundle); err != nil {
+			return nil, fmt.Errorf("assembled PEM bundle for domain %q is invalid: %w", ingresses[i].Status.Domain, err)
+		}
 		return &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      globalCertName.Name,
 				Namespace: globalCertName.Namespace,
 			},
 			Data: map[string][]byte{
-				ingresses[i].Status.Domain: bytes.Join([][]byte{
-					cert.Data["tls.crt"],
-					cert.Data["tls.key"],
-				}, nil),
+				ingresses[i].Status.Domain: bundle,
 			},
 		}, nil
 	}
@@ -191,6 +193,43 @@ func (r *reconciler) deleteRouterCertsGlobalSecret(secret *corev1.Secret) (bool,
 		return false, err
 	}
 	return true, nil
+}
+
+// joinPEMBlocks concatenates PEM-encoded blocks, ensuring each block is
+// separated by a newline.  This prevents malformed PEM output when a block
+// does not end with a trailing newline, which can happen with certificates
+// produced by certain tools.
+func joinPEMBlocks(blocks ...[]byte) []byte {
+	var buf []byte
+	for _, b := range blocks {
+		if len(b) == 0 {
+			continue
+		}
+		buf = append(buf, b...)
+		if b[len(b)-1] != '\n' {
+			buf = append(buf, '\n')
+		}
+	}
+	return buf
+}
+
+// validatePEMBundle verifies that the given byte slice contains only valid PEM
+// blocks and that there are at least two (certificate + key).
+func validatePEMBundle(bundle []byte) error {
+	rest := bundle
+	decoded := 0
+	for len(bytes.TrimSpace(rest)) > 0 {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return fmt.Errorf("failed to decode PEM block")
+		}
+		decoded++
+	}
+	if decoded < 2 {
+		return fmt.Errorf("expected at least certificate and key PEM blocks, got %d", decoded)
+	}
+	return nil
 }
 
 // routerCertsSecretsEqual compares two router-certs secrets.  Returns true if

--- a/pkg/operator/controller/certificate-publisher/publish_certs_test.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs_test.go
@@ -2,7 +2,17 @@ package certificatepublisher
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
 	"testing"
+	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
@@ -11,17 +21,45 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// generatePEMKeyPair generates a unique self-signed certificate and key in PEM
+// format.  The certificate's CN is set to the provided name so that each call
+// produces distinct PEM data, preserving the ability of table-driven tests to
+// verify which secret was selected.
+func generatePEMKeyPair(name string) (certPEM, keyPEM []byte) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate key for %q: %v", name, err))
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create certificate for %q: %v", name, err))
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal key for %q: %v", name, err))
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
 // newSecret returns a secret with the specified name and with data fields
-// "tls.crt" and "tls.key" set to the secret's name.  Note that the values for
-// "tls.crt" and "tls.key" are not valid PEM data.
+// "tls.crt" and "tls.key" set to valid PEM data unique to the secret name.
 func newSecret(name string) corev1.Secret {
+	certPEM, keyPEM := generatePEMKeyPair(name)
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Data: map[string][]byte{
-			"tls.crt": []byte(name),
-			"tls.key": []byte(name),
+			"tls.crt": certPEM,
+			"tls.key": keyPEM,
 		},
 	}
 }
@@ -99,18 +137,12 @@ func Test_desiredRouterCertsGlobalSecret(t *testing.T) {
 		// admitted by the operator.
 		invalidCustomICWithClusterIngressDomain = newIngressController("custom", "custom-router-certs-default", "apps.my.devcluster.openshift.com", false)
 
-		ic1             = newIngressController("ic1", "s1", "dom1", true)
-		ic2             = newIngressController("ic2", "s2", "dom2", true)
-		s1              = newSecret("s1")
-		s2              = newSecret("s2")
-		defaultCertData = bytes.Join([][]byte{
-			defaultCert.Data["tls.crt"],
-			defaultCert.Data["tls.key"],
-		}, nil)
-		customDefaultCertData = bytes.Join([][]byte{
-			customDefaultCert.Data["tls.crt"],
-			customDefaultCert.Data["tls.key"],
-		}, nil)
+		ic1                   = newIngressController("ic1", "s1", "dom1", true)
+		ic2                   = newIngressController("ic2", "s2", "dom2", true)
+		s1                    = newSecret("s1")
+		s2                    = newSecret("s2")
+		defaultCertData       = joinPEMBlocks(defaultCert.Data["tls.crt"], defaultCert.Data["tls.key"])
+		customDefaultCertData = joinPEMBlocks(customDefaultCert.Data["tls.crt"], customDefaultCert.Data["tls.key"])
 	)
 	testCases := []struct {
 		description string
@@ -277,6 +309,182 @@ func Test_desiredRouterCertsGlobalSecret(t *testing.T) {
 					t.Errorf("expected %v, got %v", expected, actual)
 				}
 			}
+		})
+	}
+}
+
+// generateTestCertAndKey creates a self-signed cert and private key in PEM
+// format.  If noTrailingNewline is true, the trailing newline is stripped from
+// the certificate PEM to simulate certs produced by certain tools.
+func generateTestCertAndKey(t *testing.T, noTrailingNewline bool) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "*.apps.example.com"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if noTrailingNewline {
+		certPEM = bytes.TrimRight(certPEM, "\n")
+	}
+
+	return certPEM, keyPEM
+}
+
+// Test_desiredRouterCertsGlobalSecret_PEMNewline verifies that
+// desiredRouterCertsGlobalSecret produces a valid PEM bundle regardless of
+// whether tls.crt has a trailing newline.  Previously, bytes.Join with a nil
+// separator would concatenate the END CERTIFICATE and BEGIN PRIVATE KEY
+// markers on the same line when tls.crt lacked a trailing newline, producing
+// a malformed PEM bundle that downstream consumers could not parse.
+func Test_desiredRouterCertsGlobalSecret_PEMNewline(t *testing.T) {
+	domain := "apps.my.devcluster.openshift.com"
+
+	testCases := []struct {
+		name              string
+		noTrailingNewline bool
+	}{
+		{
+			name:              "cert with trailing newline produces valid PEM",
+			noTrailingNewline: false,
+		},
+		{
+			name:              "cert without trailing newline produces valid PEM",
+			noTrailingNewline: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certPEM, keyPEM := generateTestCertAndKey(t, tc.noTrailingNewline)
+
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "router-certs-default",
+				},
+				Data: map[string][]byte{
+					"tls.crt": certPEM,
+					"tls.key": keyPEM,
+				},
+			}
+
+			ic := newIngressController("default", "", domain, true)
+
+			result, err := desiredRouterCertsGlobalSecret(
+				[]corev1.Secret{secret},
+				[]operatorv1.IngressController{ic},
+				"openshift-ingress",
+				domain,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a secret, got nil")
+			}
+
+			bundleData := result.Data[domain]
+
+			// The bundle must not contain concatenated PEM markers
+			if strings.Contains(string(bundleData), "-----END CERTIFICATE----------BEGIN") {
+				t.Errorf("PEM bundle contains concatenated markers:\n%s", string(bundleData))
+			}
+
+			// The bundle must yield both a CERTIFICATE and a key block
+			var blockTypes []string
+			rest := bundleData
+			for {
+				var block *pem.Block
+				block, rest = pem.Decode(rest)
+				if block == nil {
+					break
+				}
+				blockTypes = append(blockTypes, block.Type)
+			}
+			if len(blockTypes) != 2 {
+				t.Errorf("expected 2 PEM blocks (CERTIFICATE + key), got %d: %v\nPEM bundle:\n%s", len(blockTypes), blockTypes, string(bundleData))
+			}
+		})
+	}
+}
+
+// Test_joinPEMBlocks verifies that joinPEMBlocks produces well-formed output
+// for various input combinations.
+func Test_joinPEMBlocks(t *testing.T) {
+	withNewline := []byte("-----BEGIN CERTIFICATE-----\ndata\n-----END CERTIFICATE-----\n")
+	withoutNewline := []byte("-----BEGIN CERTIFICATE-----\ndata\n-----END CERTIFICATE-----")
+	keyBlock := []byte("-----BEGIN EC PRIVATE KEY-----\nkeydata\n-----END EC PRIVATE KEY-----\n")
+
+	testCases := []struct {
+		name   string
+		blocks [][]byte
+		check  func(t *testing.T, result []byte)
+	}{
+		{
+			name:   "both blocks have trailing newlines",
+			blocks: [][]byte{withNewline, keyBlock},
+			check: func(t *testing.T, result []byte) {
+				// Should not double up newlines
+				if strings.Contains(string(result), "\n\n") {
+					t.Error("unexpected double newline")
+				}
+			},
+		},
+		{
+			name:   "first block missing trailing newline",
+			blocks: [][]byte{withoutNewline, keyBlock},
+			check: func(t *testing.T, result []byte) {
+				if strings.Contains(string(result), "----------") {
+					t.Error("markers concatenated without newline")
+				}
+			},
+		},
+		{
+			name:   "empty block is skipped",
+			blocks: [][]byte{nil, withNewline, {}, keyBlock},
+			check: func(t *testing.T, result []byte) {
+				if !bytes.Equal(result, append(withNewline, keyBlock...)) {
+					t.Errorf("unexpected output: %q", result)
+				}
+			},
+		},
+		{
+			name:   "all empty blocks",
+			blocks: [][]byte{nil, {}},
+			check: func(t *testing.T, result []byte) {
+				if len(result) != 0 {
+					t.Errorf("expected empty output, got %q", result)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := joinPEMBlocks(tc.blocks...)
+			tc.check(t, result)
 		})
 	}
 }

--- a/pkg/operator/controller/certificate-publisher/publish_certs_test.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs_test.go
@@ -355,16 +355,20 @@ func generateTestCertAndKey(t *testing.T, noTrailingNewline bool) (certPEM, keyP
 
 // Test_desiredRouterCertsGlobalSecret_PEMNewline verifies that
 // desiredRouterCertsGlobalSecret produces a valid PEM bundle regardless of
-// whether tls.crt has a trailing newline.  Previously, bytes.Join with a nil
-// separator would concatenate the END CERTIFICATE and BEGIN PRIVATE KEY
-// markers on the same line when tls.crt lacked a trailing newline, producing
-// a malformed PEM bundle that downstream consumers could not parse.
+// whether tls.crt has a trailing newline, and rejects malformed PEM input.
+// Previously, bytes.Join with a nil separator would concatenate the END
+// CERTIFICATE and BEGIN PRIVATE KEY markers on the same line when tls.crt
+// lacked a trailing newline, producing a malformed PEM bundle that downstream
+// consumers could not parse.
 func Test_desiredRouterCertsGlobalSecret_PEMNewline(t *testing.T) {
 	domain := "apps.my.devcluster.openshift.com"
 
 	testCases := []struct {
 		name              string
 		noTrailingNewline bool
+		mutateCertPEM     func([]byte) []byte
+		mutateKeyPEM      func([]byte) []byte
+		wantErrSubstring  string
 	}{
 		{
 			name:              "cert with trailing newline produces valid PEM",
@@ -374,11 +378,24 @@ func Test_desiredRouterCertsGlobalSecret_PEMNewline(t *testing.T) {
 			name:              "cert without trailing newline produces valid PEM",
 			noTrailingNewline: true,
 		},
+		{
+			name: "malformed key PEM returns error",
+			mutateKeyPEM: func([]byte) []byte {
+				return []byte("not a PEM block")
+			},
+			wantErrSubstring: "failed to decode PEM block",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			certPEM, keyPEM := generateTestCertAndKey(t, tc.noTrailingNewline)
+			if tc.mutateCertPEM != nil {
+				certPEM = tc.mutateCertPEM(certPEM)
+			}
+			if tc.mutateKeyPEM != nil {
+				keyPEM = tc.mutateKeyPEM(keyPEM)
+			}
 
 			secret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -398,6 +415,18 @@ func Test_desiredRouterCertsGlobalSecret_PEMNewline(t *testing.T) {
 				"openshift-ingress",
 				domain,
 			)
+			if len(tc.wantErrSubstring) != 0 {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrSubstring, err)
+				}
+				if result != nil {
+					t.Fatalf("expected no secret on error, got %#v", result)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -412,19 +441,25 @@ func Test_desiredRouterCertsGlobalSecret_PEMNewline(t *testing.T) {
 				t.Errorf("PEM bundle contains concatenated markers:\n%s", string(bundleData))
 			}
 
-			// The bundle must yield both a CERTIFICATE and a key block
-			var blockTypes []string
-			rest := bundleData
-			for {
-				var block *pem.Block
-				block, rest = pem.Decode(rest)
-				if block == nil {
-					break
-				}
-				blockTypes = append(blockTypes, block.Type)
+			// The bundle must contain exactly a CERTIFICATE block followed by the key block.
+			firstBlock, rest := pem.Decode(bundleData)
+			if firstBlock == nil {
+				t.Fatalf("expected first PEM block, got nil\nPEM bundle:\n%s", string(bundleData))
 			}
-			if len(blockTypes) != 2 {
-				t.Errorf("expected 2 PEM blocks (CERTIFICATE + key), got %d: %v\nPEM bundle:\n%s", len(blockTypes), blockTypes, string(bundleData))
+			if firstBlock.Type != "CERTIFICATE" {
+				t.Fatalf("expected first PEM block type CERTIFICATE, got %q\nPEM bundle:\n%s", firstBlock.Type, string(bundleData))
+			}
+
+			secondBlock, rest := pem.Decode(rest)
+			if secondBlock == nil {
+				t.Fatalf("expected second PEM block, got nil\nPEM bundle:\n%s", string(bundleData))
+			}
+			if secondBlock.Type != "EC PRIVATE KEY" {
+				t.Fatalf("expected second PEM block type EC PRIVATE KEY, got %q\nPEM bundle:\n%s", secondBlock.Type, string(bundleData))
+			}
+
+			if len(bytes.TrimSpace(rest)) != 0 {
+				t.Fatalf("expected exactly 2 PEM blocks, found trailing data %q\nPEM bundle:\n%s", string(rest), string(bundleData))
 			}
 		})
 	}


### PR DESCRIPTION
[OCPBUGS-80966](https://redhat.atlassian.net/browse/OCPBUGS-80966)

## Summary

- The certificate publisher concatenated `tls.crt` and `tls.key` using `bytes.Join` with a `nil` separator. When `tls.crt` did not end with a trailing newline (valid PEM, can happen with certs from certain tools), the `END CERTIFICATE` and `BEGIN PRIVATE KEY` markers were concatenated on the same line, making the entire PEM unparseable.
- This caused the authentication operator to go degraded with a `MalformedRouterCertsPEM` condition because it could not parse the `v4-0-config-system-router-certs` secret copied from `openshift-config-managed/router-certs`.
- Replace `bytes.Join` with a `joinPEMBlocks` helper that ensures each PEM block is newline-terminated before concatenation. Add `pem.Decode` validation after assembly so malformed bundles are caught at the source.

## Test plan

- [x] `go test ./pkg/operator/controller/certificate-publisher/` passes (17 tests)
- [x] Existing table-driven tests use distinct PEM data per secret, preserving certificate-selection coverage
- [x] New `Test_desiredRouterCertsGlobalSecret_PEMNewline` verifies both trailing-newline and no-trailing-newline cases produce valid, parseable PEM bundles
- [x] New `Test_joinPEMBlocks` covers: both blocks OK, missing trailing newline, empty blocks skipped, all-empty input