### PR TITLE
OCPBUGS-81442: TestUnsupportedConfigOverride: Ignore featuregate and defaults

### DIFF
--- a/test/e2e/checkinterval_test.go
+++ b/test/e2e/checkinterval_test.go
@@ -57,7 +57,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	}
 
 	// verify the update to double the default
-	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, deploymentTimeout, ingresscontroller.RouterBackendCheckInterval, (2 * defaultHealthCheckInterval).String()); err != nil {
+	if err := waitForDeploymentEnvVar(t, routerDeployment, deploymentTimeout, ingresscontroller.RouterBackendCheckInterval, (2 * defaultHealthCheckInterval).String()); err != nil {
 		t.Fatalf("expected router deployment to set %s to %v: %v", ingresscontroller.RouterBackendCheckInterval, 2*defaultHealthCheckInterval, err)
 	}
 
@@ -71,7 +71,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	}
 
 	// when set to an unacceptable value, the env variable should not exist
-	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, deploymentTimeout, ingresscontroller.RouterBackendCheckInterval, ""); err != nil {
+	if err := waitForDeploymentEnvVar(t, routerDeployment, deploymentTimeout, ingresscontroller.RouterBackendCheckInterval, ""); err != nil {
 		t.Fatalf("expected router deployment to remove %s: %v", ingresscontroller.RouterBackendCheckInterval, err)
 	}
 }

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -315,7 +315,7 @@ func TestClientTLS(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller %q: %v", icName, err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_MUTUAL_TLS_AUTH", "required"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_MUTUAL_TLS_AUTH", "required"); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_MUTUAL_TLS_AUTH=required: %v", err)
 	}
 	if err := waitForDeploymentCompleteWithOldPodTermination(t, kclient, deploymentName, 3*time.Minute); err != nil {

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -201,7 +201,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_SET_FORWARDED_HEADERS", "append"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_SET_FORWARDED_HEADERS", "append"); err != nil {
 		t.Fatalf("failed to observe ROUTER_SET_FORWARDED_HEADERS=append: %v", err)
 	}
 	if err := waitForDeploymentComplete(t, kclient, deployment, 3*time.Minute); err != nil {

--- a/test/e2e/maxconn_metric_test.go
+++ b/test/e2e/maxconn_metric_test.go
@@ -93,7 +93,7 @@ func TestMaxConnectionsMetric(t *testing.T) {
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, ingress.RouterMaxConnectionsEnvName, fmt.Sprintf("%d", customMaxConn)); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, ingress.RouterMaxConnectionsEnvName, fmt.Sprintf("%d", customMaxConn)); err != nil {
 		t.Fatalf("router deployment not updated with %s=%d: %v", ingress.RouterMaxConnectionsEnvName, customMaxConn, err)
 	}
 	if err := waitForDeploymentComplete(t, kclient, deployment, 3*time.Minute); err != nil {

--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -59,7 +59,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
 
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, ""); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, ""); err != nil {
 		t.Fatalf("expected router deployment to have %s unset: %v", ingress.RouterMaxConnectionsEnvName, err)
 	}
 
@@ -80,7 +80,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 		if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 			t.Fatalf("failed to observe expected conditions: %v", err)
 		}
-		if err := waitForDeploymentEnvVar(t, kclient, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, testCase.expectedEnvVar); err != nil {
+		if err := waitForDeploymentEnvVar(t, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, testCase.expectedEnvVar); err != nil {
 			t.Fatalf("router deployment not updated with %s=%v: %v", ingress.RouterMaxConnectionsEnvName, testCase.expectedEnvVar, err)
 		}
 	}
@@ -125,7 +125,7 @@ func TestTunableMaxConnectionsInvalidValues(t *testing.T) {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
 
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, ""); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, time.Minute, ingress.RouterMaxConnectionsEnvName, ""); err != nil {
 		t.Fatalf("expected router deployment to have %s unset: %v", ingress.RouterMaxConnectionsEnvName, err)
 	}
 

--- a/test/e2e/nbthread_test.go
+++ b/test/e2e/nbthread_test.go
@@ -42,7 +42,7 @@ func TestRouteNbthreadIngressController(t *testing.T) {
 	defaultThreadsStr := strconv.Itoa(ingresscontroller.RouterHAProxyThreadsDefaultValue)
 
 	// by default, the router deployment should have ROUTER_THREADS set to 4
-	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", defaultThreadsStr); err != nil {
+	if err := waitForDeploymentEnvVar(t, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", defaultThreadsStr); err != nil {
 		t.Fatalf("expected router deployment to set ROUTER_THREADS to %v: %v", ingresscontroller.RouterHAProxyThreadsDefaultValue, err)
 	}
 
@@ -55,7 +55,7 @@ func TestRouteNbthreadIngressController(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", strconv.Itoa(ingresscontroller.RouterHAProxyThreadsDefaultValue*2)); err != nil {
+	if err := waitForDeploymentEnvVar(t, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", strconv.Itoa(ingresscontroller.RouterHAProxyThreadsDefaultValue*2)); err != nil {
 		t.Fatalf("expected router deployment to set ROUTER_THREADS to %v: %v", ingresscontroller.RouterHAProxyThreadsDefaultValue*2, err)
 	}
 
@@ -65,7 +65,7 @@ func TestRouteNbthreadIngressController(t *testing.T) {
 	}
 
 	// when set back to default, the router deployment should have ROUTER_THREADS set to 4
-	if err := waitForDeploymentEnvVar(t, kclient, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", defaultThreadsStr); err != nil {
+	if err := waitForDeploymentEnvVar(t, routerDeployment, nbthreadRouterDeployTimeout, "ROUTER_THREADS", defaultThreadsStr); err != nil {
 		t.Fatalf("expected router deployment to set ROUTER_THREADS to %v: %v", ingresscontroller.RouterHAProxyThreadsDefaultValue, err)
 	}
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -4242,26 +4242,45 @@ func waitForDeploymentComplete(t *testing.T, cl client.Client, deployment *appsv
 // value, or unset if the provided value is the empty string.
 func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.Deployment, timeout time.Duration, name, value string) error {
 	t.Helper()
-	deploymentName := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}
-	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		deployment := &appsv1.Deployment{}
-		if err := kclient.Get(context.TODO(), deploymentName, deployment); err != nil {
-			t.Logf("error getting deployment %s/%s: %v", deploymentName.Namespace, deploymentName.Name, err)
-			return false, nil
-		}
+
+	return waitForDeploymentFunc(t, deployment, timeout, func(deployment *appsv1.Deployment) bool {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			if container.Name == "router" {
 				for _, v := range container.Env {
 					if v.Name == name {
-						return v.Value == value, nil
+						return v.Value == value
 					}
 				}
-				return len(value) == 0, nil
+
+				return len(value) == 0
 			}
 		}
-		return false, nil
+
+		return false
 	})
-	return err
+}
+
+// waitForDeploymentFunc polls the given deployment until the given condition
+// func returns true or the timeout elapses.
+func waitForDeploymentFunc(t *testing.T, deployment *appsv1.Deployment, timeout time.Duration, fn func(deployment *appsv1.Deployment) bool) error {
+	t.Helper()
+
+	deploymentName := types.NamespacedName{
+		Namespace: deployment.Namespace,
+		Name:      deployment.Name,
+	}
+
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		var deployment appsv1.Deployment
+
+		if err := kclient.Get(ctx, deploymentName, &deployment); err != nil {
+			t.Logf("Failed to get deployment %s: %v", deploymentName, err)
+
+			return false, nil
+		}
+
+		return fn(&deployment), nil
+	})
 }
 
 // waitForDeploymentCompleteWithOldPodTermination waits for a deployment to

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -4237,9 +4237,9 @@ func waitForDeploymentComplete(t *testing.T, cl client.Client, deployment *appsv
 	return nil
 }
 
-// Wait for the provided deployment to have the specified environment variable
-// set with the provided value, or unset if the provided value is the empty
-// string.
+// waitForDeploymentEnvVar waits for the provided router deployment to have the
+// specified environment variable set in the router container with the provided
+// value, or unset if the provided value is the empty string.
 func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.Deployment, timeout time.Duration, name, value string) error {
 	t.Helper()
 	deploymentName := types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -27,7 +27,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -3612,74 +3611,110 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 }
 
 // TestUnsupportedConfigOverride verifies that the operator
-// configures router pod replicas to use the:
-// - dynamic config manager
-// - contstats
-// - max dynamic servers
-// if the ingresscontroller is so configured using an unsupported config override.
+// handles the following overrides for the router deployment:
+//
+// - loadBalancingAlgorithm
+// - dynamicConfigManager
+// - contStats
+// - maxDynamicServers
 func TestUnsupportedConfigOverride(t *testing.T) {
 	t.Parallel()
 
-	var (
-		dcmDefaultValue         = ""
-		dcmUpdateValue          = "true"
-		dcmExpectedValue        = "true"
-		maxServersDefaultValue  = ""
-		maxServersUpdateValue   = "2"
-		maxServersExpectedValue = "" // max dynamic servers cannot be set if DCM is off
-	)
-
-	if dcmEnabled, err := isFeatureGateEnabled(features.FeatureGateIngressControllerDynamicConfigurationManager); err != nil {
-		t.Fatalf("failed to get dynamic config manager feature gate: %v", err)
-	} else if dcmEnabled {
-		t.Logf("DynamicConfigurationManager feature gate is enabled for this test")
-		dcmDefaultValue = "true"
-		dcmUpdateValue = "false"
-		dcmExpectedValue = ""
-		maxServersDefaultValue = "1"
-		maxServersUpdateValue = "2"
-		maxServersExpectedValue = "2"
+	var tests = []struct {
+		name                       string
+		unsupportedConfigOverrides string
+		expectedEnv                map[string]string
+	}{
+		{
+			name:                       "dynamic-config-manager-false",
+			unsupportedConfigOverrides: `{"dynamicConfigManager":"false"}`,
+			expectedEnv: map[string]string{
+				"ROUTER_HAPROXY_CONFIG_MANAGER": "",
+				"ROUTER_HAPROXY_CONTSTATS":      "",
+				"ROUTER_MAX_DYNAMIC_SERVERS":    "",
+			},
+		}, {
+			name:                       "dynamic-config-manager-true",
+			unsupportedConfigOverrides: `{"dynamicConfigManager":"true"}`,
+			expectedEnv: map[string]string{
+				// DCM should be enabled.
+				"ROUTER_HAPROXY_CONFIG_MANAGER": "true",
+				"ROUTER_HAPROXY_CONTSTATS":      "",
+				"ROUTER_MAX_DYNAMIC_SERVERS":    "1",
+			},
+		}, {
+			name:                       "contstats-true",
+			unsupportedConfigOverrides: `{"dynamicConfigManager":"true","contStats":"true"}`,
+			expectedEnv: map[string]string{
+				"ROUTER_HAPROXY_CONFIG_MANAGER": "true",
+				"ROUTER_HAPROXY_CONTSTATS":      "true",
+				"ROUTER_MAX_DYNAMIC_SERVERS":    "1",
+			},
+		}, {
+			name:                       "max-dynamic-servers",
+			unsupportedConfigOverrides: `{"dynamicConfigManager":"true","maxDynamicServers":"2"}`,
+			expectedEnv: map[string]string{
+				"ROUTER_HAPROXY_CONFIG_MANAGER": "true",
+				"ROUTER_HAPROXY_CONTSTATS":      "",
+				"ROUTER_MAX_DYNAMIC_SERVERS":    "2",
+			},
+		}, {
+			name:                       "max-dynamic-servers-without-dynamic-config-manager-enabled",
+			unsupportedConfigOverrides: `{"dynamicConfigManager":"false","maxDynamicServers":"2"}`,
+			expectedEnv: map[string]string{
+				"ROUTER_HAPROXY_CONFIG_MANAGER": "",
+				"ROUTER_HAPROXY_CONTSTATS":      "",
+				"ROUTER_MAX_DYNAMIC_SERVERS":    "",
+			},
+		}, {
+			name:                       "load-balancing-algorithm",
+			unsupportedConfigOverrides: `{"loadBalancingAlgorithm":"leastconn"}`,
+			expectedEnv: map[string]string{
+				"ROUTER_LOAD_BALANCE_ALGORITHM": "leastconn",
+				"ROUTER_TCP_BALANCE_SCHEME":     "source",
+			},
+		},
 	}
 
-	var tests = []struct {
-		name, unsupportedConfigOverride, env, defaultValue, updateValue, expectedValue string
-	}{
-		{"dynamic-config-manager", "dynamicConfigManager", "ROUTER_HAPROXY_CONFIG_MANAGER", dcmDefaultValue, dcmUpdateValue, dcmExpectedValue},
-		{"contstats", "contStats", "ROUTER_HAPROXY_CONTSTATS", "", "true", "true"},
-		{"max-dynamic-servers", "maxDynamicServers", "ROUTER_MAX_DYNAMIC_SERVERS", maxServersDefaultValue, maxServersUpdateValue, maxServersExpectedValue},
+	icName := types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      names.SimpleNameGenerator.GenerateName("unsupported-config-override-"),
+	}
+	domain := fmt.Sprintf("%s.%s", icName.Name, dnsConfig.Spec.BaseDomain)
+	ic := newPrivateController(icName, domain)
+	if err := kclient.Create(context.Background(), ic); err != nil {
+		t.Fatalf("failed to create ingresscontroller: %v", err)
+	}
+	defer assertIngressControllerDeleted(t, kclient, ic)
+
+	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
+		t.Errorf("failed to observe expected conditions: %v", err)
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			icName := types.NamespacedName{Namespace: operatorNamespace, Name: tt.name}
-			domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
-			ic := newPrivateController(icName, domain)
-			if err := kclient.Create(context.TODO(), ic); err != nil {
-				t.Fatalf("failed to create ingresscontroller: %v", err)
-			}
-			defer assertIngressControllerDeleted(t, kclient, ic)
-
-			if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
-				t.Errorf("failed to observe expected conditions: %v", err)
-			}
-
-			deployment := &appsv1.Deployment{}
-			if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-				t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-			}
-			if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, tt.env, tt.defaultValue); err != nil {
-				t.Fatalf("expected initial deployment not to set %s=%s: %v", tt.env, tt.defaultValue, err)
-			}
-
 			if err := updateIngressControllerWithRetryOnConflict(t, icName, timeout, func(ic *operatorv1.IngressController) {
 				ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{
-					Raw: []byte(fmt.Sprintf(`{"%s":"%s"}`, tt.unsupportedConfigOverride, tt.updateValue)),
+					Raw: []byte(tt.unsupportedConfigOverrides),
 				}
 			}); err != nil {
 				t.Fatalf("failed to update ingresscontroller: %v", err)
 			}
-			if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, tt.env, tt.expectedValue); err != nil {
-				t.Fatalf("expected updated deployment to set %s=%s: %v", tt.env, tt.expectedValue, err)
+
+			deploymentName := controller.RouterDeploymentName(ic)
+			deployment := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentName.Name,
+					Namespace: deploymentName.Namespace,
+				},
+			}
+
+			if err := waitForDeploymentEnv(t, &deployment, "router", 1*time.Minute, tt.expectedEnv); err != nil {
+				if err := kclient.Get(context.Background(), deploymentName, &deployment); err != nil {
+					t.Logf("failed to get ingresscontroller deployment: %v", err)
+				}
+				actualEnv := getDeploymentContainer(&deployment, "router").Env
+				t.Fatalf("expected updated deployment to set env. vars. %#v, found %#v: %v", tt.expectedEnv, actualEnv, err)
 			}
 		})
 	}
@@ -4258,6 +4293,50 @@ func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.
 
 		return false
 	})
+}
+
+// waitForDeploymentEnv waits for the provided deployment to have the specified
+// environment variables set in the named container.  Specifying the empty
+// string "" for an environment variable in expectedEnv indicates that the
+// environment variable is expected *not* to be set in the container.
+func waitForDeploymentEnv(t *testing.T, deployment *appsv1.Deployment, containerName string, timeout time.Duration, expectedEnv map[string]string) error {
+	t.Helper()
+
+	return waitForDeploymentFunc(t, deployment, timeout, func(deployment *appsv1.Deployment) bool {
+		currentEnv := map[string]string{}
+		for k := range expectedEnv {
+			// Initialize the entry in currentEnv to "" to indicate
+			// that the env. var.  is not set.  The next loop
+			// updates the entry if it is in fact set.
+			currentEnv[k] = ""
+		}
+
+		container := getDeploymentContainer(deployment, containerName)
+		for _, envVar := range container.Env {
+			k, v := envVar.Name, envVar.Value
+
+			if _, ok := expectedEnv[k]; !ok {
+				// Ignore env. vars. that are not in
+				// expectedEnv.
+				continue
+			}
+
+			currentEnv[k] = v
+		}
+
+		return reflect.DeepEqual(expectedEnv, currentEnv)
+	})
+}
+
+// getDeploymentContainer returns the named container from the given deployment.
+func getDeploymentContainer(deployment *appsv1.Deployment, containerName string) corev1.Container {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			return container
+		}
+	}
+
+	return corev1.Container{}
 }
 
 // waitForDeploymentFunc polls the given deployment until the given condition

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -530,7 +530,7 @@ func TestProxyProtocolAPI(t *testing.T) {
 	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_USE_PROXY_PROTOCOL", ""); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_USE_PROXY_PROTOCOL", ""); err != nil {
 		t.Fatalf("expected initial deployment not to enable PROXY protocol: %v", err)
 	}
 
@@ -541,7 +541,7 @@ func TestProxyProtocolAPI(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_USE_PROXY_PROTOCOL", "true"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_USE_PROXY_PROTOCOL", "true"); err != nil {
 		t.Fatalf("expected updated deployment to enable PROXY protocol: %v", err)
 	}
 }
@@ -3587,10 +3587,10 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
 	}
 	expectedAlgorithm := "random"
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 30*time.Second, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
 		t.Fatalf("expected initial deployment to have ROUTER_LOAD_BALANCE_ALGORITHM=%s: %v", expectedAlgorithm, err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "ROUTER_TCP_BALANCE_SCHEME", "source"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 30*time.Second, "ROUTER_TCP_BALANCE_SCHEME", "source"); err != nil {
 		t.Fatalf("expected initial deployment to have ROUTER_TCP_BALANCE_SCHEME=source: %v", err)
 	}
 
@@ -3602,10 +3602,10 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 		t.Fatalf("failed to update ingresscontroller: %v", err)
 	}
 	expectedAlgorithm = "leastconn"
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_LOAD_BALANCE_ALGORITHM", expectedAlgorithm); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_LOAD_BALANCE_ALGORITHM=%s: %v", expectedAlgorithm, err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 30*time.Second, "ROUTER_TCP_BALANCE_SCHEME", "source"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 30*time.Second, "ROUTER_TCP_BALANCE_SCHEME", "source"); err != nil {
 		t.Fatalf("expected updated deployment to have ROUTER_TCP_BALANCE_SCHEME=source: %v", err)
 	}
 }
@@ -3906,7 +3906,7 @@ func TestCustomErrorpages(t *testing.T) {
 	if err := kclient.Get(context.TODO(), deploymentName, deployment); err != nil {
 		t.Fatalf("failed to get deployment %q: %v", deploymentName, err)
 	}
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, "ROUTER_ERRORFILE_503", "/var/lib/haproxy/conf/error_code_pages/error-page-503.http"); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, "ROUTER_ERRORFILE_503", "/var/lib/haproxy/conf/error_code_pages/error-page-503.http"); err != nil {
 		t.Fatalf("expected deployment %q to use the custom error-page file: %v", deploymentName, err)
 	}
 
@@ -4275,7 +4275,7 @@ func waitForDeploymentComplete(t *testing.T, cl client.Client, deployment *appsv
 // waitForDeploymentEnvVar waits for the provided router deployment to have the
 // specified environment variable set in the router container with the provided
 // value, or unset if the provided value is the empty string.
-func waitForDeploymentEnvVar(t *testing.T, cl client.Client, deployment *appsv1.Deployment, timeout time.Duration, name, value string) error {
+func waitForDeploymentEnvVar(t *testing.T, deployment *appsv1.Deployment, timeout time.Duration, name, value string) error {
 	t.Helper()
 
 	return waitForDeploymentFunc(t, deployment, timeout, func(deployment *appsv1.Deployment) bool {

--- a/test/e2e/reloadinterval_test.go
+++ b/test/e2e/reloadinterval_test.go
@@ -124,7 +124,7 @@ func TestReloadInterval(t *testing.T) {
 			t.Fatalf("failed to delete and recreate the %q deployment", controller.RouterDeploymentName(ic))
 		}
 
-		if err := waitForDeploymentEnvVar(t, kclient, deployment, 1*time.Minute, ingresscontroller.RouterReloadIntervalEnvName, testCase.expectedEnvVar); err != nil {
+		if err := waitForDeploymentEnvVar(t, deployment, 1*time.Minute, ingresscontroller.RouterReloadIntervalEnvName, testCase.expectedEnvVar); err != nil {
 			t.Fatalf("router deployment not updated with %s=%v: %v", ingresscontroller.RouterReloadIntervalEnvName, testCase.expectedEnvVar, err)
 		}
 	}

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -129,7 +129,7 @@ func testCompressionPolicy(t *testing.T, name string, compressionPolicy operator
 
 	// Check if the MIME type environment variable has been updated
 	mimeTypes := ingress.GetMIMETypes(compressionPolicy.MimeTypes)
-	if err := waitForDeploymentEnvVar(t, kclient, deployment, 2*time.Minute, "ROUTER_COMPRESSION_MIME", strings.Join(mimeTypes, " ")); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, 2*time.Minute, "ROUTER_COMPRESSION_MIME", strings.Join(mimeTypes, " ")); err != nil {
 		return fmt.Errorf("expected deployment to have mimeTypes %s: %v", mimeTypes, err)
 	}
 


### PR DESCRIPTION
#### `waitForDeploymentEnvVar`: Fix godoc

Update the godoc for the `waitForDeploymentEnvVar` test helper func to start with the func name and to mention that the helper specifically checks the "router" container.


#### Add `waitForDeploymentFunc` test helper func

Factor the polling loop logic out of the `waitForDeploymentEnvVar` helper into the new `waitForDeploymentFunc` helper.


#### `TestUnsupportedConfigOverride`: Ignore featuregate

Ignore the featuregate for the Dynamic Configuration Manager when testing `unsupportedConfigOverrides` options related to DCM, and don't verify defaults.  Overrides take precedence over the featuregate, and the test's purpose is to verify that overrides work properly, not verify the default settings.

Follow-up to #1385.


