### PR TITLE
NE-2332: Implement ROUTER_CURVES environment variable

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -116,6 +116,7 @@ const (
 	RouterEnableCompression    = "ROUTER_ENABLE_COMPRESSION"
 	RouterCompressionMIMETypes = "ROUTER_COMPRESSION_MIME"
 	RouterBackendCheckInterval = "ROUTER_BACKEND_CHECK_INTERVAL"
+	RouterTLSCurves            = "ROUTER_CURVES"
 
 	RouterServiceHTTPPort  = "ROUTER_SERVICE_HTTP_PORT"
 	RouterServiceHTTPSPort = "ROUTER_SERVICE_HTTPS_PORT"
@@ -996,6 +997,22 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			Value: strings.Join(tls13Ciphers, ":"),
 		})
 	}
+
+	// The default TLS supportedGroups (curves) include X25519MLKEM768,
+	// x25519, P-256, P-384, and P-521.
+	tlsCurves := "X25519MLKEM768:X25519:P-256:P-384:P-521"
+	// If FIPS is enabled on this cluster, we cannot use
+	// ML-KEM or X25519 in the TLS supportedGroups (aka curves).
+	// ML-KEM and X25519 are not supported by OpenSSL FIPS 140-3.
+	// See https://redhat.atlassian.net/browse/TRT-2597 and Appendix D of
+	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
+	if isFIPSEnabled {
+		tlsCurves = "P-256:P-384:P-521"
+	}
+	env = append(env, corev1.EnvVar{
+		Name:  RouterTLSCurves,
+		Value: tlsCurves,
+	})
 
 	var minTLSVersion string
 	switch tlsProfileSpec.MinTLSVersion {

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -2781,3 +2781,55 @@ func Test_ClosedClientConnectionPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestDesiredRouterDeploymentTLSCurves verifies that desiredRouterDeployment
+// sets ROUTER_CURVES as expected with and without FIPS enabled.
+func TestDesiredRouterDeploymentTLSCurves(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fipsEnabled bool
+		expectedEnv []envData
+	}{
+		{
+			name:        "Include ML-KEM and X25519 when FIPS is not enabled",
+			fipsEnabled: false,
+			expectedEnv: []envData{
+				{"ROUTER_CURVES", true, "X25519MLKEM768:X25519:P-256:P-384:P-521"},
+			},
+		}, {
+			name:        "Exclude ML-KEM and X25519 when FIPS is enabled",
+			fipsEnabled: true,
+			expectedEnv: []envData{
+				{"ROUTER_CURVES", true, "P-256:P-384:P-521"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ic := &operatorv1.IngressController{
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.PrivateStrategyType,
+					},
+				},
+			}
+
+			wasFIPSEnabled := isFIPSEnabled
+			// Restore the real value of isFIPSEnabled in case it is used by other tests.
+			defer func() {
+				isFIPSEnabled = wasFIPSEnabled
+			}()
+			// Use the temporary test case status of FIPS enablement for testing.
+			isFIPSEnabled = tc.fipsEnabled
+
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, false, false, nil, &configv1.Proxy{})
+			if err != nil {
+				t.Error(err)
+			}
+
+			if err := checkDeploymentEnvironment(t, deployment, tc.expectedEnv); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Set a default ROUTER_CURVES value at deploy time to support PQC compliance. If FIPS is enabled on the cluster, we cannot use the ML-KEM TLS curve because the OpenSSL FIPS provider in RHEL9 does not support ML-KEM.  Make the default ROUTER_CURVES observe this constraint.