### PR TITLE
CORS-4372: Create IPv6 records for GCP

### DIFF
--- a/pkg/dns/gcp/provider.go
+++ b/pkg/dns/gcp/provider.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/dns"
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	"github.com/openshift/cluster-ingress-operator/pkg/util/ipfamily"
 
 	gdnsv1 "google.golang.org/api/dns/v1"
 	"google.golang.org/api/option"
@@ -34,6 +36,10 @@ type Config struct {
 	Project         string
 	UserAgent       string
 	CredentialsJSON []byte
+	// IPFamily is the cluster's IP family configuration from the
+	// Infrastructure CR. When dual-stack, the provider creates both
+	// A and AAAA DNS records.
+	IPFamily configv1.IPFamilyType
 }
 
 func New(config Config) (*Provider, error) {
@@ -75,13 +81,62 @@ func (p *Provider) parseZone(zone configv1.DNSZone) (string, string, error) {
 }
 
 func (p *Provider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error {
-	change := &gdnsv1.Change{Additions: []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}}
-
 	project, zoneID, err := p.parseZone(zone)
 	if err != nil {
 		return err
 	}
 
+	var additions []*gdnsv1.ResourceRecordSet
+
+	// For A records, check if this is a dual-stack configuration.
+	// Dual-stack is detected either by the IPFamily configuration or by
+	// the presence of both IPv4 and IPv6 addresses in the targets.
+	if record.Spec.RecordType == iov1.ARecordType {
+		// Filter targets by IP version
+		ipv4Targets := filterIPv4Addresses(record.Spec.Targets)
+		ipv6Targets := filterIPv6Addresses(record.Spec.Targets)
+
+		// Determine if this is dual-stack: either IPFamily is set to dual-stack,
+		// or we have both IPv4 and IPv6 addresses in the targets.
+		isDualStack := ipfamily.IsDualStack(p.config.IPFamily) || (len(ipv4Targets) > 0 && len(ipv6Targets) > 0)
+
+		if isDualStack {
+			// Create A record with IPv4 addresses
+			if len(ipv4Targets) > 0 {
+				aRecord := &gdnsv1.ResourceRecordSet{
+					Name:    record.Spec.DNSName,
+					Rrdatas: ipv4Targets,
+					Type:    "A",
+					Ttl:     record.Spec.RecordTTL,
+				}
+				additions = append(additions, aRecord)
+			}
+
+			// Create AAAA record with IPv6 addresses
+			if len(ipv6Targets) > 0 {
+				aaaaRecord := &gdnsv1.ResourceRecordSet{
+					Name:    record.Spec.DNSName,
+					Rrdatas: ipv6Targets,
+					Type:    "AAAA",
+					Ttl:     record.Spec.RecordTTL,
+				}
+				additions = append(additions, aaaaRecord)
+			}
+		} else {
+			// Not dual-stack, create A record as-is.
+			additions = []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}
+		}
+	} else {
+		// For non-A records (CNAME, etc.), create the record as-is.
+		additions = []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}
+	}
+
+	if len(additions) == 0 {
+		log.Info("no records to create", "record", record.Spec.DNSName)
+		return nil
+	}
+
+	change := &gdnsv1.Change{Additions: additions}
 	call := p.dnsService.Changes.Create(project, zoneID, change)
 	_, err = call.Do()
 	// Since we don't yet handle updates, assume that existing records are correct.
@@ -98,22 +153,32 @@ func (p *Provider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error 
 	if err != nil {
 		return err
 	}
+
+	// Collect all existing records for this DNS name (including both A and AAAA for dual-stack).
+	var deletions []*gdnsv1.ResourceRecordSet
 	oldRecord := p.dnsService.ResourceRecordSets.List(project, zoneID).Name(record.Spec.DNSName)
 	if err := oldRecord.Pages(ctx, func(page *gdnsv1.ResourceRecordSetsListResponse) error {
 		for _, resourceRecordSet := range page.Rrsets {
 			log.Info("found old DNS resource record set", "resourceRecordSet", resourceRecordSet)
-			change := &gdnsv1.Change{Deletions: []*gdnsv1.ResourceRecordSet{resourceRecordSet}}
-			call := p.dnsService.Changes.Create(project, zoneID, change)
-			_, err := call.Do()
-			if ae, ok := err.(*googleapi.Error); ok && ae.Code == http.StatusNotFound {
-				return nil
-			}
-			return err
+			deletions = append(deletions, resourceRecordSet)
 		}
 		return nil
 	}); err != nil {
 		return err
 	}
+
+	// Delete all existing records in a single change.
+	if len(deletions) > 0 {
+		change := &gdnsv1.Change{Deletions: deletions}
+		call := p.dnsService.Changes.Create(project, zoneID, change)
+		_, err := call.Do()
+		if ae, ok := err.(*googleapi.Error); ok && ae.Code == http.StatusNotFound {
+			// Continue if not found - the records may have already been deleted.
+		} else if err != nil {
+			return err
+		}
+	}
+
 	if err := p.Ensure(record, zone); err != nil {
 		return err
 	}
@@ -121,11 +186,62 @@ func (p *Provider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error 
 }
 
 func (p *Provider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error {
-	change := &gdnsv1.Change{Deletions: []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}}
 	project, zoneID, err := p.parseZone(zone)
 	if err != nil {
 		return err
 	}
+
+	var deletions []*gdnsv1.ResourceRecordSet
+
+	// For A records, check if this is a dual-stack configuration.
+	// Dual-stack is detected either by the IPFamily configuration or by
+	// the presence of both IPv4 and IPv6 addresses in the targets.
+	if record.Spec.RecordType == iov1.ARecordType {
+		// Filter targets by IP version
+		ipv4Targets := filterIPv4Addresses(record.Spec.Targets)
+		ipv6Targets := filterIPv6Addresses(record.Spec.Targets)
+
+		// Determine if this is dual-stack: either IPFamily is set to dual-stack,
+		// or we have both IPv4 and IPv6 addresses in the targets.
+		isDualStack := ipfamily.IsDualStack(p.config.IPFamily) || (len(ipv4Targets) > 0 && len(ipv6Targets) > 0)
+
+		if isDualStack {
+			// Delete A record with IPv4 addresses
+			if len(ipv4Targets) > 0 {
+				aRecord := &gdnsv1.ResourceRecordSet{
+					Name:    record.Spec.DNSName,
+					Rrdatas: ipv4Targets,
+					Type:    "A",
+					Ttl:     record.Spec.RecordTTL,
+				}
+				deletions = append(deletions, aRecord)
+			}
+
+			// Delete AAAA record with IPv6 addresses
+			if len(ipv6Targets) > 0 {
+				aaaaRecord := &gdnsv1.ResourceRecordSet{
+					Name:    record.Spec.DNSName,
+					Rrdatas: ipv6Targets,
+					Type:    "AAAA",
+					Ttl:     record.Spec.RecordTTL,
+				}
+				deletions = append(deletions, aaaaRecord)
+			}
+		} else {
+			// Not dual-stack, delete A record as-is.
+			deletions = []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}
+		}
+	} else {
+		// For non-A records (CNAME, etc.), delete the record as-is.
+		deletions = []*gdnsv1.ResourceRecordSet{resourceRecordSet(record)}
+	}
+
+	if len(deletions) == 0 {
+		log.Info("no records to delete", "record", record.Spec.DNSName)
+		return nil
+	}
+
+	change := &gdnsv1.Change{Deletions: deletions}
 	call := p.dnsService.Changes.Create(project, zoneID, change)
 	_, err = call.Do()
 	if ae, ok := err.(*googleapi.Error); ok && ae.Code == http.StatusNotFound {
@@ -141,4 +257,26 @@ func resourceRecordSet(record *iov1.DNSRecord) *gdnsv1.ResourceRecordSet {
 		Type:    string(record.Spec.RecordType),
 		Ttl:     record.Spec.RecordTTL,
 	}
+}
+
+// filterIPv4Addresses filters a list of IP addresses to only include IPv4 addresses.
+func filterIPv4Addresses(addresses []string) []string {
+	var ipv4 []string
+	for _, addr := range addresses {
+		if ip := net.ParseIP(addr); ip != nil && ip.To4() != nil {
+			ipv4 = append(ipv4, addr)
+		}
+	}
+	return ipv4
+}
+
+// filterIPv6Addresses filters a list of IP addresses to only include IPv6 addresses.
+func filterIPv6Addresses(addresses []string) []string {
+	var ipv6 []string
+	for _, addr := range addresses {
+		if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
+			ipv6 = append(ipv6, addr)
+		}
+	}
+	return ipv6
 }

--- a/pkg/dns/gcp/provider_dualstack_test.go
+++ b/pkg/dns/gcp/provider_dualstack_test.go
@@ -1,0 +1,139 @@
+package gcp
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestFilterIPv4Addresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "only IPv4",
+			input:    []string{"192.168.1.1", "10.0.0.1"},
+			expected: []string{"192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "only IPv6",
+			input:    []string{"2001:db8::1", "fe80::1"},
+			expected: []string{},
+		},
+		{
+			name:     "mixed IPv4 and IPv6",
+			input:    []string{"192.168.1.1", "2001:db8::1", "10.0.0.1"},
+			expected: []string{"192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "empty",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "invalid IPs",
+			input:    []string{"not-an-ip", "192.168.1.1"},
+			expected: []string{"192.168.1.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterIPv4Addresses(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d IPv4 addresses, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, addr := range result {
+				if addr != tt.expected[i] {
+					t.Errorf("expected address %s at index %d, got %s", tt.expected[i], i, addr)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterIPv6Addresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "only IPv6",
+			input:    []string{"2001:db8::1", "fe80::1"},
+			expected: []string{"2001:db8::1", "fe80::1"},
+		},
+		{
+			name:     "only IPv4",
+			input:    []string{"192.168.1.1", "10.0.0.1"},
+			expected: []string{},
+		},
+		{
+			name:     "mixed IPv4 and IPv6",
+			input:    []string{"192.168.1.1", "2001:db8::1", "10.0.0.1", "fe80::1"},
+			expected: []string{"2001:db8::1", "fe80::1"},
+		},
+		{
+			name:     "empty",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "invalid IPs",
+			input:    []string{"not-an-ip", "2001:db8::1"},
+			expected: []string{"2001:db8::1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterIPv6Addresses(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d IPv6 addresses, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, addr := range result {
+				if addr != tt.expected[i] {
+					t.Errorf("expected address %s at index %d, got %s", tt.expected[i], i, addr)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigIPFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipFamily configv1.IPFamilyType
+	}{
+		{
+			name:     "IPv4",
+			ipFamily: configv1.IPv4,
+		},
+		{
+			name:     "DualStackIPv4Primary",
+			ipFamily: configv1.DualStackIPv4Primary,
+		},
+		{
+			name:     "DualStackIPv6Primary",
+			ipFamily: configv1.DualStackIPv6Primary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				Project:         "test-project",
+				UserAgent:       "test-agent",
+				CredentialsJSON: []byte("{}"),
+				IPFamily:        tt.ipFamily,
+			}
+			if config.IPFamily != tt.ipFamily {
+				t.Errorf("expected IPFamily %s, got %s", tt.ipFamily, config.IPFamily)
+			}
+		})
+	}
+}

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -696,10 +696,19 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 		}
 		dnsProvider = provider
 	case configv1.GCPPlatformType:
+		// Get IPFamily from GCP platform status if available.
+		// GCP currently doesn't have an IPFamily field in its platform status,
+		// so we default to IPv4. The provider will still detect dual-stack
+		// configurations by examining the IP addresses in the DNS record targets.
+		// When GCP adds IPFamily support to its platform status, update this to:
+		// ipFamily := platformStatus.GCP.IPFamily
+		ipFamily := configv1.IPv4
+
 		provider, err := gcpdns.New(gcpdns.Config{
 			Project:         platformStatus.GCP.ProjectID,
 			CredentialsJSON: creds.Data["service_account.json"],
 			UserAgent:       userAgent,
+			IPFamily:        ipFamily,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create GCP DNS provider: %v", err)

--- a/pkg/util/aws/dualstack.go
+++ b/pkg/util/aws/dualstack.go
@@ -1,9 +1,14 @@
 package aws
 
-import configv1 "github.com/openshift/api/config/v1"
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-ingress-operator/pkg/util/ipfamily"
+)
 
 // IsDualStack returns true if the given IPFamilyType indicates a dual-stack
 // configuration.
+// This is a wrapper around the common ipfamily.IsDualStack function for
+// backward compatibility.
 func IsDualStack(ipFamily configv1.IPFamilyType) bool {
-	return ipFamily == configv1.DualStackIPv4Primary || ipFamily == configv1.DualStackIPv6Primary
+	return ipfamily.IsDualStack(ipFamily)
 }

--- a/pkg/util/ipfamily/ipfamily.go
+++ b/pkg/util/ipfamily/ipfamily.go
@@ -1,0 +1,9 @@
+package ipfamily
+
+import configv1 "github.com/openshift/api/config/v1"
+
+// IsDualStack returns true if the given IPFamilyType indicates a dual-stack
+// configuration.
+func IsDualStack(ipFamily configv1.IPFamilyType) bool {
+	return ipFamily == configv1.DualStackIPv4Primary || ipFamily == configv1.DualStackIPv6Primary
+}

--- a/pkg/util/ipfamily/ipfamily_test.go
+++ b/pkg/util/ipfamily/ipfamily_test.go
@@ -1,0 +1,45 @@
+package ipfamily
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestIsDualStack(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipFamily configv1.IPFamilyType
+		expected bool
+	}{
+		{
+			name:     "IPv4 is not dual-stack",
+			ipFamily: configv1.IPv4,
+			expected: false,
+		},
+		{
+			name:     "DualStackIPv4Primary is dual-stack",
+			ipFamily: configv1.DualStackIPv4Primary,
+			expected: true,
+		},
+		{
+			name:     "DualStackIPv6Primary is dual-stack",
+			ipFamily: configv1.DualStackIPv6Primary,
+			expected: true,
+		},
+		{
+			name:     "Empty string is not dual-stack",
+			ipFamily: "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDualStack(tt.ipFamily)
+			if result != tt.expected {
+				t.Errorf("IsDualStack(%q) = %v, expected %v", tt.ipFamily, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
pkg/util/aws/dualstack.go:

- Removed the "aws specific" capability of determining stack type

pkg/util/ipfamily/ipfamily.go:

- Created the common function to determine stack type dynamically.

pkg/util/ipfamily/ipfamily_test.go:

- Generated tests for the stack determination

pkg/dns/gcp/provider.go:

- Added dual-stack DNS support for GCP *.apps records

pkg/operator/controller/dns/controller.go:

- Add IP family to the controller call.