### PR TITLE
OCPBUGS-81761: ClusterHostedDNS: Don't update Infrastrcture CR when order of Ingress LB IPs changes

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -165,6 +165,12 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	)); err != nil {
 		return nil, err
 	}
+	// Watch for changes to machine-config ClusterOperator to know when MCO is ready.
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.ClusterOperator{}, handler.EnqueueRequestsFromMapFunc(reconciler.ingressConfigToIngressController),
+		predicate.NewPredicateFuncs(hasName("machine-config")),
+	)); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -167,6 +167,12 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	)); err != nil {
 		return nil, err
 	}
+	// Watch for changes to machine-config ClusterOperator to know when MCO is ready.
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.ClusterOperator{}, handler.EnqueueRequestsFromMapFunc(reconciler.ingressConfigToIngressController),
+		predicate.NewPredicateFuncs(hasName("machine-config")),
+	)); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -1,11 +1,13 @@
 package ingress
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"regexp"
 	"regexp/syntax"
+	"slices"
 	"strings"
 	"time"
 
@@ -1485,6 +1487,20 @@ func isMCOReady(ctx context.Context, client client.Client) bool {
 	return availableCondition && !progressingCondition
 }
 
+// sortAndConvertIPs sorts a slice of net.IP addresses and converts them to []configv1.IP
+func sortAndConvertIPs(ips []net.IP) []configv1.IP {
+	slices.SortFunc(ips, func(a, b net.IP) int {
+		return bytes.Compare(a, b)
+	})
+	result := make([]configv1.IP, 0, len(ips))
+	for _, ip := range ips {
+		if ip != nil {
+			result = append(result, configv1.IP(ip.String()))
+		}
+	}
+	return result
+}
+
 // computeUpdatedInfraFromService updates PlatformStatus for AWS, Azure and GCP with Ingress LB IPs when the DNSType is `ClusterHosted`.
 func computeUpdatedInfraFromService(service *corev1.Service, infraConfig *configv1.Infrastructure) (bool, error) {
 	platformStatus := infraConfig.Status.PlatformStatus
@@ -1508,20 +1524,16 @@ func computeUpdatedInfraFromService(service *corev1.Service, infraConfig *config
 				platformStatus.AWS.CloudLoadBalancerConfig.ClusterHosted = &configv1.CloudLoadBalancerIPs{}
 			}
 			ingresses := service.Status.LoadBalancer.Ingress
-			ingressLBIPs := []configv1.IP{}
+			latestIngressIPs := []net.IP{}
 			for _, ingress := range ingresses {
 				// Resolving the LoadBalancer's IPs is not ideal because they may change, but currently there is no better alternative.
 				ingressIPs, err := net.LookupIP(ingress.Hostname)
 				if err != nil {
 					return false, fmt.Errorf("failed to lookup IP addresses corresponding to AWS LB hostname: %w", err)
 				}
-
-				if len(ingressIPs) > 0 {
-					for _, ingressIP := range ingressIPs {
-						ingressLBIPs = append(ingressLBIPs, configv1.IP(ingressIP.String()))
-					}
-				}
+				latestIngressIPs = append(latestIngressIPs, ingressIPs...)
 			}
+			ingressLBIPs := sortAndConvertIPs(latestIngressIPs)
 			if !cmp.Equal(platformStatus.AWS.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs, ingressLBIPs, ipCmpOpts...) {
 				platformStatus.AWS.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs = ingressLBIPs
 				log.Info("Updating AWS Infrastructure status with Ingress Load Balancer IPs")
@@ -1535,12 +1547,17 @@ func computeUpdatedInfraFromService(service *corev1.Service, infraConfig *config
 				platformStatus.Azure.CloudLoadBalancerConfig.ClusterHosted = &configv1.CloudLoadBalancerIPs{}
 			}
 			ingresses := service.Status.LoadBalancer.Ingress
-			ingressLBIPs := []configv1.IP{}
+			latestIngressIPs := []net.IP{}
 			for _, ingress := range ingresses {
 				if len(ingress.IP) > 0 {
-					ingressLBIPs = append(ingressLBIPs, configv1.IP(ingress.IP))
+					if ip := net.ParseIP(ingress.IP); ip != nil {
+						latestIngressIPs = append(latestIngressIPs, ip)
+					} else {
+						log.Info("skipping invalid IP address", "ip", ingress.IP, "platform", "Azure")
+					}
 				}
 			}
+			ingressLBIPs := sortAndConvertIPs(latestIngressIPs)
 			if !cmp.Equal(platformStatus.Azure.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs, ingressLBIPs, ipCmpOpts...) {
 				platformStatus.Azure.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs = ingressLBIPs
 				log.Info("Updating Azure Infrastructure status with Ingress Load Balancer IPs")
@@ -1554,12 +1571,17 @@ func computeUpdatedInfraFromService(service *corev1.Service, infraConfig *config
 				platformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted = &configv1.CloudLoadBalancerIPs{}
 			}
 			ingresses := service.Status.LoadBalancer.Ingress
-			ingressLBIPs := []configv1.IP{}
+			latestIngressIPs := []net.IP{}
 			for _, ingress := range ingresses {
 				if len(ingress.IP) > 0 {
-					ingressLBIPs = append(ingressLBIPs, configv1.IP(ingress.IP))
+					if ip := net.ParseIP(ingress.IP); ip != nil {
+						latestIngressIPs = append(latestIngressIPs, ip)
+					} else {
+						log.Info("skipping invalid IP address", "ip", ingress.IP, "platform", "GCP")
+					}
 				}
 			}
+			ingressLBIPs := sortAndConvertIPs(latestIngressIPs)
 			if !cmp.Equal(platformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs, ingressLBIPs, ipCmpOpts...) {
 				platformStatus.GCP.CloudLoadBalancerConfig.ClusterHosted.IngressLoadBalancerIPs = ingressLBIPs
 				log.Info("Updating GCP Infrastructure status with Ingress Load Balancer IPs")

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -1868,12 +1868,44 @@ func Test_computeUpdatedInfraFromService(t *testing.T) {
 				},
 			},
 		}
+		gcpPlatformWithMultipleLBIPs = configv1.PlatformStatus{
+			Type: configv1.GCPPlatformType,
+			GCP: &configv1.GCPPlatformStatus{
+				CloudLoadBalancerConfig: &configv1.CloudLoadBalancerConfig{
+					DNSType: configv1.ClusterHostedDNSType,
+					ClusterHosted: &configv1.CloudLoadBalancerIPs{
+						IngressLoadBalancerIPs: []configv1.IP{
+							configv1.IP("10.10.10.4"),
+							IngressLBIP,
+						},
+					},
+				},
+			},
+		}
+		azurePlatformWithMultipleLBIPs = configv1.PlatformStatus{
+			Type: configv1.AzurePlatformType,
+			Azure: &configv1.AzurePlatformStatus{
+				CloudLoadBalancerConfig: &configv1.CloudLoadBalancerConfig{
+					DNSType: configv1.ClusterHostedDNSType,
+					ClusterHosted: &configv1.CloudLoadBalancerIPs{
+						IngressLoadBalancerIPs: []configv1.IP{
+							configv1.IP("10.10.10.4"),
+							IngressLBIP,
+						},
+					},
+				},
+			},
+		}
 		ingresses = []corev1.LoadBalancerIngress{
 			{IP: "196.78.125.4"},
 		}
 		ingressesWithMultipleIPs = []corev1.LoadBalancerIngress{
 			{IP: "196.78.125.4"},
 			{IP: "10.10.10.4"},
+		}
+		ingressesWithMultipleIPsReversed = []corev1.LoadBalancerIngress{
+			{IP: "10.10.10.4"},
+			{IP: "196.78.125.4"},
 		}
 		// Hostname is intentionally assigned an IP address for unit testing purposes since net.LookupIP simply returns the provided IP.
 		awsIngresses = []corev1.LoadBalancerIngress{
@@ -1939,8 +1971,16 @@ func Test_computeUpdatedInfraFromService(t *testing.T) {
 			description:   "gcp platform with DNSType and LB IP",
 			platform:      &gcpPlatformWithLBIP,
 			ingresses:     ingressesWithMultipleIPs,
-			expectedLBIPs: []configv1.IP{IngressLBIP, configv1.IP("10.10.10.4")},
+			expectedLBIPs: []configv1.IP{configv1.IP("10.10.10.4"), IngressLBIP},
 			expectUpdated: true,
+			expectError:   false,
+		},
+		{
+			description:   "gcp platform with multiple IPs in different order should not update",
+			platform:      &gcpPlatformWithMultipleLBIPs,
+			ingresses:     ingressesWithMultipleIPsReversed,
+			expectedLBIPs: []configv1.IP{configv1.IP("10.10.10.4"), IngressLBIP},
+			expectUpdated: false,
 			expectError:   false,
 		},
 		{
@@ -2015,8 +2055,16 @@ func Test_computeUpdatedInfraFromService(t *testing.T) {
 			description:   "azure platform with multiple IPs",
 			platform:      &azurePlatformWithLBIP,
 			ingresses:     ingressesWithMultipleIPs,
-			expectedLBIPs: []configv1.IP{IngressLBIP, configv1.IP("10.10.10.4")},
+			expectedLBIPs: []configv1.IP{configv1.IP("10.10.10.4"), IngressLBIP},
 			expectUpdated: true,
+			expectError:   false,
+		},
+		{
+			description:   "azure platform with multiple IPs in different order should not update",
+			platform:      &azurePlatformWithMultipleLBIPs,
+			ingresses:     ingressesWithMultipleIPsReversed,
+			expectedLBIPs: []configv1.IP{configv1.IP("10.10.10.4"), IngressLBIP},
+			expectUpdated: false,
 			expectError:   false,
 		},
 	}


### PR DESCRIPTION
This PR contains 2 commits:

1. On AWS, Azure and GCP platforms, do not update the Ingress LB IPs in the Infra CR's Platform Status when only the order of Ingress Load Balancer IPs have changed.
Fixes: https://redhat.atlassian.net/browse/OCPBUGS-81761

2. Follow-up to [comment](https://github.com/openshift/cluster-ingress-operator/pull/1411#issuecomment-4219996451) on  https://github.com/openshift/cluster-ingress-operator/pull/1411.