### PR TITLE
[release-4.20] OCPBUGS-82152: Filter non-FIPS TLS 1.3 ciphers and validate effective profiles

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -83,6 +83,14 @@ var (
 		"TLS_AES_128_CCM_SHA256",
 		"TLS_AES_128_CCM_8_SHA256",
 	)
+
+	// fipsApprovedTLS13Ciphers is the set of TLS 1.3 cipher suites that are
+	// FIPS-approved. These are kept in ROUTER_CIPHERSUITES when the operator
+	// is running in FIPS mode, while others are filtered out.
+	fipsApprovedTLS13Ciphers = sets.NewString(
+		"TLS_AES_128_GCM_SHA256",
+		"TLS_AES_256_GCM_SHA384",
+	)
 )
 
 // New creates the ingress controller from configuration. This is the controller
@@ -304,7 +312,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// successful, immediately re-queue to refresh state.
 	alreadyAdmitted := ingresscontroller.IsAdmitted(ingress)
 	if !alreadyAdmitted || needsReadmission(ingress) {
-		if err := r.admit(ingress, ingressConfig, platformStatus, dnsConfig, alreadyAdmitted); err != nil {
+		if err := r.admit(ingress, ingressConfig, platformStatus, dnsConfig, apiConfig, alreadyAdmitted); err != nil {
 			switch err := err.(type) {
 			case *admissionRejection:
 				r.recorder.Event(ingress, "Warning", "Rejected", err.Reason)
@@ -358,7 +366,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 // fields.  Returns an error value, which will have a non-nil value of type
 // admissionRejection if the ingresscontroller was rejected, or a non-nil
 // value of a different type if the ingresscontroller could not be processed.
-func (r *reconciler) admit(current *operatorv1.IngressController, ingressConfig *configv1.Ingress, platformStatus *configv1.PlatformStatus, dnsConfig *configv1.DNS, alreadyAdmitted bool) error {
+func (r *reconciler) admit(current *operatorv1.IngressController, ingressConfig *configv1.Ingress, platformStatus *configv1.PlatformStatus, dnsConfig *configv1.DNS, apiConfig *configv1.APIServer, alreadyAdmitted bool) error {
 	updated := current.DeepCopy()
 
 	setDefaultDomain(updated, ingressConfig)
@@ -373,7 +381,7 @@ func (r *reconciler) admit(current *operatorv1.IngressController, ingressConfig 
 	// get the default from the APIServer config (which is assumed to be
 	// valid).
 
-	if err := r.validate(updated); err != nil {
+	if err := r.validate(updated, apiConfig); err != nil {
 		switch err := err.(type) {
 		case *admissionRejection:
 			updated.Status.Conditions = MergeConditions(updated.Status.Conditions, operatorv1.OperatorCondition{
@@ -827,7 +835,7 @@ func tlsProfileSpecForSecurityProfile(profile *configv1.TLSSecurityProfile) *con
 // returns an error value, which will have a non-nil value of type
 // admissionRejection if the ingresscontroller is invalid, or a non-nil value of
 // a different type if validation could not be completed.
-func (r *reconciler) validate(ic *operatorv1.IngressController) error {
+func (r *reconciler) validate(ic *operatorv1.IngressController, apiConfig *configv1.APIServer) error {
 	var errors []error
 
 	ingresses := &operatorv1.IngressControllerList{}
@@ -841,7 +849,7 @@ func (r *reconciler) validate(ic *operatorv1.IngressController) error {
 	if err := validateDomainUniqueness(ic, ingresses.Items); err != nil {
 		errors = append(errors, err)
 	}
-	if err := validateTLSSecurityProfile(ic); err != nil {
+	if err := validateTLSSecurityProfile(ic, apiConfig); err != nil {
 		errors = append(errors, err)
 	}
 	if err := validateHTTPHeaderBufferValues(ic); err != nil {
@@ -894,49 +902,76 @@ var (
 )
 
 // validateTLSSecurityProfile validates the given ingresscontroller's TLS
-// security profile, if it specifies one.
-func validateTLSSecurityProfile(ic *operatorv1.IngressController) error {
-	if !hasTLSSecurityProfile(ic) {
-		return nil
-	}
-
-	if ic.Spec.TLSSecurityProfile.Type != configv1.TLSProfileCustomType {
-		return nil
-	}
-
-	spec := ic.Spec.TLSSecurityProfile.Custom
-	if spec == nil {
-		return fmt.Errorf("security profile is not defined")
-	}
-
+// security profile. It resolves the effective profile (which may be inherited
+// from the APIServer config) and ensures it is properly configured and FIPS-compliant.
+func validateTLSSecurityProfile(ic *operatorv1.IngressController, apiConfig *configv1.APIServer) error {
 	var errs []error
 
-	if len(spec.Ciphers) == 0 {
-		errs = append(errs, fmt.Errorf("security profile has an empty ciphers list"))
+	if apiConfig == nil {
+		apiConfig = &configv1.APIServer{}
+	}
+
+	// 1. Figure out which profile is in effect.
+	var effectiveProfile *configv1.TLSSecurityProfile
+	if hasTLSSecurityProfile(ic) {
+		effectiveProfile = ic.Spec.TLSSecurityProfile
 	} else {
-		invalidCiphers := []string{}
-		for _, cipher := range spec.Ciphers {
-			if !isValidCipher(strings.TrimPrefix(cipher, "!")) {
-				invalidCiphers = append(invalidCiphers, cipher)
+		effectiveProfile = apiConfig.Spec.TLSSecurityProfile
+	}
+
+	// 2. Validate the effective profile.
+	if effectiveProfile != nil && effectiveProfile.Type == configv1.TLSProfileCustomType {
+		spec := effectiveProfile.Custom
+		if spec == nil {
+			return fmt.Errorf("security profile is not defined")
+		}
+
+		if len(spec.Ciphers) == 0 {
+			errs = append(errs, fmt.Errorf("security profile has an empty ciphers list"))
+		} else {
+			invalidCiphers := []string{}
+			for _, cipher := range spec.Ciphers {
+				if !isValidCipher(strings.TrimPrefix(cipher, "!")) {
+					invalidCiphers = append(invalidCiphers, cipher)
+				}
+			}
+			if len(invalidCiphers) != 0 {
+				errs = append(errs, fmt.Errorf("security profile has invalid ciphers: %s", strings.Join(invalidCiphers, ", ")))
+			}
+			switch spec.MinTLSVersion {
+			case configv1.VersionTLS10, configv1.VersionTLS11, configv1.VersionTLS12:
+				if tlsVersion13Ciphers.HasAll(spec.Ciphers...) {
+					errs = append(errs, fmt.Errorf("security profile specifies minTLSVersion: %s and contains only TLSv1.3 cipher suites", spec.MinTLSVersion))
+				}
+			case configv1.VersionTLS13:
+				if !tlsVersion13Ciphers.HasAny(spec.Ciphers...) {
+					errs = append(errs, fmt.Errorf("security profile specifies minTLSVersion: %s and contains no TLSv1.3 cipher suites", spec.MinTLSVersion))
+				}
 			}
 		}
-		if len(invalidCiphers) != 0 {
-			errs = append(errs, fmt.Errorf("security profile has invalid ciphers: %s", strings.Join(invalidCiphers, ", ")))
-		}
-		switch spec.MinTLSVersion {
-		case configv1.VersionTLS10, configv1.VersionTLS11, configv1.VersionTLS12:
-			if tlsVersion13Ciphers.HasAll(spec.Ciphers...) {
-				errs = append(errs, fmt.Errorf("security profile specifies minTLSVersion: %s and contains only TLSv1.3 cipher suites", spec.MinTLSVersion))
-			}
-		case configv1.VersionTLS13:
-			if !tlsVersion13Ciphers.HasAny(spec.Ciphers...) {
-				errs = append(errs, fmt.Errorf("security profile specifies minTLSVersion: %s and contains no TLSv1.3 cipher suites", spec.MinTLSVersion))
-			}
+
+		if _, ok := validTLSVersions[spec.MinTLSVersion]; !ok {
+			errs = append(errs, fmt.Errorf("security profile has invalid minimum security protocol version: %q", spec.MinTLSVersion))
 		}
 	}
 
-	if _, ok := validTLSVersions[spec.MinTLSVersion]; !ok {
-		errs = append(errs, fmt.Errorf("security profile has invalid minimum security protocol version: %q", spec.MinTLSVersion))
+	// On FIPS-enabled clusters, non-FIPS TLS 1.3 ciphers are filtered from
+	// ROUTER_CIPHERSUITES. If the effective profile's only TLS 1.3 cipher suites
+	// are non-FIPS, they would all be removed, leaving no TLS 1.3 ciphers
+	// configured. Reject such profiles with a clear error message.
+	if isFIPSEnabled {
+		resolvedSpec := tlsProfileSpecForIngressController(ic, apiConfig)
+		tls13InProfile := tlsVersion13Ciphers.Intersection(sets.NewString(resolvedSpec.Ciphers...))
+		if tls13InProfile.Len() > 0 && !tls13InProfile.HasAny(fipsApprovedTLS13Ciphers.UnsortedList()...) {
+			errs = append(errs, fmt.Errorf(
+				"security profile's TLS 1.3 cipher suites (%s) are not FIPS-compliant"+
+					" and will be removed on this FIPS-enabled cluster,"+
+					" leaving no TLS 1.3 ciphers configured;"+
+					" specify at least one FIPS-compliant TLS 1.3 cipher suite"+
+					" (e.g. TLS_AES_128_GCM_SHA256 or TLS_AES_256_GCM_SHA384)"+
+					" or remove the non-FIPS cipher suites from the profile",
+				strings.Join(tls13InProfile.List(), ", ")))
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/pkg/operator/controller/ingress/controller_test.go
+++ b/pkg/operator/controller/ingress/controller_test.go
@@ -1086,7 +1086,7 @@ func Test_tlsProfileSpecForSecurityProfile(t *testing.T) {
 				},
 			}
 			tlsProfileSpec := tlsProfileSpecForSecurityProfile(ic.Spec.TLSSecurityProfile)
-			err := validateTLSSecurityProfile(ic)
+			err := validateTLSSecurityProfile(ic, &configv1.APIServer{})
 			if tc.valid && err != nil {
 				t.Fatalf("unexpected error: %v\nprofile:\n%s", err, util.ToYaml(tlsProfileSpec))
 			}
@@ -1097,6 +1097,98 @@ func Test_tlsProfileSpecForSecurityProfile(t *testing.T) {
 				t.Fatalf("expected profile:\n%s\ngot profile:\n%s", util.ToYaml(tc.expectedSpec), util.ToYaml(tlsProfileSpec))
 			}
 			t.Logf("got expected values; profile:\n%s\nerror value: %v", util.ToYaml(tlsProfileSpec), err)
+		})
+	}
+}
+
+// Test_validateTLSSecurityProfileFIPS verifies that validateTLSSecurityProfile
+// rejects custom profiles whose only TLS 1.3 cipher suites are non-FIPS when
+// the cluster is running in FIPS mode (OCPBUGS-3917).
+func Test_validateTLSSecurityProfileFIPS(t *testing.T) {
+	// Simulate FIPS mode by overriding the package-level isFIPSEnabled var.
+	origFIPS := isFIPSEnabled
+	isFIPSEnabled = true
+	defer func() { isFIPSEnabled = origFIPS }()
+
+	testCases := []struct {
+		description    string
+		ciphers        []string
+		expectError    bool
+		inheritFromAPI bool
+	}{
+		{
+			description: "FIPS mode: profile with only TLS_CHACHA20_POLY1305_SHA256 as TLS 1.3 cipher should be rejected",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+			expectError: true,
+		},
+		{
+			description: "FIPS mode: profile with FIPS-compliant TLS 1.3 cipher alongside CHACHA20 should be accepted",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+			expectError: false,
+		},
+		{
+			description: "FIPS mode: profile with only FIPS-compliant TLS 1.3 ciphers should be accepted",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+			},
+			expectError: false,
+		},
+		{
+			description: "FIPS mode: inherited custom profile from APIServer with only TLS_CHACHA20_POLY1305_SHA256 as TLS 1.3 cipher should be rejected",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+			expectError:    true,
+			inheritFromAPI: true,
+		},
+		{
+			description: "FIPS mode: profile with only TLS 1.2 ciphers (no TLS 1.3 at all) should be accepted",
+			ciphers: []string{
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES256-GCM-SHA384",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ic := &operatorv1.IngressController{}
+			apiConfig := &configv1.APIServer{}
+
+			profile := &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       tc.ciphers,
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			}
+
+			if tc.inheritFromAPI {
+				apiConfig.Spec.TLSSecurityProfile = profile
+			} else {
+				ic.Spec.TLSSecurityProfile = profile
+			}
+
+			err := validateTLSSecurityProfile(ic, apiConfig)
+			if tc.expectError && err == nil {
+				t.Error("expected error for FIPS-incompatible profile, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 		})
 	}
 }

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -37,6 +38,17 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 )
+
+// isFIPSEnabled reports whether the current node is operating in FIPS
+// mode by checking /proc/sys/crypto/fips_enabled. This is a
+// package-level variable so tests can override it to simulate FIPS mode.
+var isFIPSEnabled = func() bool {
+	data, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+	if err != nil {
+		return false
+	}
+	return len(data) > 0 && data[0] == '1'
+}()
 
 const (
 	WildcardRouteAdmissionPolicy = "ROUTER_ALLOW_WILDCARD_ROUTES"
@@ -959,6 +971,20 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		} else {
 			otherCiphers = append(otherCiphers, cipher)
 		}
+	}
+	// On FIPS-enabled clusters, remove non-FIPS-compliant TLS 1.3 cipher
+	// suites (specifically TLS_CHACHA20_POLY1305_SHA256) from
+	// ROUTER_CIPHERSUITES. HAProxy would fail TLS handshakes when a client
+	// offers a non-FIPS cipher first if that cipher is listed in
+	// ssl-default-bind-ciphersuites but excluded by the OS FIPS policy.
+	if isFIPSEnabled {
+		fipsCiphers := tls13Ciphers[:0]
+		for _, c := range tls13Ciphers {
+			if fipsApprovedTLS13Ciphers.Has(c) {
+				fipsCiphers = append(fipsCiphers, c)
+			}
+		}
+		tls13Ciphers = fipsCiphers
 	}
 	env = append(env, corev1.EnvVar{
 		Name:  "ROUTER_CIPHERS",

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1002,6 +1002,64 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 	checkContainerPort(t, deployment, "metrics", 9146)
 }
 
+// TestDesiredRouterDeploymentFIPS verifies that on a FIPS-enabled cluster,
+// TLS_CHACHA20_POLY1305_SHA256 is removed from ROUTER_CIPHERSUITES while
+// FIPS-compliant TLS 1.3 ciphers are kept (OCPBUGS-3917).
+func TestDesiredRouterDeploymentFIPS(t *testing.T) {
+	// Simulate FIPS mode by swapping the package-level isFIPSEnabled var.
+	origFIPS := isFIPSEnabled
+	isFIPSEnabled = true
+	defer func() { isFIPSEnabled = origFIPS }()
+
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
+
+	// Profile: two FIPS-compliant TLS 1.3 ciphers + one non-FIPS TLS 1.3 cipher.
+	ic.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				Ciphers: []string{
+					"ECDHE-RSA-AES128-GCM-SHA256",  // TLS 1.2
+					"TLS_AES_128_GCM_SHA256",       // TLS 1.3, FIPS-compliant
+					"TLS_AES_256_GCM_SHA384",       // TLS 1.3, FIPS-compliant
+					"TLS_CHACHA20_POLY1305_SHA256", // TLS 1.3, non-FIPS — must be removed
+				},
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CHACHA20 must be absent; the two FIPS-compliant ciphers must be present.
+	expected := []envData{
+		{"ROUTER_CIPHERS", true, "ECDHE-RSA-AES128-GCM-SHA256"},
+		{"ROUTER_CIPHERSUITES", true, "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"},
+	}
+	if err := checkDeploymentEnvironment(t, deployment, expected); err != nil {
+		t.Errorf("FIPS cipher filtering: %v", err)
+	}
+
+	checkDeploymentHasEnvSorted(t, deployment)
+
+	// Also verify non-FIPS mode leaves all ciphers intact.
+	isFIPSEnabled = false
+	deploymentNonFIPS, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, false, nil, clusterProxyConfig)
+	if err != nil {
+		t.Fatalf("unexpected error (non-FIPS): %v", err)
+	}
+	expectedNonFIPS := []envData{
+		{"ROUTER_CIPHERS", true, "ECDHE-RSA-AES128-GCM-SHA256"},
+		{"ROUTER_CIPHERSUITES", true, "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"},
+	}
+	if err := checkDeploymentEnvironment(t, deploymentNonFIPS, expectedNonFIPS); err != nil {
+		t.Errorf("non-FIPS cipher passthrough: %v", err)
+	}
+}
+
 // TestDesiredRouterDeploymentHostNetworkNil verifies that
 // desiredRouterDeployment behaves correctly when
 // status.endpointPublishingStrategy.type is "HostNetwork" but


### PR DESCRIPTION
Manual backport of #1401 due to merge conflicts.