### PR TITLE
OCPBUGS-84551: isFIPSEnabled: Check FIPS_ENABLED env. var. first

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -40,16 +40,47 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 )
 
-// isFIPSEnabled reports whether the current node is operating in FIPS
-// mode by checking /proc/sys/crypto/fips_enabled. This is a
-// package-level variable so tests can override it to simulate FIPS mode.
-var isFIPSEnabled = func() bool {
-	data, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
-	if err != nil {
-		return false
+// isFIPSEnabled reports whether the cluster has FIPS enabled.
+var isFIPSEnabled = detectFIPS()
+
+// lookupEnv is an alias for os.LookupEnv that can be overridden in unit tests.
+var lookupEnv = os.LookupEnv
+
+// readFile is an alias for os.ReadFile that can be overridden in unit tests.
+var readFile = os.ReadFile
+
+// detectFIPS reports whether the cluster is operating in FIPS
+// mode by checking the FIPS_ENABLED environment variable if it set or
+// the /proc/sys/crypto/fips_enabled file otherwise. This is a package-
+// level variable so tests can override it to simulate FIPS mode.
+func detectFIPS() bool {
+	if v, ok := lookupEnv("FIPS_ENABLED"); ok {
+		if result, err := strconv.ParseBool(v); err != nil {
+			log.Error(err, "Failed to parse FIPS_ENABLED environment variable; falling back to procfs")
+		} else {
+			log.Info("Found FIPS_ENABLED environment variable", "value", v, "result", result)
+
+			return result
+		}
 	}
-	return len(data) > 0 && data[0] == '1'
-}()
+
+	result := false
+	if data, err := readFile("/proc/sys/crypto/fips_enabled"); err != nil {
+		log.Error(err, "Failed to read /proc/sys/crypto/fips_enabled; assuming FIPS is not enabled", "result", result)
+
+		return result
+	} else if len(data) == 0 {
+		log.Error(nil, "Got empty /proc/sys/crypto/fips_enabled; assuming FIPS is not enabled", "result", result)
+
+		return result
+	} else {
+		result = data[0] == '1'
+
+		log.Info("Read /proc/sys/crypto/fips_enabled", "data", data, "result", result)
+
+		return result
+	}
+}
 
 const (
 	WildcardRouteAdmissionPolicy = "ROUTER_ALLOW_WILDCARD_ROUTES"

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -2830,6 +2831,98 @@ func TestDesiredRouterDeploymentTLSCurves(t *testing.T) {
 			if err := checkDeploymentEnvironment(t, deployment, tc.expectedEnv); err != nil {
 				t.Error(err)
 			}
+		})
+	}
+}
+
+// Test_detectFIPS verifies that detectFIPS correctly checks the FIPS_ENABLED
+// environment variable if it is set and falls back to the
+// /proc/sys/crypto/fips_enabled file.
+func Test_detectFIPS(t *testing.T) {
+	defer func() {
+		lookupEnv = os.LookupEnv
+		readFile = os.ReadFile
+	}()
+
+	var fipsEnabledEnvVar *string
+	lookupEnv = func(name string) (string, bool) {
+		switch name {
+		case "FIPS_ENABLED":
+			if fipsEnabledEnvVar == nil {
+				return "", false
+			} else {
+				return *fipsEnabledEnvVar, true
+			}
+		default:
+			t.Fatalf("unexpected argument for lookupEnv: %s", name)
+			return "", false
+		}
+	}
+
+	var fipsEnabledProcfsData []byte
+	readFile = func(name string) ([]byte, error) {
+		switch name {
+		case "/proc/sys/crypto/fips_enabled":
+			return fipsEnabledProcfsData, nil
+		default:
+			t.Fatalf("unexpected argument for readFile: %s", name)
+
+			return fipsEnabledProcfsData, nil
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		envVarValue *string
+		procfsData  []byte
+		expected    bool
+	}{{
+		name:        `expect false if no env var and procfs has "0"`,
+		envVarValue: nil,
+		procfsData:  []byte{'0'},
+		expected:    false,
+	}, {
+		name:        `expect true if no env var and procfs has "1"`,
+		envVarValue: nil,
+		procfsData:  []byte{'1'},
+		expected:    true,
+	}, {
+		name:        `expect false if env var has "false"`,
+		envVarValue: ptr.To("false"),
+		procfsData:  []byte{'1'},
+		expected:    false,
+	}, {
+		name:        `expect true if env var has "true"`,
+		envVarValue: ptr.To("true"),
+		procfsData:  []byte{'1'},
+		expected:    true,
+	}, {
+		name:        `expect false if env var is empty and procfs has "0"`,
+		envVarValue: ptr.To(""),
+		procfsData:  []byte{'0'},
+		expected:    false,
+	}, {
+		name:        `expect true if env var is empty and procfs has "1"`,
+		envVarValue: ptr.To(""),
+		procfsData:  []byte{'1'},
+		expected:    true,
+	}, {
+		name:        `expect false if env var has garbage and procfs has "0"`,
+		envVarValue: ptr.To("garbage"),
+		procfsData:  []byte{'0'},
+		expected:    false,
+	}, {
+		name:        `expect true if env var has garbage and procfs has "1"`,
+		envVarValue: ptr.To("garbage"),
+		procfsData:  []byte{'1'},
+		expected:    true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fipsEnabledEnvVar = tc.envVarValue
+			fipsEnabledProcfsData = tc.procfsData
+			assert.Equal(t, tc.expected, detectFIPS())
 		})
 	}
 }


### PR DESCRIPTION
When detecting whether the cluster has FIPS enabled, check the FIPS_ENABLED environment variable before checking procfs.  HyperShift sets this environment variable so that the operator can correctly detect the FIPS status of hosted clusters, which can be different from the FIPS status of the management cluster where the operator runs.

--- 

https://github.com/openshift/hypershift/pull/8375 sets `FIPS_ENABLED`, so the complete fix depends on both that PR and this one.  However, because this PR falls back to procfs, it doesn't strictly depend on the hypershift PR.  