### PR TITLE
OCPBUGS-84773: Allow host network connections to the ingress canary

### DIFF
--- a/pkg/manifests/assets/canary/networkpolicy-allow.yaml
+++ b/pkg/manifests/assets/canary/networkpolicy-allow.yaml
@@ -15,8 +15,13 @@ spec:
     - protocol: TCP
       port: 8443
     from:
+    # depending on topology, valid canary checks will either appear to come from
+    # the router's namespace or the host network.
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: openshift-ingress
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
   policyTypes:
   - Ingress


### PR DESCRIPTION
Depending on network topology, canary checks will appear to come either from the router's namespace (openshift-ingress), or the host network. Allow either source to access the canary.

This is part of the fix for OCPBUGS-84773.