### PR TITLE
OCPBUGS-85679: Improve e2e tests reliability

### DIFF
--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -3,7 +3,15 @@
 
 package e2e
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+// Define default timeouts
+const (
+	DefaultRetryTimeout = 2 * time.Minute
+)
 
 // TestAll is the entrypoint for `make test-e2e` unless you override
 // with: make TEST=Test<foo> test-e2e.

--- a/test/e2e/allowed_source_ranges_test.go
+++ b/test/e2e/allowed_source_ranges_test.go
@@ -60,7 +60,7 @@ func TestAllowedSourceRanges(t *testing.T) {
 	// Create an ingresscontroller with a valid CIDR
 	t.Logf("Creating ingresscontroller with spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges set to a valid CIDR range %s", validCIDR)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges = []operatorv1.CIDR{operatorv1.CIDR(validCIDR)}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestAllowedSourceRangesStatus(t *testing.T) {
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -264,7 +264,7 @@ func TestSourceRangesProgressingAndEvaluationConditionsDetectedStatuses(t *testi
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/allowed_source_ranges_test.go
+++ b/test/e2e/allowed_source_ranges_test.go
@@ -60,7 +60,7 @@ func TestAllowedSourceRanges(t *testing.T) {
 	// Create an ingresscontroller with a valid CIDR
 	t.Logf("Creating ingresscontroller with spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges set to a valid CIDR range %s", validCIDR)
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges = []operatorv1.CIDR{operatorv1.CIDR(validCIDR)}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestAllowedSourceRangesStatus(t *testing.T) {
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -166,7 +166,7 @@ func TestAllowedSourceRangesStatus(t *testing.T) {
 		t.Fatalf("failed to update service: %v", err)
 	}
 
-	err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(10*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), name, ic); err != nil {
 			return false, fmt.Errorf("failed to get ingresscontroller: %w", err)
 		}
@@ -204,7 +204,7 @@ func TestAllowedSourceRangesStatus(t *testing.T) {
 		t.Fatalf("failed to update service: %v", err)
 	}
 
-	err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(10*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), name, ic); err != nil {
 			return false, fmt.Errorf("failed to get ingresscontroller: %w", err)
 		}
@@ -264,7 +264,7 @@ func TestSourceRangesProgressingAndEvaluationConditionsDetectedStatuses(t *testi
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -277,7 +277,7 @@ func TestCanaryWithMTLS(t *testing.T) {
 		t.Fatalf("Failed to create configmap %s: %v", clientCAConfigmap.Name, err)
 	}
 
-	t.Cleanup(func() { assertDeleted(t, kclient, clientCAConfigmap) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute) })
 
 	defaultIC := &operatorv1.IngressController{}
 	if err := kclient.Get(context.TODO(), defaultName, defaultIC); err != nil {

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -83,7 +83,7 @@ func TestCanaryRoute(t *testing.T) {
 
 	clientPodName := types.NamespacedName{Name: "canary-route-check", Namespace: canaryRoute.Namespace}
 	clientNetworkPolicy := buildTestPodNetworkPolicy(clientPodName)
-	if err := kclient.Create(context.TODO(), clientNetworkPolicy); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientNetworkPolicy, 2*time.Minute); err != nil {
 		t.Fatalf("Failed to create network policy %s/%s: %v", clientNetworkPolicy.Namespace, clientNetworkPolicy.Name, err)
 	}
 	t.Cleanup(func() {
@@ -97,7 +97,7 @@ func TestCanaryRoute(t *testing.T) {
 
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildCanaryCurlPod(clientPodName.Name, clientPodName.Namespace, image, canaryRouteHost)
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("Failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() {
@@ -273,7 +273,7 @@ func TestCanaryWithMTLS(t *testing.T) {
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), clientCAConfigmap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute); err != nil {
 		t.Fatalf("Failed to create configmap %s: %v", clientCAConfigmap.Name, err)
 	}
 

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -303,7 +303,7 @@ func TestCanaryWithMTLS(t *testing.T) {
 		if err := updateIngressControllerWithRetryOnConflict(t, defaultName, timeout, func(defaultIC *operatorv1.IngressController) {
 			defaultIC.Spec.ClientTLS = *originalClientTLS
 		}); err != nil {
-			t.Fatalf("Failed to restore default ingress configuration: %v", err)
+			t.Errorf("Failed to restore default ingress configuration: %v", err)
 		}
 		t.Log("Restored clientTLS config for default ingresscontroller.")
 	})

--- a/test/e2e/canary_test.go
+++ b/test/e2e/canary_test.go
@@ -83,7 +83,7 @@ func TestCanaryRoute(t *testing.T) {
 
 	clientPodName := types.NamespacedName{Name: "canary-route-check", Namespace: canaryRoute.Namespace}
 	clientNetworkPolicy := buildTestPodNetworkPolicy(clientPodName)
-	if err := createWithRetryOnError(t, context.Background(), clientNetworkPolicy, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientNetworkPolicy, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create network policy %s/%s: %v", clientNetworkPolicy.Namespace, clientNetworkPolicy.Name, err)
 	}
 	t.Cleanup(func() {
@@ -97,7 +97,7 @@ func TestCanaryRoute(t *testing.T) {
 
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildCanaryCurlPod(clientPodName.Name, clientPodName.Namespace, image, canaryRouteHost)
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() {
@@ -273,11 +273,11 @@ func TestCanaryWithMTLS(t *testing.T) {
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create configmap %s: %v", clientCAConfigmap.Name, err)
 	}
 
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, DefaultRetryTimeout) })
 
 	defaultIC := &operatorv1.IngressController{}
 	if err := kclient.Get(context.TODO(), defaultName, defaultIC); err != nil {

--- a/test/e2e/checkinterval_test.go
+++ b/test/e2e/checkinterval_test.go
@@ -32,7 +32,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)

--- a/test/e2e/checkinterval_test.go
+++ b/test/e2e/checkinterval_test.go
@@ -29,7 +29,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/checkinterval_test.go
+++ b/test/e2e/checkinterval_test.go
@@ -29,7 +29,7 @@ func TestHealthCheckIntervalIngressController(t *testing.T) {
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -129,13 +129,13 @@ func TestClientTLS(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, echoPod) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, echoService) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Spec.TLS = &routev1.TLSConfig{
@@ -145,7 +145,7 @@ func TestClientTLS(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, echoRoute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	// Wait for echo pod to be ready.
 	err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -844,7 +844,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				if err := kclient.Create(context.TODO(), &crlConfigMap); err != nil {
 					t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 				}
-				t.Cleanup(func() { assertDeleted(t, kclient, &crlConfigMap) })
+				t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
 			}
 
 			if err := kclient.Create(context.TODO(), &crlHostPod); err != nil {
@@ -875,7 +875,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &crlHostService); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &crlHostService) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
 			// Wait for CRL host to be ready.
 			err := wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), crlHostName, &crlHostPod); err != nil {
@@ -903,7 +903,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &clientCAConfigmap); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &clientCAConfigmap) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
 			icName := types.NamespacedName{
 				Name:      "mtls-with-crls",
 				Namespace: operatorNamespace,
@@ -945,7 +945,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &clientCertsConfigmap); err != nil {
 				t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmap.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &clientCertsConfigmap) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCertsConfigmap, 2*time.Minute) })
 
 			// Use the router image for the exec pod since it has curl.
 			routerDeployment := &appsv1.Deployment{}
@@ -979,7 +979,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), clientPod); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, clientPod) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), clientPodName, clientPod); err != nil {
@@ -1031,13 +1031,13 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), echoPod); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, echoPod) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 			if err := kclient.Create(context.TODO(), echoService); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, echoService) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 			echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 			echoRoute.Spec.TLS = &routev1.TLSConfig{
@@ -1047,7 +1047,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 			if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, echoRoute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 			// Wait for echo pod to be ready.
 			err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -1128,7 +1128,7 @@ func TestCRLUpdate(t *testing.T) {
 	if err := kclient.Create(context.TODO(), &namespace); err != nil {
 		t.Fatalf("Failed to create namespace %q: %v", namespace.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, &namespace) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &namespace, 2*time.Minute) })
 	testCases := []struct {
 		// Test case name
 		Name string
@@ -1250,7 +1250,7 @@ func TestCRLUpdate(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &crlConfigMap); err != nil {
 				t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &crlConfigMap) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
 			crlHostPod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      crlHostName.Name,
@@ -1324,7 +1324,7 @@ func TestCRLUpdate(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &crlHostService); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &crlHostService) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
 			// Wait for CRL host to be ready.
 			err := wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), crlHostName, &crlHostPod); err != nil {
@@ -1352,7 +1352,7 @@ func TestCRLUpdate(t *testing.T) {
 			if err := kclient.Create(context.TODO(), &clientCAConfigmap); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
-			t.Cleanup(func() { assertDeleted(t, kclient, &clientCAConfigmap) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
 			icName := types.NamespacedName{
 				Name:      testName,
 				Namespace: operatorNamespace,

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -96,10 +96,10 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientCAConfigmap.Name,
 		Namespace: clientCAConfigmap.Namespace,
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCAConfigmapName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, DefaultRetryTimeout) })
 
 	// Create the custom ingresscontroller.
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "client-tls"}
@@ -111,7 +111,7 @@ func TestClientTLS(t *testing.T) {
 			Name: clientCAConfigmapName.Name,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -121,26 +121,26 @@ func TestClientTLS(t *testing.T) {
 	}
 
 	echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), testNamespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Spec.TLS = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	// Wait for echo pod to be ready.
 	err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -211,11 +211,11 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientCertsConfigmap.Name,
 		Namespace: clientCertsConfigmap.Namespace,
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientCertsConfigmap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCertsConfigmap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmapName, err)
 	}
 
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCertsConfigmap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCertsConfigmap, DefaultRetryTimeout) })
 
 	// Create a test client pod with the client certificates.  We will exec
 	// curl commands in this pod to perform the tests.
@@ -241,11 +241,11 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientPod.Name,
 		Namespace: clientPod.Namespace,
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
 
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), clientPodName, clientPod); err != nil {
@@ -827,13 +827,13 @@ func TestMTLSWithCRLs(t *testing.T) {
 					ReadOnly:  true,
 				})
 
-				if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute); err != nil {
+				if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, DefaultRetryTimeout); err != nil {
 					t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 				}
-				t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
+				t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, DefaultRetryTimeout) })
 			}
 
-			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create pod %q: %v", crlHostPod.Name, err)
 			}
 			// the crlHostPod is one of the first resources to be created, and one of the last to be deleted thanks to
@@ -858,10 +858,10 @@ func TestMTLSWithCRLs(t *testing.T) {
 					}},
 				},
 			}
-			if err := createWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostService, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, DefaultRetryTimeout) })
 			// Wait for CRL host to be ready.
 			err := wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), crlHostName, &crlHostPod); err != nil {
@@ -886,10 +886,10 @@ func TestMTLSWithCRLs(t *testing.T) {
 					"ca-bundle.pem": strings.Join(tcCerts.CABundle, "\n"),
 				},
 			}
-			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, DefaultRetryTimeout) })
 			icName := types.NamespacedName{
 				Name:      "mtls-with-crls",
 				Namespace: operatorNamespace,
@@ -902,7 +902,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				},
 				ClientCertificatePolicy: operatorv1.ClientCertificatePolicyRequired,
 			}
-			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -928,10 +928,10 @@ func TestMTLSWithCRLs(t *testing.T) {
 				clientCertsConfigmap.Data[name+".key"] = encodeKey(keyCert.Key)
 				clientCertsConfigmap.Data[name+".pem"] = keyCert.CertFullChain
 			}
-			if err := createWithRetryOnError(t, context.Background(), &clientCertsConfigmap, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCertsConfigmap, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmap.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCertsConfigmap, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCertsConfigmap, DefaultRetryTimeout) })
 
 			// Use the router image for the exec pod since it has curl.
 			routerDeployment := &appsv1.Deployment{}
@@ -962,10 +962,10 @@ func TestMTLSWithCRLs(t *testing.T) {
 				Name:      clientPod.Name,
 				Namespace: clientPod.Namespace,
 			}
-			if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), clientPodName, clientPod); err != nil {
@@ -1014,26 +1014,26 @@ func TestMTLSWithCRLs(t *testing.T) {
 			})
 
 			echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), namespace.Name)
-			if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-			if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 			echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 			echoRoute.Spec.TLS = &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationEdge,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			}
-			if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 			// Wait for echo pod to be ready.
 			err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -1111,10 +1111,10 @@ func TestCRLUpdate(t *testing.T) {
 			Name: testName,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), &namespace, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), &namespace, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create namespace %q: %v", namespace.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &namespace, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &namespace, DefaultRetryTimeout) })
 	testCases := []struct {
 		// Test case name
 		Name string
@@ -1233,10 +1233,10 @@ func TestCRLUpdate(t *testing.T) {
 				},
 				Data: crlPems,
 			}
-			if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, DefaultRetryTimeout) })
 			crlHostPod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      crlHostName.Name,
@@ -1282,7 +1282,7 @@ func TestCRLUpdate(t *testing.T) {
 				},
 			}
 
-			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create pod %q: %v", crlHostPod.Name, err)
 			}
 			// the crlHostPod is one of the first resources to be created, and one of the last to be deleted thanks to
@@ -1307,10 +1307,10 @@ func TestCRLUpdate(t *testing.T) {
 					}},
 				},
 			}
-			if err := createWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostService, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, DefaultRetryTimeout) })
 			// Wait for CRL host to be ready.
 			err := wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 				if err := kclient.Get(context.TODO(), crlHostName, &crlHostPod); err != nil {
@@ -1335,10 +1335,10 @@ func TestCRLUpdate(t *testing.T) {
 					"ca-bundle.pem": strings.Join(caBundle, "\n"),
 				},
 			}
-			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, DefaultRetryTimeout) })
 			icName := types.NamespacedName{
 				Name:      testName,
 				Namespace: operatorNamespace,
@@ -1351,7 +1351,7 @@ func TestCRLUpdate(t *testing.T) {
 				},
 				ClientCertificatePolicy: operatorv1.ClientCertificatePolicyRequired,
 			}
-			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create ingresscontroller %s/%s: %v", icName.Namespace, icName.Name, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1412,9 +1412,7 @@ func TestCRLUpdate(t *testing.T) {
 				if err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
 					return verifyCRLs(t, &routerPod, currentCRLs)
 				}); err != nil {
-					if err != nil {
-						t.Fatalf("Failed waiting for %s CRL to be updated: %v", expiringCRLCAName, err)
-					}
+					t.Fatalf("Failed waiting for %s CRL to be updated: %v", expiringCRLCAName, err)
 				}
 			}
 		})
@@ -1483,7 +1481,7 @@ func getActiveCRLs(t *testing.T, clientPod *corev1.Pod) ([]*x509.RevocationList,
 		return nil, err
 	}
 	crls := []*x509.RevocationList{}
-	crlData := []byte(stdout.String())
+	crlData := stdout.Bytes()
 	for len(crlData) > 0 {
 		block, data := pem.Decode(crlData)
 		if block == nil {

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -100,11 +99,7 @@ func TestClientTLS(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientCAConfigmap); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCAConfigmapName, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.TODO(), clientCAConfigmap); err != nil {
-			t.Fatalf("failed to delete configmap %q: %v", clientCAConfigmapName, err)
-		}
-	})
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute) })
 
 	// Create the custom ingresscontroller.
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "client-tls"}
@@ -219,11 +214,8 @@ func TestClientTLS(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientCertsConfigmap); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmapName, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.TODO(), clientCertsConfigmap); err != nil {
-			t.Fatalf("failed to delete configmap %q: %v", clientCertsConfigmapName, err)
-		}
-	})
+
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCertsConfigmap, 2*time.Minute) })
 
 	// Create a test client pod with the client certificates.  We will exec
 	// curl commands in this pod to perform the tests.
@@ -252,14 +244,8 @@ func TestClientTLS(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
-		}
-	})
+
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), clientPodName, clientPod); err != nil {

--- a/test/e2e/client_tls_test.go
+++ b/test/e2e/client_tls_test.go
@@ -96,7 +96,7 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientCAConfigmap.Name,
 		Namespace: clientCAConfigmap.Namespace,
 	}
-	if err := kclient.Create(context.TODO(), clientCAConfigmap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCAConfigmapName, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientCAConfigmap, 2*time.Minute) })
@@ -111,7 +111,7 @@ func TestClientTLS(t *testing.T) {
 			Name: clientCAConfigmapName.Name,
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -121,13 +121,13 @@ func TestClientTLS(t *testing.T) {
 	}
 
 	echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), testNamespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
@@ -137,7 +137,7 @@ func TestClientTLS(t *testing.T) {
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -211,7 +211,7 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientCertsConfigmap.Name,
 		Namespace: clientCertsConfigmap.Namespace,
 	}
-	if err := kclient.Create(context.TODO(), clientCertsConfigmap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientCertsConfigmap, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmapName, err)
 	}
 
@@ -241,7 +241,7 @@ func TestClientTLS(t *testing.T) {
 		Name:      clientPod.Name,
 		Namespace: clientPod.Namespace,
 	}
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
 
@@ -827,13 +827,13 @@ func TestMTLSWithCRLs(t *testing.T) {
 					ReadOnly:  true,
 				})
 
-				if err := kclient.Create(context.TODO(), &crlConfigMap); err != nil {
+				if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute); err != nil {
 					t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 				}
 				t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
 			}
 
-			if err := kclient.Create(context.TODO(), &crlHostPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create pod %q: %v", crlHostPod.Name, err)
 			}
 			// the crlHostPod is one of the first resources to be created, and one of the last to be deleted thanks to
@@ -858,7 +858,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 					}},
 				},
 			}
-			if err := kclient.Create(context.TODO(), &crlHostService); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
@@ -886,7 +886,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 					"ca-bundle.pem": strings.Join(tcCerts.CABundle, "\n"),
 				},
 			}
-			if err := kclient.Create(context.TODO(), &clientCAConfigmap); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
@@ -902,7 +902,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				},
 				ClientCertificatePolicy: operatorv1.ClientCertificatePolicyRequired,
 			}
-			if err := kclient.Create(context.TODO(), ic); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -928,7 +928,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				clientCertsConfigmap.Data[name+".key"] = encodeKey(keyCert.Key)
 				clientCertsConfigmap.Data[name+".pem"] = keyCert.CertFullChain
 			}
-			if err := kclient.Create(context.TODO(), &clientCertsConfigmap); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCertsConfigmap, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create configmap %q: %v", clientCertsConfigmap.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCertsConfigmap, 2*time.Minute) })
@@ -962,7 +962,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				Name:      clientPod.Name,
 				Namespace: clientPod.Namespace,
 			}
-			if err := kclient.Create(context.TODO(), clientPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
@@ -1014,13 +1014,13 @@ func TestMTLSWithCRLs(t *testing.T) {
 			})
 
 			echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), namespace.Name)
-			if err := kclient.Create(context.TODO(), echoPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-			if err := kclient.Create(context.TODO(), echoService); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
@@ -1030,7 +1030,7 @@ func TestMTLSWithCRLs(t *testing.T) {
 				Termination:                   routev1.TLSTerminationEdge,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			}
-			if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -1111,7 +1111,7 @@ func TestCRLUpdate(t *testing.T) {
 			Name: testName,
 		},
 	}
-	if err := kclient.Create(context.TODO(), &namespace); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), &namespace, 2*time.Minute); err != nil {
 		t.Fatalf("Failed to create namespace %q: %v", namespace.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &namespace, 2*time.Minute) })
@@ -1233,7 +1233,7 @@ func TestCRLUpdate(t *testing.T) {
 				},
 				Data: crlPems,
 			}
-			if err := kclient.Create(context.TODO(), &crlConfigMap); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create configmap %q: %v", crlConfigMap.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlConfigMap, 2*time.Minute) })
@@ -1282,7 +1282,7 @@ func TestCRLUpdate(t *testing.T) {
 				},
 			}
 
-			if err := kclient.Create(context.TODO(), &crlHostPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostPod, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create pod %q: %v", crlHostPod.Name, err)
 			}
 			// the crlHostPod is one of the first resources to be created, and one of the last to be deleted thanks to
@@ -1307,7 +1307,7 @@ func TestCRLUpdate(t *testing.T) {
 					}},
 				},
 			}
-			if err := kclient.Create(context.TODO(), &crlHostService); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create service %q: %v", crlHostService.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &crlHostService, 2*time.Minute) })
@@ -1335,7 +1335,7 @@ func TestCRLUpdate(t *testing.T) {
 					"ca-bundle.pem": strings.Join(caBundle, "\n"),
 				},
 			}
-			if err := kclient.Create(context.TODO(), &clientCAConfigmap); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create CA cert configmap: %v", err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), &clientCAConfigmap, 2*time.Minute) })
@@ -1351,7 +1351,7 @@ func TestCRLUpdate(t *testing.T) {
 				},
 				ClientCertificatePolicy: operatorv1.ClientCertificatePolicyRequired,
 			}
-			if err := kclient.Create(context.TODO(), ic); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create ingresscontroller %s/%s: %v", icName.Namespace, icName.Name, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/configurable_route_test.go
+++ b/test/e2e/configurable_route_test.go
@@ -30,23 +30,28 @@ const (
 // TestConfigurableRouteRBAC tests that the Configurable Route Controller is correctly creating and deleting
 // roles and roleBindings based on the componentRoutes defined in the ingress resource.
 func TestConfigurableRouteRBAC(t *testing.T) {
-	ingress := &configv1.Ingress{}
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-		t.Fatalf("failed to get ingress resource: %v", err)
-	}
-	defer func() {
-		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Errorf("failed to get ingress resource: %v", err)
+	resourceName := types.NamespacedName{Namespace: "", Name: "cluster"}
+
+	t.Cleanup(func() {
+		if err := updateIngressConfigSpecWithRetryOnConflict(t, resourceName,
+			5*time.Minute,
+			func(is *configv1.IngressSpec) {
+				is.ComponentRoutes = nil
+			}); err != nil {
+			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
 		}
-		ingress.Spec.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
-			t.Errorf("failed to restore cluster ingress.spec resource to original state: %v", err)
-		}
-		ingress.Status.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
+
+		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+			is.ComponentRoutes = nil
+		}); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
 		}
-	}()
+	})
+
+	ingress := &configv1.Ingress{}
+	if err := kclient.Get(context.TODO(), resourceName, ingress); err != nil {
+		t.Fatalf("failed to get ingress resource: %v", err)
+	}
 
 	// Set the ingress.spec.
 	ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
@@ -189,23 +194,28 @@ func TestConfigurableRouteRBAC(t *testing.T) {
 // TestConfigurableRouteNoSecretNoRBAC tests that the no roles or roleBindings are generated
 // for componentRoutes that include an empty servingCertKeyPairSecret name.
 func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
+	resourceName := types.NamespacedName{Namespace: "", Name: "cluster"}
+
+	t.Cleanup(func() {
+		if err := updateIngressConfigSpecWithRetryOnConflict(t, resourceName,
+			5*time.Minute,
+			func(is *configv1.IngressSpec) {
+				is.ComponentRoutes = nil
+			}); err != nil {
+			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
+		}
+
+		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+			is.ComponentRoutes = nil
+		}); err != nil {
+			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
+		}
+	})
+
 	ingress := &configv1.Ingress{}
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
+	if err := kclient.Get(context.TODO(), resourceName, ingress); err != nil {
 		t.Fatalf("failed to get ingress resource: %v", err)
 	}
-	defer func() {
-		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Errorf("failed to get ingress resource: %v", err)
-		}
-		ingress.Spec.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
-			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
-		}
-		ingress.Status.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
-			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
-		}
-	}()
 
 	// Include the componentRoute entry in the spec.
 	ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
@@ -287,24 +297,28 @@ func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 // TestConfigurableRouteNoConsumingUserNoRBAC tests that the no roles or roleBindings are generated
 // for componentRoutes that do not include any consumingUsers.
 func TestConfigurableRouteNoConsumingUserNoRBAC(t *testing.T) {
-	// Get the cluster ingress resource.
+	resourceName := types.NamespacedName{Namespace: "", Name: "cluster"}
+
+	t.Cleanup(func() {
+		if err := updateIngressConfigSpecWithRetryOnConflict(t, resourceName,
+			5*time.Minute,
+			func(is *configv1.IngressSpec) {
+				is.ComponentRoutes = nil
+			}); err != nil {
+			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
+		}
+
+		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+			is.ComponentRoutes = nil
+		}); err != nil {
+			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
+		}
+	})
+
 	ingress := &configv1.Ingress{}
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
+	if err := kclient.Get(context.TODO(), resourceName, ingress); err != nil {
 		t.Fatalf("failed to get ingress resource: %v", err)
 	}
-	defer func() {
-		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Errorf("failed to get ingress resource: %v", err)
-		}
-		ingress.Spec.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
-			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
-		}
-		ingress.Status.ComponentRoutes = nil
-		if err := eventuallyUpdateIngressStatus(t, ingress.Status); err != nil {
-			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
-		}
-	}()
 
 	// Include the componentRoute entry in the spec
 	ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{

--- a/test/e2e/configurable_route_test.go
+++ b/test/e2e/configurable_route_test.go
@@ -36,7 +36,7 @@ func TestConfigurableRouteRBAC(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Fatalf("failed to get ingress resource: %v", err)
+			t.Errorf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
 		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
@@ -195,7 +195,7 @@ func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Fatalf("failed to get ingress resource: %v", err)
+			t.Errorf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
 		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {
@@ -294,7 +294,7 @@ func TestConfigurableRouteNoConsumingUserNoRBAC(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: "cluster"}, ingress); err != nil {
-			t.Fatalf("failed to get ingress resource: %v", err)
+			t.Errorf("failed to get ingress resource: %v", err)
 		}
 		ingress.Spec.ComponentRoutes = nil
 		if err := eventuallyUpdateIngressSpec(t, ingress.Spec); err != nil {

--- a/test/e2e/configurable_route_test.go
+++ b/test/e2e/configurable_route_test.go
@@ -41,7 +41,7 @@ func TestConfigurableRouteRBAC(t *testing.T) {
 			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
 		}
 
-		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+		if err := updateIngressConfigStatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
 			is.ComponentRoutes = nil
 		}); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
@@ -205,7 +205,7 @@ func TestConfigurableRouteNoSecretNoRBAC(t *testing.T) {
 			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
 		}
 
-		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+		if err := updateIngressConfigStatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
 			is.ComponentRoutes = nil
 		}); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)
@@ -308,7 +308,7 @@ func TestConfigurableRouteNoConsumingUserNoRBAC(t *testing.T) {
 			t.Errorf("error executing ingress 'cluster' spec update: %v", err)
 		}
 
-		if err := updateIngressConfigSstatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
+		if err := updateIngressConfigStatusWithRetryOnConflict(t, resourceName, 5*time.Minute, func(is *configv1.IngressStatus) {
 			is.ComponentRoutes = nil
 		}); err != nil {
 			t.Errorf("failed to restore cluster ingress resource to original state: %v", err)

--- a/test/e2e/domain_not_matching_base_test.go
+++ b/test/e2e/domain_not_matching_base_test.go
@@ -31,7 +31,7 @@ func TestDomainNotMatchingBase(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Ensure the DNSManaged=False condition
 	t.Logf("waiting for ingresscontroller %v", icName)

--- a/test/e2e/domain_not_matching_base_test.go
+++ b/test/e2e/domain_not_matching_base_test.go
@@ -28,7 +28,7 @@ func TestDomainNotMatchingBase(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "domain-not-matching"}
 	domain := icName.Name + ".local"
 	ic := newLoadBalancerController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/domain_not_matching_base_test.go
+++ b/test/e2e/domain_not_matching_base_test.go
@@ -28,7 +28,7 @@ func TestDomainNotMatchingBase(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "domain-not-matching"}
 	domain := icName.Name + ".local"
 	ic := newLoadBalancerController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -59,13 +58,11 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if !errors.IsNotFound(err) {
-				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-			}
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute)
+	})
+
 	expectedResponse = strings.ToLower(expectedResponse)
 	err = wait.PollImmediate(1*time.Second, 4*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
@@ -130,7 +127,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -155,31 +152,28 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+	})
 
 	// Use the OpenShift Router container image, which includes curl, to
 	// create a client pod that sends a request to the echo route and checks
@@ -227,7 +221,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -251,31 +245,25 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
 
@@ -298,7 +286,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -322,31 +310,26 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
 
@@ -370,7 +353,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -394,31 +377,25 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
-
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+	})
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
 

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -62,7 +62,7 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
 			if !errors.IsNotFound(err) {
-				t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 			}
 		}
 	}()
@@ -157,7 +157,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -167,7 +167,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -177,7 +177,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -253,7 +253,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -263,7 +263,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -273,7 +273,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -324,7 +324,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -334,7 +334,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -344,7 +344,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -396,7 +396,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -406,7 +406,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -416,7 +416,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 )
 
 // testPodCount is a counter that is used to give each test pod a distinct name.
-var testPodCount int
+var testPodCount atomic.Int32
 
 // testRouteHeaders connects to the specified route using the provided address
 // and verifies that the response has the expected number of matches of the
@@ -52,8 +53,8 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 		extraCurlArgs = append(extraCurlArgs, "-H", header)
 	}
 	extraCurlArgs = append(extraCurlArgs, "--resolve", route.Spec.Host+":80:"+address)
-	testPodCount++
-	name := fmt.Sprintf("%s%d", route.Name, testPodCount)
+	count := testPodCount.Add(1)
+	name := fmt.Sprintf("%s%d", route.Name, count)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
 	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -55,7 +55,7 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 	testPodCount++
 	name := fmt.Sprintf("%s%d", route.Name, testPodCount)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 
@@ -124,7 +124,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "forwardedheader-append"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -149,7 +149,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	// Create a pod and route that echoes back the request.
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-append-"))
 	echoPod := buildEchoPod("forwarded-header-policy-append-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
@@ -158,7 +158,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
@@ -167,7 +167,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 
@@ -218,7 +218,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.ReplaceHTTPHeaderPolicy,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -242,7 +242,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-replace-"))
 	echoPod := buildEchoPod("forwarded-header-policy-replace-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() {
@@ -250,7 +250,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
@@ -258,7 +258,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {
@@ -283,7 +283,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.NeverHTTPHeaderPolicy,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -307,7 +307,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-never-"))
 	echoPod := buildEchoPod("forwarded-header-policy-never-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
@@ -316,7 +316,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
@@ -324,7 +324,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {
@@ -350,7 +350,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.IfNoneHTTPHeaderPolicy,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -374,7 +374,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-if-none-"))
 	echoPod := buildEchoPod("forwarded-header-policy-if-none-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
@@ -383,14 +383,14 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
 		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
 	})
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {

--- a/test/e2e/forwarded_header_policy_test.go
+++ b/test/e2e/forwarded_header_policy_test.go
@@ -56,12 +56,12 @@ func testRouteHeaders(t *testing.T, image string, route *routev1.Route, address 
 	count := testPodCount.Add(1)
 	name := fmt.Sprintf("%s%d", route.Name, count)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout)
 	})
 
 	expectedResponse = strings.ToLower(expectedResponse)
@@ -125,7 +125,7 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "forwardedheader-append"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -150,30 +150,30 @@ func TestForwardedHeaderPolicyAppend(t *testing.T) {
 	// Create a pod and route that echoes back the request.
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-append-"))
 	echoPod := buildEchoPod("forwarded-header-policy-append-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout)
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout)
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout)
 	})
 
 	// Use the OpenShift Router container image, which includes curl, to
@@ -219,7 +219,7 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.ReplaceHTTPHeaderPolicy,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -243,27 +243,27 @@ func TestForwardedHeaderPolicyReplace(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-replace-"))
 	echoPod := buildEchoPod("forwarded-header-policy-replace-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout)
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout)
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout)
 	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
@@ -284,7 +284,7 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.NeverHTTPHeaderPolicy,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -308,28 +308,28 @@ func TestForwardedHeaderPolicyNever(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-never-"))
 	echoPod := buildEchoPod("forwarded-header-policy-never-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout)
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout)
 	})
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout)
 	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
@@ -351,7 +351,7 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		ForwardedHeaderPolicy: operatorv1.IfNoneHTTPHeaderPolicy,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -375,27 +375,27 @@ func TestForwardedHeaderPolicyIfNone(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("fhp-if-none-"))
 	echoPod := buildEchoPod("forwarded-header-policy-if-none-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout)
 	})
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout)
 	})
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() {
-		deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout)
 	})
 
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1149,9 +1149,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
 	}
 
-	if err := deleteWithRetryOnError(t, context.TODO(), gateway, 30*time.Second); err != nil {
-		t.Errorf("failed to delete gateway %q: %v", gateway.Name, err)
-	}
+	deleteWithRetryOnError(t, context.TODO(), gateway, 30*time.Second)
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -347,7 +347,7 @@ func testGatewayAPIManualDeployment(t *testing.T) {
 		},
 	}
 	t.Logf("Creating gateway %q...", gatewayName)
-	if err := kclient.Create(context.Background(), &gateway); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), &gateway, 2*time.Minute); err != nil {
 		t.Fatalf("Failed to create gateway %v: %v", gatewayName, err)
 	}
 	t.Cleanup(func() {
@@ -712,7 +712,7 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		name := names.SimpleNameGenerator.GenerateName("gw-test-")
 		rnd := rand.IntN(1000000)
 		testDomain := fmt.Sprintf("some-%d.%s", rnd, domain)
-		gateway, err := createGateway(gatewayClass, name, "default", testDomain)
+		gateway, err := createGateway(t, gatewayClass, name, "default", testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
 			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
@@ -742,7 +742,7 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		name := names.SimpleNameGenerator.GenerateName("gw-test-")
 		rnd := rand.IntN(1000000)
 		testDomain := fmt.Sprintf("some-%d.not.something.managed.tld", rnd)
-		gateway, err := createGateway(gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
+		gateway, err := createGateway(t, gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
 			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
@@ -784,7 +784,7 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		name := names.SimpleNameGenerator.GenerateName("gw-test-")
 		rnd := rand.IntN(1000000)
 		testDomain := fmt.Sprintf("some-%d.%s", rnd, domain)
-		gateway, err := createGateway(gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
+		gateway, err := createGateway(t, gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
 			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
@@ -1022,7 +1022,7 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		t.Run("should not conflict with a second Gateway created with the same domain", func(t *testing.T) {
 			t.Skip("skipping while the PR for duplicate DNS is not merged")
 			dupName := gateway.GetName() + "-dup"
-			dupGateway, err := createGateway(gatewayClass, dupName, operatorcontroller.DefaultOperandNamespace, testDomain)
+			dupGateway, err := createGateway(t, gatewayClass, dupName, operatorcontroller.DefaultOperandNamespace, testDomain)
 			require.NoError(t, err, "failed to create gateway", "name", name)
 			t.Cleanup(func() {
 				require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), dupGateway)), "failed to clean duplicated test gateway", "name", name)
@@ -1504,7 +1504,7 @@ func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 	// Use the dnsConfig base domain set up in TestMain.
 	domain = "gws." + dnsConfig.Spec.BaseDomain
 
-	testGateway, err := createGateway(gatewayClass, testGatewayName, operatorcontroller.DefaultOperandNamespace, domain)
+	testGateway, err := createGateway(t, gatewayClass, testGatewayName, operatorcontroller.DefaultOperandNamespace, domain)
 	if err != nil {
 		return fmt.Errorf("feature gate was enabled, but gateway object could not be created: %v", err)
 	}
@@ -1537,7 +1537,7 @@ func deleteTestCRDs(t *testing.T) {
 // ensureTestCRDs creates test Gateway API custom resource definitions.
 func ensureTestCRDs(t *testing.T) {
 	for _, crdName := range testCRDNames {
-		if _, err := createCRD(crdName); err != nil {
+		if _, err := createCRD(t, crdName); err != nil {
 			t.Fatalf("failed to create test crd %q: %v", crdName, err)
 		} else {
 			t.Logf("created test crd %q", crdName)

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -347,7 +347,7 @@ func testGatewayAPIManualDeployment(t *testing.T) {
 		},
 	}
 	t.Logf("Creating gateway %q...", gatewayName)
-	if err := createWithRetryOnError(t, context.Background(), &gateway, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), &gateway, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create gateway %v: %v", gatewayName, err)
 	}
 	t.Cleanup(func() {
@@ -368,8 +368,8 @@ func testGatewayAPIManualDeployment(t *testing.T) {
 
 	interval, timeout := 5*time.Second, 5*time.Minute
 	t.Logf("Polling for up to %v to verify that the gateway is accepted...", timeout)
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, gatewayName, &gateway); err != nil {
+	if err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, gatewayName, &gateway); err != nil {
 			t.Logf("Failed to get gateway %v: %v; retrying...", gatewayName, err)
 
 			return false, nil
@@ -398,8 +398,8 @@ func testGatewayAPIManualDeployment(t *testing.T) {
 	}
 	var service corev1.Service
 	t.Logf("Polling for up to %v to verify that service %q is created...", timeout, serviceName)
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, serviceName, &service); err != nil {
+	if err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, serviceName, &service); err != nil {
 			t.Logf("Failed to get service %s: %v; retrying...", serviceName, err)
 
 			return false, nil
@@ -469,9 +469,10 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
 			// Verify that GatewayAPI CRD creation is forbidden.
 			for i := range testCRDs {
-				if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
+				if err := wait.PollUntilContextTimeout(t.Context(), 2*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 					if err := tc.kclient.Create(ctx, testCRDs[i]); err != nil {
 						if kerrors.IsAlreadyExists(err) {
 							// VAP was disabled and re-enabled at the beginning of the test.
@@ -502,12 +503,12 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 			for i := range testCRDs {
 				crdName := types.NamespacedName{Name: testCRDs[i].Name}
 				crd := &apiextensionsv1.CustomResourceDefinition{}
-				if err := tc.kclient.Get(context.Background(), crdName, crd); err != nil {
+				if err := tc.kclient.Get(ctx, crdName, crd); err != nil {
 					t.Errorf("failed to get %q CRD: %v", crdName.Name, err)
 					continue
 				}
 				crd.Spec = testCRDs[i].Spec
-				if err := tc.kclient.Update(context.Background(), crd); err != nil {
+				if err := tc.kclient.Update(ctx, crd); err != nil {
 					if !strings.Contains(err.Error(), tc.expectedErrMsg) {
 						t.Errorf("unexpected error received while updating CRD %q: %v", testCRDs[i].Name, err)
 					}
@@ -518,7 +519,7 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 
 			// Verify that GatewayAPI CRD deletion is forbidden.
 			for i := range testCRDs {
-				if err := tc.kclient.Delete(context.Background(), testCRDs[i]); err != nil {
+				if err := tc.kclient.Delete(ctx, testCRDs[i]); err != nil {
 					if !strings.Contains(err.Error(), tc.expectedErrMsg) {
 						t.Errorf("unexpected error received while deleting CRD %q: %v", testCRDs[i].Name, err)
 					}
@@ -1157,7 +1158,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
 	}
 
-	deleteWithRetryOnError(t, context.TODO(), gateway, 2*time.Minute)
+	deleteWithRetryOnError(t, context.TODO(), gateway, DefaultRetryTimeout)
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
@@ -1253,7 +1254,7 @@ func testGatewayAPIInfrastructureAnnotations(t *testing.T) {
 	}
 
 	t.Logf("Creating gateway %s with infrastructure annotations...", gatewayName)
-	if err := createWithRetryOnError(t, context.Background(), gateway, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, t.Context(), gateway, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create gateway %s: %v", gatewayName, err)
 	}
 
@@ -1278,7 +1279,7 @@ func testGatewayAPIInfrastructureAnnotations(t *testing.T) {
 	managedLabelValue := strings.ReplaceAll(operatorcontroller.OpenShiftGatewayClassControllerName, "/", "-")
 	interval, timeout := 5*time.Second, 3*time.Minute
 	t.Logf("Polling for up to %v to verify that service for gateway %q has the expected annotation...", timeout, gatewayName)
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, false, func(ctx context.Context) (bool, error) {
 		// List services with the gateway labels
 		var services corev1.ServiceList
 		listOpts := []client.ListOption{
@@ -1288,7 +1289,7 @@ func testGatewayAPIInfrastructureAnnotations(t *testing.T) {
 			},
 			client.InNamespace(gateway.Namespace),
 		}
-		if err := kclient.List(context, &services, listOpts...); err != nil {
+		if err := kclient.List(ctx, &services, listOpts...); err != nil {
 			t.Logf("Failed to list services for gateway %s: %v; retrying...", gatewayName, err)
 			return false, nil
 		}
@@ -1325,7 +1326,7 @@ func testGatewayAPIInfrastructureAnnotations(t *testing.T) {
 }
 
 func testGatewayAPIInternalLoadBalancer(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	platform := infraConfig.Status.PlatformStatus.Type
 
 	supportedPlatforms := map[configv1.PlatformType]map[gatewayapiv1.AnnotationKey]gatewayapiv1.AnnotationValue{
@@ -1372,11 +1373,11 @@ func testGatewayAPIInternalLoadBalancer(t *testing.T) {
 
 	// create gateway and wait for it to be programmed
 	t.Logf("Creating gateway %s", gatewayName)
-	if err := createWithRetryOnError(t, ctx, gateway, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, gateway, DefaultRetryTimeout); err != nil {
 		t.Fatalf("Failed to create gateway %s: %v", gatewayName, err)
 	}
 	t.Cleanup(func() {
-		if err := kclient.Delete(ctx, gateway); err != nil {
+		if err := kclient.Delete(context.Background(), gateway); err != nil {
 			if !errors.IsNotFound(err) {
 				t.Logf("Failed to delete gateway %v: %v", gatewayName, err)
 			}

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -715,7 +715,9 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		gateway, err := createGateway(t, gatewayClass, name, "default", testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
-			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
+			if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)); err != nil {
+				t.Errorf("failed to clean test gateway %q: %v", name, err)
+			}
 		})
 
 		gateway, err = assertGatewaySuccessful(t, "default", name)
@@ -745,7 +747,9 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		gateway, err := createGateway(t, gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
-			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
+			if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)); err != nil {
+				t.Errorf("failed to clean test gateway %q: %v", name, err)
+			}
 		})
 
 		gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, name)
@@ -787,7 +791,9 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		gateway, err := createGateway(t, gatewayClass, name, operatorcontroller.DefaultOperandNamespace, testDomain)
 		require.NoError(t, err, "failed to create gateway", "name", name)
 		t.Cleanup(func() {
-			require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)), "failed to clean test gateway", "name", name)
+			if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), gateway)); err != nil {
+				t.Errorf("failed to clean test gateway %q: %v", name, err)
+			}
 		})
 
 		gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, name)
@@ -1025,7 +1031,9 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 			dupGateway, err := createGateway(t, gatewayClass, dupName, operatorcontroller.DefaultOperandNamespace, testDomain)
 			require.NoError(t, err, "failed to create gateway", "name", name)
 			t.Cleanup(func() {
-				require.NoError(t, client.IgnoreNotFound(kclient.Delete(context.TODO(), dupGateway)), "failed to clean duplicated test gateway", "name", name)
+				if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), dupGateway)); err != nil {
+					t.Errorf("failed to clean duplicated test gateway %q: %v", name, err)
+				}
 			})
 			assert.Eventually(t, func() bool {
 				current := &gatewayapiv1.Gateway{}

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1149,7 +1149,7 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
 	}
 
-	deleteWithRetryOnError(t, context.TODO(), gateway, 30*time.Second)
+	deleteWithRetryOnError(t, context.TODO(), gateway, 2*time.Minute)
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{

--- a/test/e2e/hard_stop_after_test.go
+++ b/test/e2e/hard_stop_after_test.go
@@ -66,9 +66,7 @@ func TestRouteHardStopAfterEnableOnIngressController(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (300 * time.Minute).String()); err != nil {
-		t.Fatalf("test assertions failed: %v", err)
-	}
+	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (300 * time.Minute).String())
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -92,9 +90,7 @@ func TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig
 	}
 
 	// Then set hard-stop-after on the controller which should take precedence.
-	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (500 * time.Minute).String()); err != nil {
-		t.Fatalf("test assertions failed: %v", err)
-	}
+	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (500 * time.Minute).String())
 
 	// Remove the controller setting.
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
@@ -120,9 +116,7 @@ func TestRouteHardStopAfterTestInvalidDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (600 * time.Minute).String()); err != nil {
-		t.Fatalf("test assertions failed: %v", err)
-	}
+	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (600 * time.Minute).String())
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "mañana", hardStopAfterSetValue, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -142,9 +136,7 @@ func TestRouteHardStopAfterTestZeroLengthDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (700 * time.Minute).String()); err != nil {
-		t.Fatalf("test assertions failed: %v", err)
-	}
+	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (700 * time.Minute).String())
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterSetValue, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -164,9 +156,7 @@ func TestRouteHardStopAfterTestOneDayDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, "1d"); err != nil {
-		t.Fatalf("test assertions failed: %v", err)
-	}
+	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, "1d")
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -210,20 +200,19 @@ func hardStopAfterTestIngressConfig(t *testing.T, client client.Client, ingressC
 	return nil
 }
 
-func hardStopAfterTestIngressController(t *testing.T, client client.Client, ic *operatorv1.IngressController, routerDeployment *appsv1.Deployment, duration string) error {
+func hardStopAfterTestIngressController(t *testing.T, client client.Client, ic *operatorv1.IngressController, routerDeployment *appsv1.Deployment, duration string) {
 	if err := setHardStopAfterDurationForIngressController(t, client, hardStopAfterRetryTimeout, duration, hardStopAfterSetValue, ic); err != nil {
-		t.Fatalf("failed to update ingresscontroller: %v", err)
+		t.Errorf("failed to update ingresscontroller: %v", err)
 	}
 	if err := waitForIngressControllerCondition(t, client, hardStopAfterRetryTimeout, defaultName, defaultAvailableConditions...); err != nil {
-		t.Fatalf("failed to observe expected conditions: %v", err)
+		t.Errorf("failed to observe expected conditions: %v", err)
 	}
 	if err := waitForIngressControllerHardStopAfterToBeSet(client, hardStopAfterRetryTimeout, ic, duration); err != nil {
-		t.Fatalf("hard-stop-after not set on ingress controller: %v", err)
+		t.Errorf("hard-stop-after not set on ingress controller: %v", err)
 	}
 	if err := waitForRouterDeploymentHardStopAfterToBeSet(client, routerDeployTimeout, routerDeployment, duration); err != nil {
-		t.Fatalf("expected router deployment to have hard-stop-after configured: %v", err)
+		t.Errorf("expected router deployment to have hard-stop-after configured: %v", err)
 	}
-	return nil
 }
 
 func waitForHardStopAfterUnsetInAllComponents(client client.Client, timeout time.Duration, ic *operatorv1.IngressController, ingressConfig *configv1.Ingress, routerDeployment *appsv1.Deployment) error {

--- a/test/e2e/hard_stop_after_test.go
+++ b/test/e2e/hard_stop_after_test.go
@@ -66,7 +66,9 @@ func TestRouteHardStopAfterEnableOnIngressController(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (300 * time.Minute).String())
+	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (300 * time.Minute).String()); err != nil {
+		t.Fatalf("test assertions failed: %v", err)
+	}
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -90,7 +92,9 @@ func TestRouteHardStopAfterEnableOnIngressControllerHasPriorityOverIngressConfig
 	}
 
 	// Then set hard-stop-after on the controller which should take precedence.
-	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (500 * time.Minute).String())
+	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (500 * time.Minute).String()); err != nil {
+		t.Fatalf("test assertions failed: %v", err)
+	}
 
 	// Remove the controller setting.
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
@@ -116,7 +120,9 @@ func TestRouteHardStopAfterTestInvalidDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (600 * time.Minute).String())
+	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (600 * time.Minute).String()); err != nil {
+		t.Fatalf("test assertions failed: %v", err)
+	}
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "mañana", hardStopAfterSetValue, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -136,7 +142,9 @@ func TestRouteHardStopAfterTestZeroLengthDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (700 * time.Minute).String())
+	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, (700 * time.Minute).String()); err != nil {
+		t.Fatalf("test assertions failed: %v", err)
+	}
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterSetValue, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -156,7 +164,9 @@ func TestRouteHardStopAfterTestOneDayDuration(t *testing.T) {
 		t.Fatalf("failed to get test objects: %v", err)
 	}
 
-	hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, "1d")
+	if err := hardStopAfterTestIngressController(t, kclient, ic, routerDeployment, "1d"); err != nil {
+		t.Fatalf("test assertions failed: %v", err)
+	}
 
 	if err := setHardStopAfterDurationForIngressController(t, kclient, hardStopAfterRetryTimeout, "", hardStopAfterDeleteAnnotation, ic); err != nil {
 		t.Fatalf("failed to clear hard-stop-after on ingresscontroller: %v", err)
@@ -200,19 +210,20 @@ func hardStopAfterTestIngressConfig(t *testing.T, client client.Client, ingressC
 	return nil
 }
 
-func hardStopAfterTestIngressController(t *testing.T, client client.Client, ic *operatorv1.IngressController, routerDeployment *appsv1.Deployment, duration string) {
+func hardStopAfterTestIngressController(t *testing.T, client client.Client, ic *operatorv1.IngressController, routerDeployment *appsv1.Deployment, duration string) error {
 	if err := setHardStopAfterDurationForIngressController(t, client, hardStopAfterRetryTimeout, duration, hardStopAfterSetValue, ic); err != nil {
-		t.Errorf("failed to update ingresscontroller: %v", err)
+		return fmt.Errorf("failed to update ingresscontroller: %w", err)
 	}
 	if err := waitForIngressControllerCondition(t, client, hardStopAfterRetryTimeout, defaultName, defaultAvailableConditions...); err != nil {
-		t.Errorf("failed to observe expected conditions: %v", err)
+		return fmt.Errorf("failed to observe expected conditions: %w", err)
 	}
 	if err := waitForIngressControllerHardStopAfterToBeSet(client, hardStopAfterRetryTimeout, ic, duration); err != nil {
-		t.Errorf("hard-stop-after not set on ingress controller: %v", err)
+		return fmt.Errorf("hard-stop-after not set on ingress controller: %w", err)
 	}
 	if err := waitForRouterDeploymentHardStopAfterToBeSet(client, routerDeployTimeout, routerDeployment, duration); err != nil {
-		t.Errorf("expected router deployment to have hard-stop-after configured: %v", err)
+		return fmt.Errorf("expected router deployment to have hard-stop-after configured: %w", err)
 	}
+	return nil
 }
 
 func waitForHardStopAfterUnsetInAllComponents(client client.Client, timeout time.Duration, ic *operatorv1.IngressController, ingressConfig *configv1.Ingress, routerDeployment *appsv1.Deployment) error {

--- a/test/e2e/hsts_policy_test.go
+++ b/test/e2e/hsts_policy_test.go
@@ -56,14 +56,14 @@ func TestHstsPolicyWorks(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update ingress config: %v", err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		// Remove the HSTS policies from the ingress config
 		if err := updateIngressConfigSpecWithRetryOnConflict(t, clusterConfigName, timeout, func(spec *configv1.IngressSpec) {
 			spec.RequiredHSTSPolicies = nil
 		}); err != nil {
 			t.Errorf("failed to restore ingress config: %v", err)
 		}
-	}()
+	})
 
 	p := ing.Spec.RequiredHSTSPolicies[0]
 	t.Logf("created a RequiredHSTSPolicy with DomainPatterns: %v,\n preload policy: %s,\n includeSubDomains policy: %s,\n largest age: %d,\n smallest age: %d\n", p.DomainPatterns, p.PreloadPolicy, p.IncludeSubDomainsPolicy, *p.MaxAge.LargestMaxAge, *p.MaxAge.SmallestMaxAge)

--- a/test/e2e/hsts_policy_test.go
+++ b/test/e2e/hsts_policy_test.go
@@ -61,7 +61,7 @@ func TestHstsPolicyWorks(t *testing.T) {
 		if err := updateIngressConfigSpecWithRetryOnConflict(t, clusterConfigName, timeout, func(spec *configv1.IngressSpec) {
 			spec.RequiredHSTSPolicies = nil
 		}); err != nil {
-			t.Fatalf("failed to restore ingress config: %v", err)
+			t.Errorf("failed to restore ingress config: %v", err)
 		}
 	}()
 

--- a/test/e2e/hsts_policy_test.go
+++ b/test/e2e/hsts_policy_test.go
@@ -73,13 +73,13 @@ func TestHstsPolicyWorks(t *testing.T) {
 
 	// Create pod
 	echoPod := buildEchoPod("hsts-policy-echo", ns.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", ns, echoPod.Name, err)
 	}
 
 	// Create service
 	echoService := buildEchoService(echoPod.Name, ns.Name, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
@@ -96,7 +96,7 @@ func TestHstsPolicyWorks(t *testing.T) {
 	exampleHeader := "max-age=0;preload;includesubdomains"
 	t.Logf("creating a valid route at %s", time.Now().Format(time.StampMilli))
 	validRoute := buildRouteWithHSTS("valid-route", echoPod.Namespace, echoService.Name, "valid-route."+appsDomain, exampleHeader)
-	if err := kclient.Create(context.TODO(), validRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), validRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create a valid route %s/%s: %v", validRoute.Namespace, validRoute.Name, err)
 	} else {
 		t.Logf("created a valid route at %s: %s/%s with annotation %s", time.Now().Format(time.StampMilli), validRoute.Namespace, validRoute.Name, validRoute.Annotations)

--- a/test/e2e/hsts_policy_test.go
+++ b/test/e2e/hsts_policy_test.go
@@ -73,13 +73,13 @@ func TestHstsPolicyWorks(t *testing.T) {
 
 	// Create pod
 	echoPod := buildEchoPod("hsts-policy-echo", ns.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", ns, echoPod.Name, err)
 	}
 
 	// Create service
 	echoService := buildEchoService(echoPod.Name, ns.Name, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
@@ -96,7 +96,7 @@ func TestHstsPolicyWorks(t *testing.T) {
 	exampleHeader := "max-age=0;preload;includesubdomains"
 	t.Logf("creating a valid route at %s", time.Now().Format(time.StampMilli))
 	validRoute := buildRouteWithHSTS("valid-route", echoPod.Namespace, echoService.Name, "valid-route."+appsDomain, exampleHeader)
-	if err := createWithRetryOnError(t, context.Background(), validRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), validRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create a valid route %s/%s: %v", validRoute.Namespace, validRoute.Name, err)
 	} else {
 		t.Logf("created a valid route at %s: %s/%s with annotation %s", time.Now().Format(time.StampMilli), validRoute.Namespace, validRoute.Name, validRoute.Annotations)

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -44,7 +43,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -69,31 +68,19 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -124,14 +111,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPodValidRequest); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPodValidRequest); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodValidRequest, 2*time.Minute) })
 
 	pollErr := wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
 		readCloser, err := cl.CoreV1().Pods(clientPodValidRequest.Namespace).GetLogs(clientPodValidRequest.Name, &corev1.PodLogOptions{
@@ -253,14 +233,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
 	}
 
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPodInvalidRequest); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodInvalidRequest, 2*time.Minute) })
 
 	// Check curl pod logs for a 400 response since the sent headers
 	// are too large for HAProxy.

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -71,7 +71,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -81,7 +81,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -91,7 +91,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -129,7 +129,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 			if errors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
 		}
 	}()
 
@@ -258,7 +258,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 			if errors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
 		}
 	}()
 

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -39,7 +39,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		HeaderBufferBytes:           65536,
 		HeaderBufferMaxRewriteBytes: 16384,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -65,19 +65,19 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("header-buffer-size-"))
 	echoPod := buildEchoPod("header-buffer-size-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -108,7 +108,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	name := "header-buffer-size-test-large-buffers"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPodValidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-	if err := kclient.Create(context.TODO(), clientPodValidRequest); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPodValidRequest, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodValidRequest, 2*time.Minute) })
@@ -229,7 +229,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	name = name + "-fail-case"
 	clientPodInvalidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
 
-	if err := kclient.Create(context.TODO(), clientPodInvalidRequest); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPodInvalidRequest, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
 	}
 

--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -39,7 +39,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		HeaderBufferBytes:           65536,
 		HeaderBufferMaxRewriteBytes: 16384,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -65,22 +65,22 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("header-buffer-size-"))
 	echoPod := buildEchoPod("header-buffer-size-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -108,10 +108,10 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	name := "header-buffer-size-test-large-buffers"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPodValidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-	if err := createWithRetryOnError(t, context.Background(), clientPodValidRequest, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPodValidRequest, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodValidRequest.Namespace, clientPodValidRequest.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodValidRequest, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodValidRequest, DefaultRetryTimeout) })
 
 	pollErr := wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
 		readCloser, err := cl.CoreV1().Pods(clientPodValidRequest.Namespace).GetLogs(clientPodValidRequest.Name, &corev1.PodLogOptions{
@@ -229,11 +229,11 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 	name = name + "-fail-case"
 	clientPodInvalidRequest := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
 
-	if err := createWithRetryOnError(t, context.Background(), clientPodInvalidRequest, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPodInvalidRequest, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPodInvalidRequest.Namespace, clientPodInvalidRequest.Name, err)
 	}
 
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodInvalidRequest, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodInvalidRequest, DefaultRetryTimeout) })
 
 	// Check curl pod logs for a 400 response since the sent headers
 	// are too large for HAProxy.

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -69,7 +69,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -79,7 +79,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -92,7 +92,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -120,7 +120,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 			if errors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
 

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -42,7 +41,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -67,21 +66,13 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Annotations = map[string]string{
@@ -90,11 +81,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -115,14 +102,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	pollErr := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -38,7 +38,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		HeaderNameCaseAdjustments: testHeaderNames,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -63,13 +63,13 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("header-name-"))
 	echoPod := buildEchoPod("header-name-case-adjustment-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
@@ -78,7 +78,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	echoRoute.Annotations = map[string]string{
 		"haproxy.router.openshift.io/h1-adjust-case": "true",
 	}
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -99,7 +99,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	name := "header-name-case-adjustment-test"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })

--- a/test/e2e/http_header_name_case_adjustment_test.go
+++ b/test/e2e/http_header_name_case_adjustment_test.go
@@ -38,7 +38,7 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		HeaderNameCaseAdjustments: testHeaderNames,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -63,25 +63,25 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("header-name-"))
 	echoPod := buildEchoPod("header-name-case-adjustment-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Annotations = map[string]string{
 		"haproxy.router.openshift.io/h1-adjust-case": "true",
 	}
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -99,10 +99,10 @@ func TestHeaderNameCaseAdjustment(t *testing.T) {
 	name := "header-name-case-adjustment-test"
 	image := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	pollErr := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{

--- a/test/e2e/http_keep_alive_test.go
+++ b/test/e2e/http_keep_alive_test.go
@@ -70,7 +70,7 @@ func httpKeepAliveTimeoutRunTest(t *testing.T, httpKATimeoutSeconds, clientTimeo
 			ic.Spec.TuningOptions.ClientTimeout = &metav1.Duration{Duration: time.Duration(clientTimeoutSeconds) * time.Second}
 		}
 
-		if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 			return nil, fmt.Errorf("failed to create IngressController: %w", err)
 		}
 		t.Cleanup(func() {
@@ -99,7 +99,7 @@ func httpKeepAliveTimeoutRunTest(t *testing.T, httpKATimeoutSeconds, clientTimeo
 
 		routeName := types.NamespacedName{Namespace: ns.Name, Name: webService}
 		route := buildRoute(routeName.Name, routeName.Namespace, webService)
-		if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout); err != nil {
 			return "", fmt.Errorf("failed to create route %s: %w", routeName, err)
 		}
 

--- a/test/e2e/http_keep_alive_test.go
+++ b/test/e2e/http_keep_alive_test.go
@@ -70,7 +70,7 @@ func httpKeepAliveTimeoutRunTest(t *testing.T, httpKATimeoutSeconds, clientTimeo
 			ic.Spec.TuningOptions.ClientTimeout = &metav1.Duration{Duration: time.Duration(clientTimeoutSeconds) * time.Second}
 		}
 
-		if err := kclient.Create(context.Background(), ic); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 			return nil, fmt.Errorf("failed to create IngressController: %w", err)
 		}
 		t.Cleanup(func() {
@@ -99,7 +99,7 @@ func httpKeepAliveTimeoutRunTest(t *testing.T, httpKATimeoutSeconds, clientTimeo
 
 		routeName := types.NamespacedName{Namespace: ns.Name, Name: webService}
 		route := buildRoute(routeName.Name, routeName.Namespace, webService)
-		if err := kclient.Create(context.Background(), route); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
 			return "", fmt.Errorf("failed to create route %s: %w", routeName, err)
 		}
 

--- a/test/e2e/ic_conditions_metric_test.go
+++ b/test/e2e/ic_conditions_metric_test.go
@@ -26,8 +26,8 @@ import (
 // waitForIngressControllerConditionsMetrics waits for the metrics for ingress_controller_conditions to be present.
 func waitForIngressControllerConditionsMetrics(t *testing.T, prometheusClient prometheusv1.API) error {
 	t.Logf("Waiting for ingress_controller_conditions to be present")
-	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
-		result, _, err := prometheusClient.Query(context, "ingress_controller_conditions", time.Now())
+	if err := wait.PollUntilContextTimeout(t.Context(), 1*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
+		result, _, err := prometheusClient.Query(ctx, "ingress_controller_conditions", time.Now())
 		if err != nil {
 			t.Logf("Failed to fetch metrics: %v, retrying...", err)
 			return false, nil
@@ -58,10 +58,12 @@ func restartOperatorPod(t *testing.T, kubeClient kubernetes.Interface) error {
 	interval, timeout := 5*time.Second, 5*time.Minute
 	var podsList *corev1.PodList
 
+	ctx := t.Context()
+
 	// Find the operator pod
 	t.Logf("Restarting Ingress operator pod...")
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
-		innerPodsList, err := kubeClient.CoreV1().Pods("openshift-ingress-operator").List(context, metav1.ListOptions{})
+	if err := wait.PollUntilContextTimeout(ctx, interval, timeout, false, func(ctx context.Context) (bool, error) {
+		innerPodsList, err := kubeClient.CoreV1().Pods("openshift-ingress-operator").List(ctx, metav1.ListOptions{})
 		podsList = innerPodsList
 		if err != nil {
 			t.Logf("Failed to list pods: %v, retying...", err)
@@ -78,8 +80,8 @@ func restartOperatorPod(t *testing.T, kubeClient kubernetes.Interface) error {
 	}
 
 	// Delete the operator pod
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
-		if err := kubeClient.CoreV1().Pods("openshift-ingress-operator").Delete(context, operatorPodName, metav1.DeleteOptions{}); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, interval, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kubeClient.CoreV1().Pods("openshift-ingress-operator").Delete(ctx, operatorPodName, metav1.DeleteOptions{}); err != nil {
 			t.Logf("Failed to delete operator pod: %v, retying...", err)
 			return false, nil
 		}
@@ -90,8 +92,8 @@ func restartOperatorPod(t *testing.T, kubeClient kubernetes.Interface) error {
 
 	// Wait for new pod to be ready
 	t.Logf("Polling for up to %v to verify that the operator restart is terminated...", timeout)
-	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(context context.Context) (bool, error) {
-		podsList, err := kubeClient.CoreV1().Pods("openshift-ingress-operator").List(context, metav1.ListOptions{})
+	if err := wait.PollUntilContextTimeout(ctx, interval, timeout, false, func(ctx context.Context) (bool, error) {
+		podsList, err := kubeClient.CoreV1().Pods("openshift-ingress-operator").List(ctx, metav1.ListOptions{})
 		if err != nil {
 			t.Logf("Failed to list pods: %v, retying...", err)
 			return false, nil

--- a/test/e2e/idle_connection_test.go
+++ b/test/e2e/idle_connection_test.go
@@ -129,7 +129,7 @@ func idleConnectionCreateBackendService(ctx context.Context, t *testing.T, names
 		return fmt.Errorf("failed to create replicaset %s: %w", name, err)
 	}
 
-	if err := waitForReplicaSetReady(t, kclient, rs, 2*time.Minute); err != nil {
+	if err := waitForReplicaSetReady(t, kclient, rs, DefaultRetryTimeout); err != nil {
 		return fmt.Errorf("replicaset %s is not ready: %w", name, err)
 	}
 
@@ -154,7 +154,7 @@ func idleConnectionCreateService(t *testing.T, ctx context.Context, namespace, n
 		},
 	}
 
-	if err := createWithRetryOnError(t, ctx, service, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, service, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create service %s/%s: %w", service.Namespace, service.Name, err)
 	}
 
@@ -259,7 +259,7 @@ func idleConnectionCreateReplicaSet(t *testing.T, ctx context.Context, namespace
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, ctx, rs, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, rs, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create replicaset %s/%s: %w", rs.Namespace, rs.Name, err)
 	}
 	return rs, nil
@@ -343,7 +343,7 @@ func idleConnectionTerminationPolicyRunTest(t *testing.T, policy operatorv1.Ingr
 
 		routeName := types.NamespacedName{Namespace: ns.Name, Name: "test"}
 		route := buildRoute(routeName.Name, routeName.Namespace, webService1)
-		if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout); err != nil {
 			return nil, fmt.Errorf("failed to create route %s: %w", routeName, err)
 		}
 
@@ -389,7 +389,7 @@ func idleConnectionTerminationPolicyRunTest(t *testing.T, policy operatorv1.Ingr
 		ic.Spec.NamespaceSelector = &metav1.LabelSelector{
 			MatchLabels: testNs.Labels,
 		}
-		if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 			return nil, fmt.Errorf("failed to create IngressController: %w", err)
 		}
 		t.Cleanup(func() {

--- a/test/e2e/idle_connection_test.go
+++ b/test/e2e/idle_connection_test.go
@@ -343,7 +343,7 @@ func idleConnectionTerminationPolicyRunTest(t *testing.T, policy operatorv1.Ingr
 
 		routeName := types.NamespacedName{Namespace: ns.Name, Name: "test"}
 		route := buildRoute(routeName.Name, routeName.Namespace, webService1)
-		if err := kclient.Create(context.Background(), route); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
 			return nil, fmt.Errorf("failed to create route %s: %w", routeName, err)
 		}
 
@@ -389,7 +389,7 @@ func idleConnectionTerminationPolicyRunTest(t *testing.T, policy operatorv1.Ingr
 		ic.Spec.NamespaceSelector = &metav1.LabelSelector{
 			MatchLabels: testNs.Labels,
 		}
-		if err := kclient.Create(context.Background(), ic); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 			return nil, fmt.Errorf("failed to create IngressController: %w", err)
 		}
 		t.Cleanup(func() {

--- a/test/e2e/lb_eip_test.go
+++ b/test/e2e/lb_eip_test.go
@@ -84,7 +84,7 @@ func TestAWSEIPAllocationsForNLB(t *testing.T) {
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() {
@@ -204,7 +204,7 @@ func TestUnmanagedAWSEIPAllocations(t *testing.T) {
 		},
 	}
 
-	if err := kclient.Create(context.Background(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("expected ingresscontroller creation failed: %v", err)
 	}
 	t.Cleanup(func() {

--- a/test/e2e/lb_eip_test.go
+++ b/test/e2e/lb_eip_test.go
@@ -84,7 +84,7 @@ func TestAWSEIPAllocationsForNLB(t *testing.T) {
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() {
@@ -204,7 +204,7 @@ func TestUnmanagedAWSEIPAllocations(t *testing.T) {
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("expected ingresscontroller creation failed: %v", err)
 	}
 	t.Cleanup(func() {
@@ -304,9 +304,9 @@ func verifyIngressControllerEIPAllocationStatus(t *testing.T, icName types.Names
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 	// Poll until the eipAllocation status is what we expect.
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
 		ic := &operatorv1.IngressController{}
-		if err := kclient.Get(context.Background(), icName, ic); err != nil {
+		if err := kclient.Get(ctx, icName, ic); err != nil {
 			t.Logf("failed to get ingresscontroller: %v, retrying...", err)
 			return false, nil
 		}

--- a/test/e2e/lb_subnets_test.go
+++ b/test/e2e/lb_subnets_test.go
@@ -69,7 +69,7 @@ func TestAWSLBSubnets(t *testing.T) {
 			},
 		},
 	}
-	if err = createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err = createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("expected ingresscontroller creation failed: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -226,7 +226,7 @@ func TestUnmanagedAWSLBSubnets(t *testing.T) {
 					},
 				},
 			}
-			if err = createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+			if err = createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 				t.Fatalf("expected ingresscontroller creation failed: %v", err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -301,7 +301,7 @@ func waitForLBSubnetAnnotation(t *testing.T, ic *operatorv1.IngressController, s
 	lbService := &corev1.Service{}
 	expectedSubnetAnnotation := ingress.JoinAWSSubnets(subnets, ",")
 	t.Logf("waiting for %q service to have subnet annotation of %q", controller.LoadBalancerServiceName(ic), expectedSubnetAnnotation)
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if err := kclient.Get(ctx, controller.LoadBalancerServiceName(ic), lbService); err != nil {
 			t.Logf("failed to get %q service: %v, retrying ...", controller.LoadBalancerServiceName(ic), err)
 			return false, nil
@@ -342,9 +342,9 @@ func verifyIngressControllerSubnetStatus(t *testing.T, icName types.NamespacedNa
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 	// Poll until the subnet status is what we expect.
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
 		ic := &operatorv1.IngressController{}
-		if err := kclient.Get(context.Background(), icName, ic); err != nil {
+		if err := kclient.Get(ctx, icName, ic); err != nil {
 			t.Logf("failed to get ingresscontroller: %v, retrying...", err)
 			return false, nil
 		}

--- a/test/e2e/lb_subnets_test.go
+++ b/test/e2e/lb_subnets_test.go
@@ -69,7 +69,7 @@ func TestAWSLBSubnets(t *testing.T) {
 			},
 		},
 	}
-	if err = kclient.Create(context.Background(), ic); err != nil {
+	if err = createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("expected ingresscontroller creation failed: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -226,7 +226,7 @@ func TestUnmanagedAWSLBSubnets(t *testing.T) {
 					},
 				},
 			}
-			if err = kclient.Create(context.Background(), ic); err != nil {
+			if err = createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 				t.Fatalf("expected ingresscontroller creation failed: %v", err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/maxconn_metric_test.go
+++ b/test/e2e/maxconn_metric_test.go
@@ -61,7 +61,7 @@ func TestMaxConnectionsMetric(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	t.Logf("waiting for ingresscontroller %v", icName)
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)

--- a/test/e2e/maxconn_metric_test.go
+++ b/test/e2e/maxconn_metric_test.go
@@ -58,7 +58,7 @@ func TestMaxConnectionsMetric(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconn-metric"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/maxconn_metric_test.go
+++ b/test/e2e/maxconn_metric_test.go
@@ -58,7 +58,7 @@ func TestMaxConnectionsMetric(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconn-metric"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -113,7 +113,7 @@ func waitForMaxConnectionsMetric(t *testing.T, prometheusClient prometheusv1.API
 	serviceName := "router-internal-" + icName
 	query := fmt.Sprintf(`haproxy_max_connections{namespace="openshift-ingress",service="%s"}`, serviceName)
 	t.Logf("waiting for haproxy_max_connections{service=%q} to become %d", serviceName, expectedValue)
-	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(t.Context(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		result, _, err := prometheusClient.Query(ctx, query, time.Now())
 		if err != nil {
 			t.Logf("failed to query haproxy_max_connections: %v, retrying...", err)

--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -43,7 +43,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	t.Logf("waiting for ingresscontroller %v", icName)
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -109,7 +109,7 @@ func TestTunableMaxConnectionsInvalidValues(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	t.Logf("waiting for ingresscontroller %v", icName)
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)

--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -40,7 +40,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconnections-valid-values"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -106,7 +106,7 @@ func TestTunableMaxConnectionsInvalidValues(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconnections-invalid-values"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/maxconn_test.go
+++ b/test/e2e/maxconn_test.go
@@ -40,7 +40,7 @@ func TestTunableMaxConnectionsValidValues(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconnections-valid-values"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -106,7 +106,7 @@ func TestTunableMaxConnectionsInvalidValues(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "maxconnections-invalid-values"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -281,7 +281,7 @@ func TestClusterOperatorStatusRelatedObjects(t *testing.T) {
 }
 
 func TestDefaultIngressControllerSteadyConditions(t *testing.T) {
-	if err := waitForIngressControllerCondition(t, kclient, 10*time.Second, defaultName, defaultAvailableConditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 3*time.Minute, defaultName, defaultAvailableConditions...); err != nil {
 		t.Errorf("did not get expected conditions: %v", err)
 	}
 }
@@ -436,7 +436,7 @@ func TestUserDefinedIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ing); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ing)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
 		t.Errorf("failed to observe expected conditions: %v", err)
@@ -459,7 +459,7 @@ func TestUniqueDomainRejection(t *testing.T) {
 	if err := kclient.Create(context.TODO(), conflict); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, conflict)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, conflict) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionFalse},
@@ -520,7 +520,7 @@ func TestProxyProtocolAPI(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForIngressControllerWithNodePort...); err != nil {
 		t.Errorf("failed to observe expected conditions: %v", err)
@@ -665,11 +665,7 @@ func TestUpdateDefaultIngressControllerSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create secret %s: %v", secretName, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), secret); err != nil {
-			t.Errorf("failed to delete secret %s: %v", secretName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), secret, 2*time.Minute) })
 
 	// Verify that the deployment uses the new certificate.
 	err = wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
@@ -791,7 +787,7 @@ func TestIngressControllerScale(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -1023,7 +1019,7 @@ func TestHostNetworkEndpointPublishingStrategy(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ing); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ing)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
@@ -1204,7 +1200,7 @@ func TestInternalLoadBalancer(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -1293,7 +1289,7 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -1361,7 +1357,7 @@ func TestAWSResourceTagsChanged(t *testing.T) {
 	if infraConfig.Status.Platform != "AWS" {
 		t.Skipf("test skipped on platform %q", infraConfig.Status.Platform)
 	}
-	if err := waitForIngressControllerCondition(t, kclient, 10*time.Second, defaultName, defaultAvailableConditions...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, 3*time.Minute, defaultName, defaultAvailableConditions...); err != nil {
 		t.Errorf("did not get expected conditions: %v", err)
 	}
 	defaultIC := &operatorv1.IngressController{
@@ -1446,7 +1442,7 @@ func TestAWSLBTypeChange(t *testing.T) {
 	if err := kclient.Create(context.Background(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -1548,7 +1544,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clbIC); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", clbName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, clbIC)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, clbIC) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, clbName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -1597,7 +1593,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	if err := kclient.Create(context.TODO(), nlbIC); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", nlbName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, nlbIC)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, nlbIC) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, nlbName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -1612,7 +1608,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	// default setting.
 	assertServiceAnnotation(t, controller.LoadBalancerServiceName(clbIC), ingresscontroller.AWSLBTypeAnnotation, "", false)
 
-	t.Log("resetting the default LB type to Classic")
+	t.Log("resetting the default LB type to NLB")
 	if err := updateIngressConfigSpecWithRetryOnConflict(t, clusterConfigName, timeout, func(spec *configv1.IngressSpec) {
 		spec.LoadBalancer.Platform.Type = configv1.AWSPlatformType
 		spec.LoadBalancer.Platform.AWS = &configv1.AWSIngressSpec{
@@ -1667,7 +1663,7 @@ func TestScopeChange(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -1817,7 +1813,7 @@ func TestNodePortServiceEndpointPublishingStrategy(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ing); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ing)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: ingresscontroller.IngressControllerAdmittedConditionType, Status: operatorv1.ConditionTrue},
@@ -1891,7 +1887,7 @@ func TestTLSSecurityProfile(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -1962,7 +1958,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -1976,11 +1972,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ns1); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), ns1); err != nil {
-			t.Errorf("failed to delete test namespace %v: %v", ns1.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns1, 2*time.Minute) })
 	ns2 := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "routeadmissionpolicytest2",
@@ -1989,11 +1981,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ns2); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), ns2); err != nil {
-			t.Errorf("failed to delete test namespace %v: %v", ns2.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns2, 2*time.Minute) })
 
 	// Create conflicting routes in the namespaces
 	makeRoute := func(name types.NamespacedName, host, path string) *routev1.Route {
@@ -2224,21 +2212,13 @@ func TestSyslogLogging(t *testing.T) {
 	if err := kclient.Create(context.TODO(), syslogPod); err != nil {
 		t.Fatalf("failed to create pod for rsyslog: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), syslogPod); err != nil {
-			t.Errorf("failed to delete pod %s: %v", syslogPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: syslogPod.Namespace})
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
 
 	syslogConfigmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2256,11 +2236,7 @@ $ModLoad omstdout.so
 	if err := kclient.Create(context.TODO(), syslogConfigmap); err != nil {
 		t.Fatalf("failed to create configmap for rsyslog: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), syslogConfigmap); err != nil {
-			t.Errorf("failed to delete configmap %s: %v", syslogConfigmap.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogConfigmap, 2*time.Minute) })
 
 	// Get the rsyslog endpoint.
 	var syslogAddress string
@@ -2298,7 +2274,7 @@ $ModLoad omstdout.so
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -2358,7 +2334,7 @@ func TestContainerLogging(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -2384,7 +2360,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -2443,14 +2419,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -2526,7 +2495,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -2585,14 +2554,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -2738,7 +2700,7 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", ic.Name, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	// Ensure the ingress controller is reporting expected status conditions.
 	// The readiness of the resource depends on the load of the environment, and because changing InfrastructureConfig
 	// causes the Cloud controller manager to rollout, at least 3 minutes are required for leader
@@ -2773,7 +2735,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -2846,24 +2808,13 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-header-capture", Namespace: clientPod.Namespace})
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
 
 	// Scan the access logs to make sure the expected headers were captured
 	// and logged.
@@ -2934,7 +2885,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -3004,24 +2955,13 @@ func TestHTTPCookieCapture(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-cookie-capture", Namespace: clientPod.Namespace})
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
 
 	// Scan the access logs to make sure the expected cookie was captured
 	// and logged.
@@ -3093,7 +3033,7 @@ func TestNetworkLoadBalancer(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -3145,7 +3085,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Create a pod with an HTTP application that sends delayed responses.
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("idle-timeout-"))
@@ -3153,32 +3093,20 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	if err := kclient.Create(context.TODO(), httpdPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), httpdPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
 
 	httpdService := buildEchoService(httpdPod.Name, httpdPod.Namespace, httpdPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), httpdService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), httpdService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
 	if err := kclient.Create(context.TODO(), route); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), route); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", route.Namespace, route.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -3387,11 +3315,7 @@ func TestConnectTimeout(t *testing.T) {
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
 
 	if err := waitForPodReady(t, kclient, httpdPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -3500,7 +3424,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
@@ -3520,31 +3444,19 @@ func TestUniqueIdHeader(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -3566,14 +3478,7 @@ func TestUniqueIdHeader(t *testing.T) {
 		if err := kclient.Create(context.TODO(), clientPod); err != nil {
 			t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
-		defer func() {
-			if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-				if apierrors.IsNotFound(err) {
-					return
-				}
-				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-			}
-		}()
+		t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 		err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 			readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
@@ -3628,7 +3533,7 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Errorf("failed to observe expected conditions: %v", err)
@@ -3737,7 +3642,7 @@ func TestUnsupportedConfigOverride(t *testing.T) {
 	if err := kclient.Create(context.Background(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Errorf("failed to observe expected conditions: %v", err)
@@ -3850,7 +3755,7 @@ func TestLocalWithFallbackOverrideForNodePortService(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForIngressControllerWithNodePort...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -3911,7 +3816,7 @@ func TestCustomErrorpages(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	errorPageConfigmapName := types.NamespacedName{
 		Name:      errorPageConfigmap.Name,
@@ -3920,11 +3825,7 @@ func TestCustomErrorpages(t *testing.T) {
 	if err := kclient.Create(context.TODO(), errorPageConfigmap); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", errorPageConfigmapName, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), errorPageConfigmap); err != nil {
-			t.Errorf("failed to delete configmap %q: %v", errorPageConfigmapName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), errorPageConfigmap, 2*time.Minute) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
@@ -4012,7 +3913,7 @@ func TestTunableRouterKubeletProbesForCustomIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
@@ -4088,7 +3989,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	}
 
 	// Clean up our new Ingress Controller after we are done.
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for new ingress controller to come online.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
@@ -4106,11 +4007,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	if err := kclient.Create(context.TODO(), conflictingLoadBalancerService); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingLoadBalancerServiceName, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), conflictingLoadBalancerService); err != nil {
-			t.Errorf("failed to delete service %s: %v", conflictingLoadBalancerServiceName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, 2*time.Minute) })
 
 	conflictingNodeportServiceName := types.NamespacedName{
 		Name:      "router-nodeport-" + icName.Name,
@@ -4120,11 +4017,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	if err := kclient.Create(context.TODO(), conflictingNodeportService); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingNodeportServiceName, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), conflictingNodeportService); err != nil {
-			t.Errorf("failed to delete service %s: %v", conflictingNodeportServiceName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingNodeportService, 2*time.Minute) })
 
 	ic, err := getIngressController(t, kclient, icName, 1*time.Minute)
 	if err != nil {
@@ -4186,11 +4079,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ns); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), ns); err != nil {
-			t.Errorf("failed to delete namespace %v: %v", ns.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute) })
 	// Create the new private controller in a namespace that will be ignored by the Ingress Operator.
 	icName := types.NamespacedName{
 		Namespace: ns.Name,
@@ -4203,7 +4092,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 	}
 
 	// Clean up our new Ingress Controller after we are done.
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Verify new Ingress Controller is ignored by ensuring its status never gets modified.
 	wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
@@ -4626,7 +4515,7 @@ func assertIngressControllerDeleted(t *testing.T, cl client.Client, ing *operato
 		if apierrors.IsNotFound(errors.Unwrap(err)) {
 			return
 		}
-		t.Fatalf("WARNING: cloud resources may have been leaked! failed to delete ingresscontroller %s: %v", ing.Name, err)
+		t.Errorf("WARNING: cloud resources may have been leaked! failed to delete ingresscontroller %s: %v", ing.Name, err)
 	} else {
 		t.Logf("deleted ingresscontroller %s", ing.Name)
 	}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -630,7 +630,7 @@ func TestUpdateDefaultIngressControllerSecret(t *testing.T) {
 		if err := updateIngressControllerWithRetryOnConflict(t, defaultName, timeout, func(ic *operatorv1.IngressController) {
 			ic.Spec.DefaultCertificate = originalSecret
 		}); err != nil {
-			t.Fatalf("failed to reset default ingresscontroller: %v", err)
+			t.Errorf("failed to reset default ingresscontroller: %v", err)
 		}
 	}()
 
@@ -1978,7 +1978,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), ns1); err != nil {
-			t.Fatalf("failed to delete test namespace %v: %v", ns1.Name, err)
+			t.Errorf("failed to delete test namespace %v: %v", ns1.Name, err)
 		}
 	}()
 	ns2 := &corev1.Namespace{
@@ -1991,7 +1991,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), ns2); err != nil {
-			t.Fatalf("failed to delete test namespace %v: %v", ns2.Name, err)
+			t.Errorf("failed to delete test namespace %v: %v", ns2.Name, err)
 		}
 	}()
 
@@ -2226,7 +2226,7 @@ func TestSyslogLogging(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), syslogPod); err != nil {
-			t.Fatalf("failed to delete pod %s: %v", syslogPod.Name, err)
+			t.Errorf("failed to delete pod %s: %v", syslogPod.Name, err)
 		}
 	}()
 
@@ -2236,7 +2236,7 @@ func TestSyslogLogging(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
 		}
 	}()
 
@@ -2258,7 +2258,7 @@ $ModLoad omstdout.so
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), syslogConfigmap); err != nil {
-			t.Fatalf("failed to delete configmap %s: %v", syslogConfigmap.Name, err)
+			t.Errorf("failed to delete configmap %s: %v", syslogConfigmap.Name, err)
 		}
 	}()
 
@@ -2448,7 +2448,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			if apierrors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
 
@@ -2590,7 +2590,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			if apierrors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
 
@@ -2717,7 +2717,7 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 		if err := updateAndVerifyInfrastructureConfigWithRetry(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
 			spec.PlatformSpec.AWS = nil
 		}); err != nil {
-			t.Fatalf("failed to update infrastructure config: %v", err)
+			t.Errorf("failed to update infrastructure config: %v", err)
 		}
 	}()
 
@@ -2851,7 +2851,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 			if apierrors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
 
@@ -2861,7 +2861,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
 		}
 	}()
 
@@ -3009,7 +3009,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 			if apierrors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 	}()
 
@@ -3019,7 +3019,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
 		}
 	}()
 
@@ -3155,7 +3155,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), httpdPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 		}
 	}()
 
@@ -3165,7 +3165,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), httpdService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 		}
 	}()
 
@@ -3176,7 +3176,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), route); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", route.Namespace, route.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", route.Namespace, route.Name, err)
 		}
 	}()
 
@@ -3389,7 +3389,7 @@ func TestConnectTimeout(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
-			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+			t.Errorf("failed to delete network policy %s: %v", networkPolicy.Name, err)
 		}
 	}()
 
@@ -3522,7 +3522,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -3532,7 +3532,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -3542,7 +3542,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -3571,7 +3571,7 @@ func TestUniqueIdHeader(t *testing.T) {
 				if apierrors.IsNotFound(err) {
 					return
 				}
-				t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 			}
 		}()
 
@@ -3819,7 +3819,7 @@ func TestLocalWithFallbackOverrideForLoadBalancerService(t *testing.T) {
 		if err := updateIngressControllerWithRetryOnConflict(t, defaultName, timeout, func(ic *operatorv1.IngressController) {
 			ic.Spec.UnsupportedConfigOverrides = runtime.RawExtension{}
 		}); err != nil {
-			t.Fatalf("failed to update ingresscontroller %q to remove the override: %v", defaultName, err)
+			t.Errorf("failed to update ingresscontroller %q to remove the override: %v", defaultName, err)
 		}
 	}()
 
@@ -3922,7 +3922,7 @@ func TestCustomErrorpages(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), errorPageConfigmap); err != nil {
-			t.Fatalf("failed to delete configmap %q: %v", errorPageConfigmapName, err)
+			t.Errorf("failed to delete configmap %q: %v", errorPageConfigmapName, err)
 		}
 	}()
 
@@ -4108,7 +4108,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), conflictingLoadBalancerService); err != nil {
-			t.Fatalf("failed to delete service %s: %v", conflictingLoadBalancerServiceName, err)
+			t.Errorf("failed to delete service %s: %v", conflictingLoadBalancerServiceName, err)
 		}
 	}()
 
@@ -4122,7 +4122,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), conflictingNodeportService); err != nil {
-			t.Fatalf("failed to delete service %s: %v", conflictingNodeportServiceName, err)
+			t.Errorf("failed to delete service %s: %v", conflictingNodeportServiceName, err)
 		}
 	}()
 
@@ -4188,7 +4188,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), ns); err != nil {
-			t.Fatalf("failed to delete namespace %v: %v", ns.Name, err)
+			t.Errorf("failed to delete namespace %v: %v", ns.Name, err)
 		}
 	}()
 	// Create the new private controller in a namespace that will be ignored by the Ingress Operator.

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -342,7 +342,7 @@ func TestCustomIngressClass(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
@@ -433,7 +433,7 @@ func TestUserDefinedIngressController(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "testuserdefinedingresscontroller"}
 	ing := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -456,7 +456,7 @@ func TestUniqueDomainRejection(t *testing.T) {
 
 	conflictName := types.NamespacedName{Namespace: operatorNamespace, Name: "conflict"}
 	conflict := newLoadBalancerController(conflictName, def.Status.Domain)
-	if err := createWithRetryOnError(t, context.Background(), conflict, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflict, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, conflict) })
@@ -517,7 +517,7 @@ func TestProxyProtocolAPI(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "proxy-protocol"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newNodePortController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -665,7 +665,7 @@ func TestUpdateDefaultIngressControllerSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create secret %s: %v", secretName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), secret, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), secret, DefaultRetryTimeout) })
 
 	// Verify that the deployment uses the new certificate.
 	err = wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
@@ -754,7 +754,7 @@ func TestUpdateDefaultIngressControllerSecret(t *testing.T) {
 
 	// Verify that the router-certs secret gets updated.
 	previousRouterCertsSecret = routerCertsSecret.DeepCopy()
-	wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+	err = wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), controller.RouterCertsGlobalSecretName(), routerCertsSecret); err != nil {
 			t.Logf("failed to get secret %s: %v", controller.DefaultIngressCertConfigMapName(), err)
 			return false, nil
@@ -784,7 +784,7 @@ func TestIngressControllerScale(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "scale"}
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -850,7 +850,7 @@ func TestIngressControllerScale(t *testing.T) {
 	}
 
 	// Ensure the ingresscontroller remains available
-	if err := waitForIngressControllerCondition(t, kclient, 2*time.Minute, name, availableConditionsForPrivateIngressController...); err != nil {
+	if err := waitForIngressControllerCondition(t, kclient, DefaultRetryTimeout, name, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
@@ -871,7 +871,7 @@ func TestIngressControllerScale(t *testing.T) {
 	}
 
 	// Wait for the deployment scale down to be observed.
-	if err := waitForAvailableReplicas(t, kclient, ic, 2*time.Minute, originalReplicas); err != nil {
+	if err := waitForAvailableReplicas(t, kclient, ic, DefaultRetryTimeout, originalReplicas); err != nil {
 		t.Fatalf("failed waiting deployment of ingresscontroller %s to scale to %d: %v", name, originalReplicas, err)
 	}
 
@@ -1016,7 +1016,7 @@ func TestHostNetworkEndpointPublishingStrategy(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkendpointpublishingstrategy"}
 	ing := newHostNetworkController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -1039,7 +1039,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 	t.Log("creating an ingresscontroller with the default port bindings")
 	name1 := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkportbinding"}
 	ing1 := newHostNetworkController(name1, name1.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := createWithRetryOnError(t, context.Background(), ing1, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing1, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create the first ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing1) })
@@ -1117,7 +1117,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 	ing2 := newHostNetworkController(name2, name2.Name+"."+dnsConfig.Spec.BaseDomain)
 	ing2.Spec.NodePlacement = placement
 	ing2.Spec.EndpointPublishingStrategy.HostNetwork = strategy
-	if err := createWithRetryOnError(t, context.Background(), ing2, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing2, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create the second ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing2) })
@@ -1197,7 +1197,7 @@ func TestInternalLoadBalancer(t *testing.T) {
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 		Scope:               operatorv1.InternalLoadBalancer,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1286,7 +1286,7 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1439,7 +1439,7 @@ func TestAWSLBTypeChange(t *testing.T) {
 		Scope: operatorv1.ExternalLoadBalancer,
 	}
 	t.Logf("creating ingresscontroller %q without specifying LB type", ic.Name)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1541,7 +1541,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	clbName := types.NamespacedName{Namespace: operatorNamespace, Name: "aws-lb-type-defaulting-to-clb"}
 	clbIC := newLoadBalancerController(clbName, clbName.Name+"."+dnsConfig.Spec.BaseDomain)
 	t.Logf("creating ingresscontroller %s with default LB type, which is Classic", clbName)
-	if err := createWithRetryOnError(t, context.Background(), clbIC, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clbIC, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", clbName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, clbIC) })
@@ -1590,7 +1590,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	nlbName := types.NamespacedName{Namespace: operatorNamespace, Name: "aws-lb-type-defaulting-to-nlb"}
 	nlbIC := newLoadBalancerController(nlbName, nlbName.Name+"."+dnsConfig.Spec.BaseDomain)
 	t.Logf("creating ingresscontroller %s with default LB type, which is now NLB", nlbName)
-	if err := createWithRetryOnError(t, context.Background(), nlbIC, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nlbIC, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", nlbName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, nlbIC) })
@@ -1660,7 +1660,7 @@ func TestScopeChange(t *testing.T) {
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 		Scope:               operatorv1.ExternalLoadBalancer,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1810,7 +1810,7 @@ func TestNodePortServiceEndpointPublishingStrategy(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "nodeport"}
 	ing := newNodePortController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -1884,7 +1884,7 @@ func TestTLSSecurityProfile(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "testtlssecurityprofile"}
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1955,7 +1955,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 			"routeadmissiontest": "",
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1969,19 +1969,19 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 			Name: "routeadmissionpolicytest1",
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ns1, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns1, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns1, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns1, DefaultRetryTimeout) })
 	ns2 := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "routeadmissionpolicytest2",
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ns2, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns2, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns2, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns2, DefaultRetryTimeout) })
 
 	// Create conflicting routes in the namespaces
 	makeRoute := func(name types.NamespacedName, host, path string) *routev1.Route {
@@ -2014,7 +2014,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	rejectedCondition := routev1.RouteIngressCondition{Type: routev1.RouteAdmitted, Status: corev1.ConditionFalse}
 
 	// The first route should be admitted
-	if err := createWithRetryOnError(t, context.Background(), route1, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route1, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route1Name, ic.Name, admittedCondition); err != nil {
@@ -2029,7 +2029,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// The second route should be rejected because the policy is Strict
-	if err := createWithRetryOnError(t, context.Background(), route2, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route2, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route2Name, ic.Name, rejectedCondition); err != nil {
@@ -2081,7 +2081,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// The route should be admitted because the default ingresscontroller wildcard
 	// policy is WildcardsDisallowed.
-	if err := createWithRetryOnError(t, context.Background(), route3, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route3, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route3Name, ic.Name, admittedCondition); err != nil {
@@ -2095,7 +2095,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// The route should not be admitted because the ingresscontroller wildcard policy
 	// is WildcardsDisallowed by default.
-	if err := createWithRetryOnError(t, context.Background(), route4, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route4, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route4Name, ic.Name, rejectedCondition); err != nil {
@@ -2134,7 +2134,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	}
 	route4 = makeRoute(route4Name, "route4.test.example.com", "/bar")
 	route4.Spec.WildcardPolicy = routev1.WildcardPolicySubdomain
-	if err := createWithRetryOnError(t, context.Background(), route4, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route4, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 
@@ -2209,16 +2209,16 @@ func TestSyslogLogging(t *testing.T) {
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), syslogPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), syslogPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod for rsyslog: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogPod, DefaultRetryTimeout) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: syslogPod.Namespace})
-	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout) })
 
 	syslogConfigmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2233,10 +2233,10 @@ $ModLoad omstdout.so
 `,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), syslogConfigmap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), syslogConfigmap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create configmap for rsyslog: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogConfigmap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogConfigmap, DefaultRetryTimeout) })
 
 	// Get the rsyslog endpoint.
 	var syslogAddress string
@@ -2271,7 +2271,7 @@ $ModLoad omstdout.so
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2331,7 +2331,7 @@ func TestContainerLogging(t *testing.T) {
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2357,7 +2357,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			HttpLogFormat: "8192" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 120),
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2416,10 +2416,10 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -2492,7 +2492,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			HttpLogFormat: "0480" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 40),
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2551,10 +2551,10 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -2674,14 +2674,15 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("failed to update infrastructure config: %v", err)
 	}
-	defer func() {
+
+	t.Cleanup(func() {
 		// Remove the custom endpoints from the infrastructure config.
 		if err := updateAndVerifyInfrastructureConfigWithRetry(t, types.NamespacedName{Name: "cluster"}, timeout, func(spec *configv1.InfrastructureSpec) {
 			spec.PlatformSpec.AWS = nil
 		}); err != nil {
 			t.Errorf("failed to update infrastructure config: %v", err)
 		}
-	}()
+	})
 
 	if infraConfig.Status.ControlPlaneTopology != configv1.ExternalTopologyMode {
 		// Wait for CCM to be ready with the new configuration, so we can guarantee that
@@ -2697,7 +2698,7 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 	// Ensure an ingresscontroller can be created with custom endpoints.
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "test-custom-endpoints"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", ic.Name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2732,7 +2733,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2805,16 +2806,16 @@ func TestHTTPHeaderCapture(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-header-capture", Namespace: clientPod.Namespace})
-	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout) })
 
 	// Scan the access logs to make sure the expected headers were captured
 	// and logged.
@@ -2882,7 +2883,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 			}},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2952,16 +2953,16 @@ func TestHTTPCookieCapture(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-cookie-capture", Namespace: clientPod.Namespace})
-	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout) })
 
 	// Scan the access logs to make sure the expected cookie was captured
 	// and logged.
@@ -3030,7 +3031,7 @@ func TestNetworkLoadBalancer(t *testing.T) {
 		},
 	}
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = lb
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3082,7 +3083,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 		},
 	}
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = lb
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3090,23 +3091,23 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	// Create a pod with an HTTP application that sends delayed responses.
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("idle-timeout-"))
 	httpdPod := buildSlowHTTPDPod("idle-timeout-httpd", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, DefaultRetryTimeout) })
 
 	httpdService := buildEchoService(httpdPod.Name, httpdPod.Namespace, httpdPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, DefaultRetryTimeout) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
-	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -3165,7 +3166,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 		start := time.Now()
 		response, err := client.Do(request)
 		if err != nil {
-			elapsed := time.Now().Sub(start)
+			elapsed := time.Since(start)
 
 			// Ignore errors other than EOF.
 			if !errors.Is(err, io.EOF) {
@@ -3192,7 +3193,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 				return false, nil
 			}
 
-			elapsed := time.Now().Sub(start)
+			elapsed := time.Since(start)
 			t.Logf("got response after elapsed time %v: %v", elapsed, string(body))
 		}
 
@@ -3253,7 +3254,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 		start := time.Now()
 		response, err := client.Do(request)
 		if err != nil {
-			elapsed := time.Now().Sub(start)
+			elapsed := time.Since(start)
 			t.Logf("got unexpected error after elapsed time %v: %v", elapsed, err)
 			return false, nil
 		}
@@ -3265,7 +3266,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 			return false, nil
 		}
 
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 		t.Logf("got expected response after elapsed time %v: %v", elapsed, string(body))
 
 		return true, nil
@@ -3278,6 +3279,11 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 func TestConnectTimeout(t *testing.T) {
 	t.Parallel()
 
+	// Use the test context for cancelable and time out operations
+	// DO NOT use this context for cleanup operations given it is canceled just before
+	// the cleanup
+	ctx := t.Context()
+
 	// Create a dedicated ingresscontroller with the connect timeout set to 2s
 	// instead of the default 5s to let the test run a little faster.
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "test-connect-timeout"}
@@ -3285,7 +3291,7 @@ func TestConnectTimeout(t *testing.T) {
 	ic.Spec.TuningOptions = operatorv1.IngressControllerTuningOptions{
 		ConnectTimeout: &metav1.Duration{Duration: 2 * time.Second},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3302,34 +3308,34 @@ func TestConnectTimeout(t *testing.T) {
 
 	// Create a pod with an HTTP application that delays the connection and sends echo responses.
 	httpdPod := buildDelayConnectHTTPPod("connect-timeout-http", operatorcontroller.DefaultOperandNamespace, iptablesImage, operatorImage)
-	if err := createWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, httpdPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
 
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, DefaultRetryTimeout) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "connect-timeout-http", Namespace: httpdPod.Namespace})
-	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, networkPolicy, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, DefaultRetryTimeout) })
 
-	if err := waitForPodReady(t, kclient, httpdPod, 2*time.Minute); err != nil {
+	if err := waitForPodReady(t, kclient, httpdPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
 	httpdService := buildEchoService(httpdPod.Name, httpdPod.Namespace, httpdPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, httpdService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, DefaultRetryTimeout) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
-	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, ctx, route, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, icName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {
@@ -3339,13 +3345,13 @@ func TestConnectTimeout(t *testing.T) {
 	// Get the LB's hostname via the wildcard DNS record
 	wildcardRecordName := controller.WildcardDNSRecordName(ic)
 	wildcardRecord := &iov1.DNSRecord{}
-	if err := kclient.Get(context.Background(), wildcardRecordName, wildcardRecord); err != nil {
+	if err := kclient.Get(ctx, wildcardRecordName, wildcardRecord); err != nil {
 		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
 	}
 	lbHostname := wildcardRecord.Spec.Targets[0]
 
 	// Wait until we can resolve the LB's hostname
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, dnsResolutionTimeout, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, dnsResolutionTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := net.LookupIP(lbHostname)
 		if err != nil {
 			t.Log(err)
@@ -3365,7 +3371,7 @@ func TestConnectTimeout(t *testing.T) {
 	}
 	request.Host = route.Spec.Host
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		client := &http.Client{}
 		start := time.Now()
 		response, err := client.Do(request)
@@ -3384,7 +3390,7 @@ func TestConnectTimeout(t *testing.T) {
 			t.Logf("got unexpected response code: %v", response.StatusCode)
 			return false, nil
 		}
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 
 		// Connect timeout is 2 seconds + 3 retries == ~8 seconds.
 		// Disallow lesser values to avoid false positives (e.g. problems with http pod).
@@ -3410,7 +3416,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		UniqueId: operatorv1.IngressControllerHTTPUniqueIdHeaderPolicy{Name: "x-unique-id"},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3430,22 +3436,22 @@ func TestUniqueIdHeader(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("unique-id-"))
 	echoPod := buildEchoPod("unique-id-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -3464,10 +3470,10 @@ func TestUniqueIdHeader(t *testing.T) {
 			"--resolve", echoRoute.Spec.Host + ":80:" + service.Spec.ClusterIP,
 		}
 		clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-		if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 			t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
-		t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+		t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 		err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 			readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
@@ -3519,7 +3525,7 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "leastconn"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3628,7 +3634,7 @@ func TestUnsupportedConfigOverride(t *testing.T) {
 	}
 	domain := fmt.Sprintf("%s.%s", icName.Name, dnsConfig.Spec.BaseDomain)
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3741,7 +3747,7 @@ func TestLocalWithFallbackOverrideForNodePortService(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newNodePortController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3802,7 +3808,7 @@ func TestCustomErrorpages(t *testing.T) {
 		},
 	}
 	ic.Spec.HttpErrorCodePages.Name = errorPageConfigmap.Name
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3811,10 +3817,10 @@ func TestCustomErrorpages(t *testing.T) {
 		Name:      errorPageConfigmap.Name,
 		Namespace: errorPageConfigmap.Namespace,
 	}
-	if err := createWithRetryOnError(t, context.Background(), errorPageConfigmap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), errorPageConfigmap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", errorPageConfigmapName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), errorPageConfigmap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), errorPageConfigmap, DefaultRetryTimeout) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
@@ -3899,7 +3905,7 @@ func TestTunableRouterKubeletProbesForCustomIngressController(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3973,7 +3979,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -3993,20 +3999,24 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 		Namespace: "openshift-ingress",
 	}
 	conflictingLoadBalancerService := buildEchoService(conflictingLoadBalancerServiceName.Name, conflictingLoadBalancerServiceName.Namespace, nil)
-	if err := createWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingLoadBalancerServiceName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, 2*time.Minute) })
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, DefaultRetryTimeout)
+	})
 
 	conflictingNodeportServiceName := types.NamespacedName{
 		Name:      "router-nodeport-" + icName.Name,
 		Namespace: "openshift-ingress",
 	}
 	conflictingNodeportService := buildEchoService(conflictingNodeportServiceName.Name, conflictingNodeportServiceName.Namespace, nil)
-	if err := createWithRetryOnError(t, context.Background(), conflictingNodeportService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflictingNodeportService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingNodeportServiceName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingNodeportService, 2*time.Minute) })
+	t.Cleanup(func() {
+		deleteWithRetryOnError(t, context.Background(), conflictingNodeportService, DefaultRetryTimeout)
+	})
 
 	ic, err := getIngressController(t, kclient, icName, 1*time.Minute)
 	if err != nil {
@@ -4065,10 +4075,10 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 			Name: "ignored-ns",
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout) })
 	// Create the new private controller in a namespace that will be ignored by the Ingress Operator.
 	icName := types.NamespacedName{
 		Namespace: ns.Name,
@@ -4076,7 +4086,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -4664,7 +4674,7 @@ func TestReconcileInternalService(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -342,7 +342,7 @@ func TestCustomIngressClass(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
@@ -433,7 +433,7 @@ func TestUserDefinedIngressController(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "testuserdefinedingresscontroller"}
 	ing := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := kclient.Create(context.TODO(), ing); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -456,7 +456,7 @@ func TestUniqueDomainRejection(t *testing.T) {
 
 	conflictName := types.NamespacedName{Namespace: operatorNamespace, Name: "conflict"}
 	conflict := newLoadBalancerController(conflictName, def.Status.Domain)
-	if err := kclient.Create(context.TODO(), conflict); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflict, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, conflict) })
@@ -517,7 +517,7 @@ func TestProxyProtocolAPI(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "proxy-protocol"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newNodePortController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -784,7 +784,7 @@ func TestIngressControllerScale(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "scale"}
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1016,7 +1016,7 @@ func TestHostNetworkEndpointPublishingStrategy(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkendpointpublishingstrategy"}
 	ing := newHostNetworkController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := kclient.Create(context.TODO(), ing); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -1039,7 +1039,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 	t.Log("creating an ingresscontroller with the default port bindings")
 	name1 := types.NamespacedName{Namespace: operatorNamespace, Name: "hostnetworkportbinding"}
 	ing1 := newHostNetworkController(name1, name1.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := kclient.Create(context.TODO(), ing1); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing1, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create the first ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing1) })
@@ -1117,7 +1117,7 @@ func TestHostNetworkPortBinding(t *testing.T) {
 	ing2 := newHostNetworkController(name2, name2.Name+"."+dnsConfig.Spec.BaseDomain)
 	ing2.Spec.NodePlacement = placement
 	ing2.Spec.EndpointPublishingStrategy.HostNetwork = strategy
-	if err := kclient.Create(context.TODO(), ing2); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing2, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create the second ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing2) })
@@ -1197,7 +1197,7 @@ func TestInternalLoadBalancer(t *testing.T) {
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 		Scope:               operatorv1.InternalLoadBalancer,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1286,7 +1286,7 @@ func TestInternalLoadBalancerGlobalAccessGCP(t *testing.T) {
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1439,7 +1439,7 @@ func TestAWSLBTypeChange(t *testing.T) {
 		Scope: operatorv1.ExternalLoadBalancer,
 	}
 	t.Logf("creating ingresscontroller %q without specifying LB type", ic.Name)
-	if err := kclient.Create(context.Background(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1541,7 +1541,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	clbName := types.NamespacedName{Namespace: operatorNamespace, Name: "aws-lb-type-defaulting-to-clb"}
 	clbIC := newLoadBalancerController(clbName, clbName.Name+"."+dnsConfig.Spec.BaseDomain)
 	t.Logf("creating ingresscontroller %s with default LB type, which is Classic", clbName)
-	if err := kclient.Create(context.TODO(), clbIC); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clbIC, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", clbName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, clbIC) })
@@ -1590,7 +1590,7 @@ func TestAWSLBTypeDefaulting(t *testing.T) {
 	nlbName := types.NamespacedName{Namespace: operatorNamespace, Name: "aws-lb-type-defaulting-to-nlb"}
 	nlbIC := newLoadBalancerController(nlbName, nlbName.Name+"."+dnsConfig.Spec.BaseDomain)
 	t.Logf("creating ingresscontroller %s with default LB type, which is now NLB", nlbName)
-	if err := kclient.Create(context.TODO(), nlbIC); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nlbIC, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", nlbName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, nlbIC) })
@@ -1660,7 +1660,7 @@ func TestScopeChange(t *testing.T) {
 		DNSManagementPolicy: operatorv1.ManagedLoadBalancerDNS,
 		Scope:               operatorv1.ExternalLoadBalancer,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1810,7 +1810,7 @@ func TestNodePortServiceEndpointPublishingStrategy(t *testing.T) {
 	t.Parallel()
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "nodeport"}
 	ing := newNodePortController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := kclient.Create(context.TODO(), ing); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ing, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ing) })
@@ -1884,7 +1884,7 @@ func TestTLSSecurityProfile(t *testing.T) {
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "testtlssecurityprofile"}
 	domain := name.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(name, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1955,7 +1955,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 			"routeadmissiontest": "",
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -1969,7 +1969,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 			Name: "routeadmissionpolicytest1",
 		},
 	}
-	if err := kclient.Create(context.TODO(), ns1); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns1, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns1, 2*time.Minute) })
@@ -1978,7 +1978,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 			Name: "routeadmissionpolicytest2",
 		},
 	}
-	if err := kclient.Create(context.TODO(), ns2); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns2, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns2, 2*time.Minute) })
@@ -2014,7 +2014,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	rejectedCondition := routev1.RouteIngressCondition{Type: routev1.RouteAdmitted, Status: corev1.ConditionFalse}
 
 	// The first route should be admitted
-	if err := kclient.Create(context.TODO(), route1); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route1, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route1Name, ic.Name, admittedCondition); err != nil {
@@ -2029,7 +2029,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// The second route should be rejected because the policy is Strict
-	if err := kclient.Create(context.TODO(), route2); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route2, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route2Name, ic.Name, rejectedCondition); err != nil {
@@ -2081,7 +2081,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// The route should be admitted because the default ingresscontroller wildcard
 	// policy is WildcardsDisallowed.
-	if err := kclient.Create(context.TODO(), route3); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route3, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route3Name, ic.Name, admittedCondition); err != nil {
@@ -2095,7 +2095,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 
 	// The route should not be admitted because the ingresscontroller wildcard policy
 	// is WildcardsDisallowed by default.
-	if err := kclient.Create(context.TODO(), route4); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route4, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	if err := waitForRouteIngressConditions(t, kclient, route4Name, ic.Name, rejectedCondition); err != nil {
@@ -2134,7 +2134,7 @@ func TestRouteAdmissionPolicy(t *testing.T) {
 	}
 	route4 = makeRoute(route4Name, "route4.test.example.com", "/bar")
 	route4.Spec.WildcardPolicy = routev1.WildcardPolicySubdomain
-	if err := kclient.Create(context.TODO(), route4); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route4, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 
@@ -2209,13 +2209,13 @@ func TestSyslogLogging(t *testing.T) {
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), syslogPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), syslogPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod for rsyslog: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: syslogPod.Namespace})
-	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
@@ -2233,7 +2233,7 @@ $ModLoad omstdout.so
 `,
 		},
 	}
-	if err := kclient.Create(context.TODO(), syslogConfigmap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), syslogConfigmap, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create configmap for rsyslog: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), syslogConfigmap, 2*time.Minute) })
@@ -2271,7 +2271,7 @@ $ModLoad omstdout.so
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2331,7 +2331,7 @@ func TestContainerLogging(t *testing.T) {
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2357,7 +2357,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			HttpLogFormat: "8192" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 120),
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2416,7 +2416,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
@@ -2492,7 +2492,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			HttpLogFormat: "0480" + strings.Repeat("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=", 40),
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2551,7 +2551,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
@@ -2697,7 +2697,7 @@ func TestIngressControllerCustomEndpoints(t *testing.T) {
 	// Ensure an ingresscontroller can be created with custom endpoints.
 	name := types.NamespacedName{Namespace: operatorNamespace, Name: "test-custom-endpoints"}
 	ic := newLoadBalancerController(name, name.Name+"."+dnsConfig.Spec.BaseDomain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", ic.Name, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2732,7 +2732,7 @@ func TestHTTPHeaderCapture(t *testing.T) {
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2805,13 +2805,13 @@ func TestHTTPHeaderCapture(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-header-capture", Namespace: clientPod.Namespace})
-	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
@@ -2882,7 +2882,7 @@ func TestHTTPCookieCapture(t *testing.T) {
 			}},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -2952,13 +2952,13 @@ func TestHTTPCookieCapture(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "http-cookie-capture", Namespace: clientPod.Namespace})
-	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
@@ -3030,7 +3030,7 @@ func TestNetworkLoadBalancer(t *testing.T) {
 		},
 	}
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = lb
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3082,7 +3082,7 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 		},
 	}
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = lb
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3090,20 +3090,20 @@ func TestAWSELBConnectionIdleTimeout(t *testing.T) {
 	// Create a pod with an HTTP application that sends delayed responses.
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("idle-timeout-"))
 	httpdPod := buildSlowHTTPDPod("idle-timeout-httpd", namespace.Name)
-	if err := kclient.Create(context.TODO(), httpdPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
 
 	httpdService := buildEchoService(httpdPod.Name, httpdPod.Namespace, httpdPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), httpdService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
-	if err := kclient.Create(context.TODO(), route); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
@@ -3285,7 +3285,7 @@ func TestConnectTimeout(t *testing.T) {
 	ic.Spec.TuningOptions = operatorv1.IngressControllerTuningOptions{
 		ConnectTimeout: &metav1.Duration{Duration: 2 * time.Second},
 	}
-	if err := kclient.Create(context.Background(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3302,14 +3302,14 @@ func TestConnectTimeout(t *testing.T) {
 
 	// Create a pod with an HTTP application that delays the connection and sends echo responses.
 	httpdPod := buildDelayConnectHTTPPod("connect-timeout-http", operatorcontroller.DefaultOperandNamespace, iptablesImage, operatorImage)
-	if err := kclient.Create(context.Background(), httpdPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
 
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "connect-timeout-http", Namespace: httpdPod.Namespace})
-	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), networkPolicy, 2*time.Minute) })
@@ -3319,14 +3319,14 @@ func TestConnectTimeout(t *testing.T) {
 	}
 
 	httpdService := buildEchoService(httpdPod.Name, httpdPod.Namespace, httpdPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.Background(), httpdService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
-	if err := kclient.Create(context.Background(), route); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
@@ -3410,7 +3410,7 @@ func TestUniqueIdHeader(t *testing.T) {
 	ic.Spec.HTTPHeaders = &operatorv1.IngressControllerHTTPHeaders{
 		UniqueId: operatorv1.IngressControllerHTTPUniqueIdHeaderPolicy{Name: "x-unique-id"},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3430,19 +3430,19 @@ func TestUniqueIdHeader(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("unique-id-"))
 	echoPod := buildEchoPod("unique-id-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -3464,7 +3464,7 @@ func TestUniqueIdHeader(t *testing.T) {
 			"--resolve", echoRoute.Spec.Host + ":80:" + service.Spec.ClusterIP,
 		}
 		clientPod := buildCurlPod(name, echoRoute.Namespace, image, echoRoute.Spec.Host, service.Spec.ClusterIP, extraCurlArgs...)
-		if err := kclient.Create(context.TODO(), clientPod); err != nil {
+		if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 			t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 		}
 		t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
@@ -3519,7 +3519,7 @@ func TestLoadBalancingAlgorithmUnsupportedConfigOverride(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "leastconn"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3628,7 +3628,7 @@ func TestUnsupportedConfigOverride(t *testing.T) {
 	}
 	domain := fmt.Sprintf("%s.%s", icName.Name, dnsConfig.Spec.BaseDomain)
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.Background(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3741,7 +3741,7 @@ func TestLocalWithFallbackOverrideForNodePortService(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newNodePortController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3802,7 +3802,7 @@ func TestCustomErrorpages(t *testing.T) {
 		},
 	}
 	ic.Spec.HttpErrorCodePages.Name = errorPageConfigmap.Name
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %q: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3811,7 +3811,7 @@ func TestCustomErrorpages(t *testing.T) {
 		Name:      errorPageConfigmap.Name,
 		Namespace: errorPageConfigmap.Namespace,
 	}
-	if err := kclient.Create(context.TODO(), errorPageConfigmap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), errorPageConfigmap, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create configmap %q: %v", errorPageConfigmapName, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), errorPageConfigmap, 2*time.Minute) })
@@ -3899,7 +3899,7 @@ func TestTunableRouterKubeletProbesForCustomIngressController(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -3973,7 +3973,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -3993,7 +3993,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 		Namespace: "openshift-ingress",
 	}
 	conflictingLoadBalancerService := buildEchoService(conflictingLoadBalancerServiceName.Name, conflictingLoadBalancerServiceName.Namespace, nil)
-	if err := kclient.Create(context.TODO(), conflictingLoadBalancerService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingLoadBalancerServiceName, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingLoadBalancerService, 2*time.Minute) })
@@ -4003,7 +4003,7 @@ func TestIngressControllerServiceNameCollision(t *testing.T) {
 		Namespace: "openshift-ingress",
 	}
 	conflictingNodeportService := buildEchoService(conflictingNodeportServiceName.Name, conflictingNodeportServiceName.Namespace, nil)
-	if err := kclient.Create(context.TODO(), conflictingNodeportService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), conflictingNodeportService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s: %v", conflictingNodeportServiceName, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), conflictingNodeportService, 2*time.Minute) })
@@ -4065,7 +4065,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 			Name: "ignored-ns",
 		},
 	}
-	if err := kclient.Create(context.TODO(), ns); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute) })
@@ -4076,7 +4076,7 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -4664,7 +4664,7 @@ func TestReconcileInternalService(t *testing.T) {
 	}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3305,11 +3305,8 @@ func TestConnectTimeout(t *testing.T) {
 	if err := kclient.Create(context.Background(), httpdPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.Background(), httpdPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
-		}
-	})
+
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdPod, 2*time.Minute) })
 
 	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "connect-timeout-http", Namespace: httpdPod.Namespace})
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
@@ -3325,22 +3322,14 @@ func TestConnectTimeout(t *testing.T) {
 	if err := kclient.Create(context.Background(), httpdService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.Background(), httpdService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", httpdService.Namespace, httpdService.Name, err)
-		}
-	})
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), httpdService, 2*time.Minute) })
 
 	route := buildRoute(httpdPod.Name, httpdPod.Namespace, httpdService.Name)
 	route.Spec.Host = fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, ic.Spec.Domain)
 	if err := kclient.Create(context.Background(), route); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", route.Namespace, route.Name, err)
 	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.Background(), route); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", route.Namespace, route.Name, err)
-		}
-	})
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
 
 	// Wait for the load balancer and DNS to be ready.
 	if err := waitForIngressControllerCondition(t, kclient, 10*time.Minute, icName, availableConditionsForIngressControllerWithLoadBalancer...); err != nil {

--- a/test/e2e/redirect_port_stripping_test.go
+++ b/test/e2e/redirect_port_stripping_test.go
@@ -38,7 +38,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
@@ -61,17 +61,13 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		kclient.Delete(context.TODO(), echoPod)
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		kclient.Delete(context.TODO(), echoService)
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Spec.TLS = &routev1.TLSConfig{
@@ -81,9 +77,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		kclient.Delete(context.TODO(), echoRoute)
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	// Use an exec pod to run multiple curl commands.
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
@@ -92,9 +86,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create client pod: %v", err)
 	}
-	defer func() {
-		kclient.Delete(context.TODO(), clientPod)
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	// Wait for client pod to be ready
 	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {

--- a/test/e2e/redirect_port_stripping_test.go
+++ b/test/e2e/redirect_port_stripping_test.go
@@ -35,7 +35,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: name}
 	domain := name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -58,13 +58,13 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("secure-redirect-"))
 	echoPod := buildEchoPod(name+"-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
@@ -74,7 +74,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -83,7 +83,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildExecPod(name+"-client", echoRoute.Namespace, clientPodImage)
 
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create client pod: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })

--- a/test/e2e/redirect_port_stripping_test.go
+++ b/test/e2e/redirect_port_stripping_test.go
@@ -35,7 +35,7 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: name}
 	domain := name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -58,38 +58,38 @@ func TestSecureRedirectCorrectness(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("secure-redirect-"))
 	echoPod := buildEchoPod(name+"-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	echoRoute.Spec.TLS = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	// Use an exec pod to run multiple curl commands.
 	clientPodImage := deployment.Spec.Template.Spec.Containers[0].Image
 	clientPod := buildExecPod(name+"-client", echoRoute.Namespace, clientPodImage)
 
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create client pod: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	// Wait for client pod to be ready
-	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(1*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		p := &corev1.Pod{}
 		if err := kclient.Get(context.TODO(), types.NamespacedName{Name: clientPod.Name, Namespace: clientPod.Namespace}, p); err != nil {
 			return false, nil

--- a/test/e2e/reloadinterval_test.go
+++ b/test/e2e/reloadinterval_test.go
@@ -34,7 +34,7 @@ func TestReloadInterval(t *testing.T) {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	t.Logf("waiting for ingresscontroller %v", icName)
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 		t.Fatalf("failed to observe expected conditions: %v", err)

--- a/test/e2e/reloadinterval_test.go
+++ b/test/e2e/reloadinterval_test.go
@@ -30,7 +30,7 @@ func TestReloadInterval(t *testing.T) {
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 

--- a/test/e2e/reloadinterval_test.go
+++ b/test/e2e/reloadinterval_test.go
@@ -30,7 +30,7 @@ func TestReloadInterval(t *testing.T) {
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 
@@ -106,7 +106,7 @@ func TestReloadInterval(t *testing.T) {
 		}
 
 		// Ensure the deployment has been recreated.
-		err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(1*time.Second, DefaultRetryTimeout, func() (bool, error) {
 			deployment := &appsv1.Deployment{}
 			if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
 				t.Logf("Get %q failed: %v, retrying ...", controller.RouterDeploymentName(ic), err)

--- a/test/e2e/route_metrics_test.go
+++ b/test/e2e/route_metrics_test.go
@@ -152,7 +152,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 	}
 
 	// Cleanup step - delete the Ingress Controller.
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for metrics to be added and set to 0.
 	if err := waitForRouteMetricsAddorUpdate(t, prometheusClient, ic.Name, 0); err != nil {
@@ -178,11 +178,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 	}
 
 	// Cleanup step - delete the Namespace.
-	defer func() {
-		if err := kclient.Delete(context.TODO(), ns); err != nil {
-			t.Errorf("failed to delete test namespace %s: %v", ns.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute) })
 
 	// Create a Route to be immediately admitted by this Ingress Controller.
 	routeFooLabelName := types.NamespacedName{Namespace: ns.Name, Name: routeNameStr}
@@ -208,15 +204,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 	}
 
 	// Cleanup step - delete the Route.
-	defer func() {
-		if err := kclient.Delete(context.TODO(), routeFooLabel); err != nil {
-			if apierrors.IsNotFound(err) {
-				return
-			} else {
-				t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
-			}
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
 
 	// Wait for metrics to be updated to 1 as the Route will get admitted by the IC.
 	if err := waitForRouteMetricsAddorUpdate(t, prometheusClient, ic.Name, 1); err != nil {

--- a/test/e2e/route_metrics_test.go
+++ b/test/e2e/route_metrics_test.go
@@ -180,7 +180,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 	// Cleanup step - delete the Namespace.
 	defer func() {
 		if err := kclient.Delete(context.TODO(), ns); err != nil {
-			t.Fatalf("failed to delete test namespace %s: %v", ns.Name, err)
+			t.Errorf("failed to delete test namespace %s: %v", ns.Name, err)
 		}
 	}()
 
@@ -213,7 +213,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 			if apierrors.IsNotFound(err) {
 				return
 			} else {
-				t.Fatalf("failed to delete route %s: %v", routeFooLabelName, err)
+				t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
 			}
 		}
 	}()

--- a/test/e2e/route_metrics_test.go
+++ b/test/e2e/route_metrics_test.go
@@ -147,7 +147,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 		}
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 
@@ -173,12 +173,12 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 			"expression": correctLabel,
 		}
 	}
-	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 
 	// Cleanup step - delete the Namespace.
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout) })
 
 	// Create a Route to be immediately admitted by this Ingress Controller.
 	routeFooLabelName := types.NamespacedName{Namespace: ns.Name, Name: routeNameStr}
@@ -199,12 +199,12 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 
 	// Cleanup step - delete the Route.
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout) })
 
 	// Wait for metrics to be updated to 1 as the Route will get admitted by the IC.
 	if err := waitForRouteMetricsAddorUpdate(t, prometheusClient, ic.Name, 1); err != nil {
@@ -353,7 +353,7 @@ func updateRouteAndWaitForMetricsUpdate(t *testing.T, name types.NamespacedName,
 // waitForRouteMetricsAddorUpdate waits for the metrics for the corresponding shard to be added or updated to the expected value.
 func waitForRouteMetricsAddorUpdate(t *testing.T, prometheusClient prometheusv1.API, shardName string, value int) error {
 	t.Logf("waiting for route_metrics_controller_routes_per_shard{shard_name=%s} to become %d", shardName, value)
-	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(1*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		result, _, err := prometheusClient.Query(context.TODO(), fmt.Sprintf(`route_metrics_controller_routes_per_shard{shard_name="%s"}`, shardName), time.Now())
 		if err != nil {
 			t.Logf("failed to fetch metrics: %v", err)
@@ -387,7 +387,7 @@ func waitForRouteMetricsAddorUpdate(t *testing.T, prometheusClient prometheusv1.
 
 // waitForRouteMetricsDelete waits for the metrics for the corresponding shard to be deleted.
 func waitForRouteMetricsDelete(t *testing.T, prometheusClient prometheusv1.API, shardName string) error {
-	if err := wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(1*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		result, _, err := prometheusClient.Query(context.TODO(), fmt.Sprintf(`route_metrics_controller_routes_per_shard{shard_name="%s"}`, shardName), time.Now())
 		if err != nil {
 			t.Logf("failed to fetch metrics: %v", err)

--- a/test/e2e/route_metrics_test.go
+++ b/test/e2e/route_metrics_test.go
@@ -147,7 +147,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 		}
 	}
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 
@@ -173,7 +173,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 			"expression": correctLabel,
 		}
 	}
-	if err := kclient.Create(context.TODO(), ns); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 
@@ -199,7 +199,7 @@ func testRouteMetricsControllerLabelSelector(t *testing.T, testRS, testNS bool) 
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), routeFooLabel); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -49,7 +49,7 @@ func TestRouterCompressionParsing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting private controller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, pc4)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, pc4) })
 
 	if err := testCompressionPolicy(t, "http-compression-4", compressionPolicyErrors); err == nil {
 		t.Errorf("compression policy with errors should have failed but didn't")
@@ -63,7 +63,7 @@ func testParsing(t *testing.T, name string, policy operatorv1.HTTPCompressionPol
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, pc)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, pc) })
 
 	if err := testCompressionPolicy(t, name, policy); err != nil {
 		t.Errorf(errorMsg, err)
@@ -201,7 +201,7 @@ func TestRouterCompressionOperation(t *testing.T) {
 	if err := kclient.Create(context.TODO(), helloConfigMap); err != nil {
 		t.Fatalf("failed to create configmap %s/%s: %v", helloConfigMap.Namespace, helloConfigMap.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, helloConfigMap) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloConfigMap, 2*time.Minute) })
 
 	helloPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -239,13 +239,13 @@ func TestRouterCompressionOperation(t *testing.T) {
 	if err := kclient.Create(context.TODO(), helloPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", helloPod.Namespace, helloPod.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, helloPod) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloPod, 2*time.Minute) })
 
 	helloService := buildEchoService(helloPod.Name, helloPod.Namespace, helloPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), helloService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", helloService.Namespace, helloService.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, helloService) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloService, 2*time.Minute) })
 
 	helloRoute := buildRoute(helloPod.Name, helloPod.Namespace, helloService.Name)
 	helloRoute.Spec.TLS = &routev1.TLSConfig{
@@ -255,7 +255,7 @@ func TestRouterCompressionOperation(t *testing.T) {
 	if err := kclient.Create(context.TODO(), helloRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", helloRoute.Namespace, helloRoute.Name, err)
 	}
-	t.Cleanup(func() { assertDeleted(t, kclient, helloRoute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloRoute, 2*time.Minute) })
 
 	// Wait for hello pod to be ready.
 	if err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -78,7 +78,7 @@ func createPrivateController(t *testing.T, privateName string, privateDomain str
 
 	ic := newPrivateController(icName, domain)
 	// Create a new private Ingress Controller (deletion handled by caller)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		return ic, fmt.Errorf("error creating private ingresscontroller %s: %v", privateName, err)
 	}
 	return ic, nil
@@ -198,7 +198,7 @@ func TestRouterCompressionOperation(t *testing.T) {
 			"index.html": "Hello World!",
 		},
 	}
-	if err := kclient.Create(context.TODO(), helloConfigMap); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloConfigMap, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create configmap %s/%s: %v", helloConfigMap.Namespace, helloConfigMap.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloConfigMap, 2*time.Minute) })
@@ -236,13 +236,13 @@ func TestRouterCompressionOperation(t *testing.T) {
 			}},
 		},
 	}
-	if err := kclient.Create(context.TODO(), helloPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", helloPod.Namespace, helloPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloPod, 2*time.Minute) })
 
 	helloService := buildEchoService(helloPod.Name, helloPod.Namespace, helloPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), helloService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", helloService.Namespace, helloService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloService, 2*time.Minute) })
@@ -252,7 +252,7 @@ func TestRouterCompressionOperation(t *testing.T) {
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := kclient.Create(context.TODO(), helloRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", helloRoute.Namespace, helloRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloRoute, 2*time.Minute) })

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -169,7 +169,7 @@ func TestRouterCompressionOperation(t *testing.T) {
 			}
 			return true, nil
 		}); err != nil {
-			t.Fatalf("failed to cleanup ingress controller: %v", err)
+			t.Errorf("failed to cleanup ingress controller: %v", err)
 		}
 	})
 

--- a/test/e2e/router_compression_test.go
+++ b/test/e2e/router_compression_test.go
@@ -78,7 +78,7 @@ func createPrivateController(t *testing.T, privateName string, privateDomain str
 
 	ic := newPrivateController(icName, domain)
 	// Create a new private Ingress Controller (deletion handled by caller)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		return ic, fmt.Errorf("error creating private ingresscontroller %s: %v", privateName, err)
 	}
 	return ic, nil
@@ -92,7 +92,7 @@ func testCompressionPolicy(t *testing.T, name string, compressionPolicy operator
 	namespacedName := types.NamespacedName{Namespace: operatorNamespace, Name: name}
 	routerDeploymentNamespacedName := types.NamespacedName{Namespace: controller.DefaultOperandNamespace, Name: "router-" + name}
 
-	if err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		ic, err := getIngressController(t, kclient, namespacedName, 5*time.Second)
 		if err != nil {
 			t.Logf("failed to get ingress controller: %v, retrying...", err)
@@ -122,14 +122,14 @@ func testCompressionPolicy(t *testing.T, name string, compressionPolicy operator
 	}
 
 	// Get the router deployment
-	deployment, err := getDeployment(t, kclient, routerDeploymentNamespacedName, 2*time.Minute)
+	deployment, err := getDeployment(t, kclient, routerDeploymentNamespacedName, DefaultRetryTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to get deployment: %v", err)
 	}
 
 	// Check if the MIME type environment variable has been updated
 	mimeTypes := ingress.GetMIMETypes(compressionPolicy.MimeTypes)
-	if err := waitForDeploymentEnvVar(t, deployment, 2*time.Minute, "ROUTER_COMPRESSION_MIME", strings.Join(mimeTypes, " ")); err != nil {
+	if err := waitForDeploymentEnvVar(t, deployment, DefaultRetryTimeout, "ROUTER_COMPRESSION_MIME", strings.Join(mimeTypes, " ")); err != nil {
 		return fmt.Errorf("expected deployment to have mimeTypes %s: %v", mimeTypes, err)
 	}
 
@@ -198,10 +198,10 @@ func TestRouterCompressionOperation(t *testing.T) {
 			"index.html": "Hello World!",
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), helloConfigMap, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloConfigMap, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create configmap %s/%s: %v", helloConfigMap.Namespace, helloConfigMap.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloConfigMap, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloConfigMap, DefaultRetryTimeout) })
 
 	helloPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -236,26 +236,26 @@ func TestRouterCompressionOperation(t *testing.T) {
 			}},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), helloPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", helloPod.Namespace, helloPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloPod, DefaultRetryTimeout) })
 
 	helloService := buildEchoService(helloPod.Name, helloPod.Namespace, helloPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), helloService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", helloService.Namespace, helloService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloService, DefaultRetryTimeout) })
 
 	helloRoute := buildRoute(helloPod.Name, helloPod.Namespace, helloService.Name)
 	helloRoute.Spec.TLS = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
-	if err := createWithRetryOnError(t, context.Background(), helloRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), helloRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", helloRoute.Namespace, helloRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), helloRoute, DefaultRetryTimeout) })
 
 	// Wait for hello pod to be ready.
 	if err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {

--- a/test/e2e/router_status_test.go
+++ b/test/e2e/router_status_test.go
@@ -40,7 +40,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Create a route to be admitted by this ingress controller.
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
@@ -49,11 +49,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 	if err := kclient.Create(context.TODO(), route); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), route); err != nil {
-			t.Errorf("failed to delete route %s: %v", routeName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
 
 	// Wait for route to be admitted.
 	if err := waitForRouteIngressConditions(t, kclient, routeName, ic.Name, admittedCondition); err != nil {
@@ -86,7 +82,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Create a route to be immediately admitted by this ingress controller and then when the IC label selectors are
 	// updated, the status should clear.
@@ -96,11 +92,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	if err := kclient.Create(context.TODO(), routeFooLabel); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), routeFooLabel); err != nil {
-			t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
 
 	// Create a route that will NOT be immediately admitted by the ingress controller, but will be admitted AFTER
 	// the IC selectors are updated. The status SHOULD be successfully admitted.
@@ -110,11 +102,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	if err := kclient.Create(context.TODO(), routeBarLabel); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), routeBarLabel); err != nil {
-			t.Errorf("failed to delete route %s: %v", routeBarLabel, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })
 
 	// Wait for routeFooLabel to be admitted upon creation.
 	if err := waitForRouteIngressConditions(t, kclient, routeFooLabelName, ic.Name, admittedCondition); err != nil {
@@ -159,7 +147,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Create a new namespace for the route that we can immediately match with the IC's namespace selector.
 	nsFoo := &corev1.Namespace{
@@ -173,11 +161,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	if err := kclient.Create(context.TODO(), nsFoo); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), nsFoo); err != nil {
-			t.Errorf("failed to delete test namespace %v: %v", nsFoo.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsFoo, 2*time.Minute) })
 
 	// Create a new namespace for the route that we can NOT immediately match with the IC's namespace selector.
 	nsBar := &corev1.Namespace{
@@ -191,11 +175,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	if err := kclient.Create(context.TODO(), nsBar); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), nsBar); err != nil {
-			t.Errorf("failed to delete test namespace %v: %v", nsBar.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsBar, 2*time.Minute) })
 
 	// Create a route to be immediately admitted by this ingress controller and then when the IC label selectors are
 	// updated, the status should clear.
@@ -204,11 +184,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	if err := kclient.Create(context.TODO(), routeFooLabel); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), routeFooLabel); err != nil {
-			t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
 
 	// Create a route that will NOT be immediately admitted by the ingress controller, but will be admitted AFTER
 	// the IC selectors are updated. The status SHOULD be successfully admitted.
@@ -217,11 +193,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	if err := kclient.Create(context.TODO(), routeBarLabel); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), routeBarLabel); err != nil {
-			t.Errorf("failed to delete route %s: %v", routeBarLabel, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })
 
 	// Ensure routeBarLabel starts with a clear status.
 	if err := waitForRouteStatusClear(t, kclient, routeBarLabelName, ic.Name); err != nil {

--- a/test/e2e/router_status_test.go
+++ b/test/e2e/router_status_test.go
@@ -51,7 +51,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), route); err != nil {
-			t.Fatalf("failed to delete route %s: %v", routeName, err)
+			t.Errorf("failed to delete route %s: %v", routeName, err)
 		}
 	}()
 
@@ -98,7 +98,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), routeFooLabel); err != nil {
-			t.Fatalf("failed to delete route %s: %v", routeFooLabelName, err)
+			t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
 		}
 	}()
 
@@ -112,7 +112,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), routeBarLabel); err != nil {
-			t.Fatalf("failed to delete route %s: %v", routeBarLabel, err)
+			t.Errorf("failed to delete route %s: %v", routeBarLabel, err)
 		}
 	}()
 
@@ -175,7 +175,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), nsFoo); err != nil {
-			t.Fatalf("failed to delete test namespace %v: %v", nsFoo.Name, err)
+			t.Errorf("failed to delete test namespace %v: %v", nsFoo.Name, err)
 		}
 	}()
 
@@ -193,7 +193,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), nsBar); err != nil {
-			t.Fatalf("failed to delete test namespace %v: %v", nsBar.Name, err)
+			t.Errorf("failed to delete test namespace %v: %v", nsBar.Name, err)
 		}
 	}()
 
@@ -206,7 +206,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), routeFooLabel); err != nil {
-			t.Fatalf("failed to delete route %s: %v", routeFooLabelName, err)
+			t.Errorf("failed to delete route %s: %v", routeFooLabelName, err)
 		}
 	}()
 
@@ -219,7 +219,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), routeBarLabel); err != nil {
-			t.Fatalf("failed to delete route %s: %v", routeBarLabel, err)
+			t.Errorf("failed to delete route %s: %v", routeBarLabel, err)
 		}
 	}()
 

--- a/test/e2e/router_status_test.go
+++ b/test/e2e/router_status_test.go
@@ -37,7 +37,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 			"type": icName.Name,
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -46,7 +46,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeName := types.NamespacedName{Namespace: "openshift-console", Name: "route-" + icName.Name}
 	route := newRouteWithLabel(routeName, icName.Name)
-	if err := kclient.Create(context.TODO(), route); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
@@ -79,7 +79,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -89,7 +89,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeFooLabelName := types.NamespacedName{Namespace: "openshift-console", Name: "route-foo-label"}
 	routeFooLabel := newRouteWithLabel(routeFooLabelName, "foo")
-	if err := kclient.Create(context.TODO(), routeFooLabel); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
@@ -99,7 +99,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeBarLabelName := types.NamespacedName{Namespace: "openshift-console", Name: "route-bar-label"}
 	routeBarLabel := newRouteWithLabel(routeBarLabelName, "bar")
-	if err := kclient.Create(context.TODO(), routeBarLabel); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })
@@ -144,7 +144,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 		},
 	}
 
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -158,7 +158,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), nsFoo); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nsFoo, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsFoo, 2*time.Minute) })
@@ -172,7 +172,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), nsBar); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nsBar, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsBar, 2*time.Minute) })
@@ -181,7 +181,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	// updated, the status should clear.
 	routeFooLabelName := types.NamespacedName{Namespace: nsFoo.Name, Name: "route-foo-label"}
 	routeFooLabel := newRouteWithLabel(routeFooLabelName, "")
-	if err := kclient.Create(context.TODO(), routeFooLabel); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
@@ -190,7 +190,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 	// the IC selectors are updated. The status SHOULD be successfully admitted.
 	routeBarLabelName := types.NamespacedName{Namespace: nsBar.Name, Name: "route-bar-label"}
 	routeBarLabel := newRouteWithLabel(routeBarLabelName, "bar")
-	if err := kclient.Create(context.TODO(), routeBarLabel); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })

--- a/test/e2e/router_status_test.go
+++ b/test/e2e/router_status_test.go
@@ -37,7 +37,7 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 			"type": icName.Name,
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -46,10 +46,10 @@ func TestDeleteIngressControllerShouldClearRouteStatus(t *testing.T) {
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeName := types.NamespacedName{Namespace: "openshift-console", Name: "route-" + icName.Name}
 	route := newRouteWithLabel(routeName, icName.Name)
-	if err := createWithRetryOnError(t, context.Background(), route, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), route, DefaultRetryTimeout) })
 
 	// Wait for route to be admitted.
 	if err := waitForRouteIngressConditions(t, kclient, routeName, ic.Name, admittedCondition); err != nil {
@@ -79,7 +79,7 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -89,20 +89,20 @@ func TestIngressControllerRouteSelectorUpdateShouldClearRouteStatus(t *testing.T
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeFooLabelName := types.NamespacedName{Namespace: "openshift-console", Name: "route-foo-label"}
 	routeFooLabel := newRouteWithLabel(routeFooLabelName, "foo")
-	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout) })
 
 	// Create a route that will NOT be immediately admitted by the ingress controller, but will be admitted AFTER
 	// the IC selectors are updated. The status SHOULD be successfully admitted.
 	// Use openshift-console namespace to get a namespace outside the ingress-operator's cache.
 	routeBarLabelName := types.NamespacedName{Namespace: "openshift-console", Name: "route-bar-label"}
 	routeBarLabel := newRouteWithLabel(routeBarLabelName, "bar")
-	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, DefaultRetryTimeout) })
 
 	// Wait for routeFooLabel to be admitted upon creation.
 	if err := waitForRouteIngressConditions(t, kclient, routeFooLabelName, ic.Name, admittedCondition); err != nil {
@@ -144,7 +144,7 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -158,10 +158,10 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), nsFoo, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nsFoo, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsFoo, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsFoo, DefaultRetryTimeout) })
 
 	// Create a new namespace for the route that we can NOT immediately match with the IC's namespace selector.
 	nsBar := &corev1.Namespace{
@@ -172,28 +172,28 @@ func TestIngressControllerNamespaceSelectorUpdateShouldClearRouteStatus(t *testi
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), nsBar, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), nsBar, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsBar, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), nsBar, DefaultRetryTimeout) })
 
 	// Create a route to be immediately admitted by this ingress controller and then when the IC label selectors are
 	// updated, the status should clear.
 	routeFooLabelName := types.NamespacedName{Namespace: nsFoo.Name, Name: "route-foo-label"}
 	routeFooLabel := newRouteWithLabel(routeFooLabelName, "")
-	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeFooLabel, DefaultRetryTimeout) })
 
 	// Create a route that will NOT be immediately admitted by the ingress controller, but will be admitted AFTER
 	// the IC selectors are updated. The status SHOULD be successfully admitted.
 	routeBarLabelName := types.NamespacedName{Namespace: nsBar.Name, Name: "route-bar-label"}
 	routeBarLabel := newRouteWithLabel(routeBarLabelName, "bar")
-	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), routeBarLabel, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route: %v", err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), routeBarLabel, DefaultRetryTimeout) })
 
 	// Ensure routeBarLabel starts with a clear status.
 	if err := waitForRouteStatusClear(t, kclient, routeBarLabelName, ic.Name); err != nil {

--- a/test/e2e/set_delete_test.go
+++ b/test/e2e/set_delete_test.go
@@ -26,9 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/client-go/kubernetes"
+	"sync/atomic"
 )
 
-var podCount int
+var podCount atomic.Int32
 
 const (
 	headerName  = "x-frame-options"
@@ -50,8 +51,8 @@ func testHeaders(t *testing.T, image string, route *routev1.Route, address strin
 	var extraCurlArgs []string
 
 	extraCurlArgs = append(extraCurlArgs, "-v", "--resolve", route.Spec.Host+":80:"+address)
-	podCount++
-	name := fmt.Sprintf("%s%d", route.Name, podCount)
+	count := podCount.Add(1)
+	name := fmt.Sprintf("%s%d", route.Name, count)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
@@ -59,7 +60,7 @@ func testHeaders(t *testing.T, image string, route *routev1.Route, address strin
 	defer func() {
 		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
 			if !errors.IsNotFound(err) {
-				t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 			}
 		}
 	}()
@@ -157,7 +158,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -167,7 +168,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -177,7 +178,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 	cond := routev1.RouteIngressCondition{
@@ -229,7 +230,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -239,7 +240,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -249,7 +250,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 	cond := routev1.RouteIngressCondition{

--- a/test/e2e/set_delete_test.go
+++ b/test/e2e/set_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,12 +22,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/client-go/kubernetes"
-	"sync/atomic"
 )
 
 var podCount atomic.Int32
@@ -57,13 +56,7 @@ func testHeaders(t *testing.T, image string, route *routev1.Route, address strin
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if !errors.IsNotFound(err) {
-				t.Errorf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
-			}
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 	err = wait.PollImmediate(1*time.Second, 4*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
 			Container: "curl",
@@ -132,7 +125,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -156,31 +149,19 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 	cond := routev1.RouteIngressCondition{
 		Type:   routev1.RouteAdmitted,
 		Status: corev1.ConditionTrue,
@@ -204,7 +185,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -228,31 +209,19 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHTTPResponseHeaders(echoPod.Name, echoPod.Namespace, echoService.Name, headerName, headerValue)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 	cond := routev1.RouteIngressCondition{
 		Type:   routev1.RouteAdmitted,
 		Status: corev1.ConditionTrue,

--- a/test/e2e/set_delete_test.go
+++ b/test/e2e/set_delete_test.go
@@ -53,7 +53,7 @@ func testHeaders(t *testing.T, image string, route *routev1.Route, address strin
 	count := podCount.Add(1)
 	name := fmt.Sprintf("%s%d", route.Name, count)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
@@ -122,7 +122,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 			},
 		},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -146,19 +146,19 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("set-response-headers-"))
 	echoPod := buildEchoPod("set-response-header-via-ic-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -182,7 +182,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "set-response-headers-route"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -206,19 +206,19 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("set-response-headers-"))
 	echoPod := buildEchoPod("set-response-header-via-route-echo", namespace.Name)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHTTPResponseHeaders(echoPod.Name, echoPod.Namespace, echoService.Name, headerName, headerValue)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })

--- a/test/e2e/set_delete_test.go
+++ b/test/e2e/set_delete_test.go
@@ -53,10 +53,10 @@ func testHeaders(t *testing.T, image string, route *routev1.Route, address strin
 	count := podCount.Add(1)
 	name := fmt.Sprintf("%s%d", route.Name, count)
 	clientPod := buildCurlPod(name, route.Namespace, image, route.Spec.Host, address, extraCurlArgs...)
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 	err = wait.PollImmediate(1*time.Second, 4*time.Minute, func() (bool, error) {
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
 			Container: "curl",
@@ -122,7 +122,7 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 			},
 		},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -146,22 +146,22 @@ func TestSetIngressControllerResponseHeaders(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("set-response-headers-"))
 	echoPod := buildEchoPod("set-response-header-via-ic-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 	cond := routev1.RouteIngressCondition{
 		Type:   routev1.RouteAdmitted,
 		Status: corev1.ConditionTrue,
@@ -182,7 +182,7 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 	icName := types.NamespacedName{Namespace: operatorNamespace, Name: "set-response-headers-route"}
 	domain := icName.Name + "." + dnsConfig.Spec.BaseDomain
 	ic := newPrivateController(icName, domain)
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -206,22 +206,22 @@ func TestSetRouteResponseHeaders(t *testing.T) {
 
 	namespace := createNamespace(t, names.SimpleNameGenerator.GenerateName("set-response-headers-"))
 	echoPod := buildEchoPod("set-response-header-via-route-echo", namespace.Name)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRouteWithHTTPResponseHeaders(echoPod.Name, echoPod.Namespace, echoService.Name, headerName, headerValue)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 	cond := routev1.RouteIngressCondition{
 		Type:   routev1.RouteAdmitted,
 		Status: corev1.ConditionTrue,

--- a/test/e2e/tuning_options_test.go
+++ b/test/e2e/tuning_options_test.go
@@ -63,7 +63,7 @@ func TestHAProxyTimeouts(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -222,7 +222,7 @@ func TestHAProxyTimeoutsRejection(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 	conditions := []operatorv1.OperatorCondition{
 		{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 		{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionFalse},
@@ -385,7 +385,7 @@ func TestCookieLen(t *testing.T) {
 			if err := kclient.Create(context.TODO(), ic); err != nil {
 				t.Fatalf("Failed to create ingresscontroller %s: %v", icName, err)
 			}
-			defer assertIngressControllerDeleted(t, kclient, ic)
+			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 			if err := waitForIngressControllerCondition(t, kclient, 2*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
 				t.Fatalf("Timed out waiting for ingresscontroller %s to become available: %v", icName.Name, err)
@@ -395,19 +395,19 @@ func TestCookieLen(t *testing.T) {
 			if err := kclient.Create(context.TODO(), echoPod); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
-			defer assertDeleted(t, kclient, echoPod)
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 			if err := kclient.Create(context.TODO(), echoService); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
-			defer assertDeleted(t, kclient, echoService)
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 			echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
 			if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
-			defer assertDeleted(t, kclient, echoRoute)
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 			// Wait for echo pod to be ready
 			err := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -475,7 +475,7 @@ func TestCookieLen(t *testing.T) {
 			if err := kclient.Create(context.TODO(), curlPod); err != nil {
 				t.Fatalf("failed to create pod %q: %v", curlPodName.Name, err)
 			}
-			defer assertDeleted(t, kclient, curlPod)
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), curlPod, 2*time.Minute) })
 
 			// Wait for the curl pod to complete its request
 			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {

--- a/test/e2e/tuning_options_test.go
+++ b/test/e2e/tuning_options_test.go
@@ -60,7 +60,7 @@ func TestHAProxyTimeouts(t *testing.T) {
 		TLSInspectDelay:      &metav1.Duration{Duration: tlsInspectDelayInput},
 		HTTPKeepAliveTimeout: &metav1.Duration{Duration: httpKeepAliveInput},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -219,7 +219,7 @@ func TestHAProxyTimeoutsRejection(t *testing.T) {
 		TunnelTimeout:    &metav1.Duration{Duration: tunnelTimeoutInput},
 		TLSInspectDelay:  &metav1.Duration{Duration: tlsInspectDelayInput},
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -382,7 +382,7 @@ func TestCookieLen(t *testing.T) {
 				},
 			}
 
-			if err := kclient.Create(context.TODO(), ic); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 				t.Fatalf("Failed to create ingresscontroller %s: %v", icName, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -392,19 +392,19 @@ func TestCookieLen(t *testing.T) {
 			}
 
 			echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), namespace.Name)
-			if err := kclient.Create(context.TODO(), echoPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-			if err := kclient.Create(context.TODO(), echoService); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 			echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-			if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -472,7 +472,7 @@ func TestCookieLen(t *testing.T) {
 			}
 
 			curlPod := buildCurlPod(curlPodName.Name, curlPodName.Namespace, curlPodImage, echoRoute.Spec.Host, "", curlArgs...)
-			if err := kclient.Create(context.TODO(), curlPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), curlPod, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create pod %q: %v", curlPodName.Name, err)
 			}
 			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), curlPod, 2*time.Minute) })

--- a/test/e2e/tuning_options_test.go
+++ b/test/e2e/tuning_options_test.go
@@ -60,7 +60,7 @@ func TestHAProxyTimeouts(t *testing.T) {
 		TLSInspectDelay:      &metav1.Duration{Duration: tlsInspectDelayInput},
 		HTTPKeepAliveTimeout: &metav1.Duration{Duration: httpKeepAliveInput},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -219,7 +219,7 @@ func TestHAProxyTimeoutsRejection(t *testing.T) {
 		TunnelTimeout:    &metav1.Duration{Duration: tunnelTimeoutInput},
 		TLSInspectDelay:  &metav1.Duration{Duration: tlsInspectDelayInput},
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller %s: %v", icName, err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -382,32 +382,32 @@ func TestCookieLen(t *testing.T) {
 				},
 			}
 
-			if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 				t.Fatalf("Failed to create ingresscontroller %s: %v", icName, err)
 			}
 			t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
-			if err := waitForIngressControllerCondition(t, kclient, 2*time.Minute, icName, availableConditionsForPrivateIngressController...); err != nil {
+			if err := waitForIngressControllerCondition(t, kclient, DefaultRetryTimeout, icName, availableConditionsForPrivateIngressController...); err != nil {
 				t.Fatalf("Timed out waiting for ingresscontroller %s to become available: %v", icName.Name, err)
 			}
 
 			echoPod := buildEchoPod(names.SimpleNameGenerator.GenerateName("echo-pod-"), namespace.Name)
-			if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 			echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-			if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 			echoRoute := buildRoute(echoPod.Name, echoPod.Namespace, echoService.Name)
-			if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 			// Wait for echo pod to be ready
 			err := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
@@ -472,10 +472,10 @@ func TestCookieLen(t *testing.T) {
 			}
 
 			curlPod := buildCurlPod(curlPodName.Name, curlPodName.Namespace, curlPodImage, echoRoute.Spec.Host, "", curlArgs...)
-			if err := createWithRetryOnError(t, context.Background(), curlPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), curlPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create pod %q: %v", curlPodName.Name, err)
 			}
-			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), curlPod, 2*time.Minute) })
+			t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), curlPod, DefaultRetryTimeout) })
 
 			// Wait for the curl pod to complete its request
 			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -48,7 +48,7 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to reach stable conditions.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS, operatorProgressingFalse)...); err != nil {
@@ -127,7 +127,7 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to reach stable conditions.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancer, operatorProgressingFalse)...); err != nil {
@@ -228,7 +228,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	if err := kclient.Create(context.TODO(), ic); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
-	defer assertIngressControllerDeleted(t, kclient, ic)
+	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
 
 	// Wait for the load balancer and DNS to reach stable conditions.
 	if err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, append(availableConditionsForIngressControllerWithLoadBalancerUnmanagedDNS, operatorProgressingFalse)...); err != nil {

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -45,7 +45,7 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -124,7 +124,7 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
 		Scope: operatorv1.ExternalLoadBalancer,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -225,7 +225,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 		Scope:               operatorv1.InternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
 	}
-	if err := kclient.Create(context.TODO(), ic); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })

--- a/test/e2e/unmanaged_dns_test.go
+++ b/test/e2e/unmanaged_dns_test.go
@@ -45,7 +45,7 @@ func TestUnmanagedDNSToManagedDNSIngressController(t *testing.T) {
 		Scope:               operatorv1.ExternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -124,7 +124,7 @@ func TestManagedDNSToUnmanagedDNSIngressController(t *testing.T) {
 	ic.Spec.EndpointPublishingStrategy.LoadBalancer = &operatorv1.LoadBalancerStrategy{
 		Scope: operatorv1.ExternalLoadBalancer,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -225,7 +225,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 		Scope:               operatorv1.InternalLoadBalancer,
 		DNSManagementPolicy: operatorv1.UnmanagedLoadBalancerDNS,
 	}
-	if err := createWithRetryOnError(t, context.Background(), ic, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ic, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create ingresscontroller: %v", err)
 	}
 	t.Cleanup(func() { assertIngressControllerDeleted(t, kclient, ic) })
@@ -287,8 +287,8 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	// Ensure the service's load-balancer status changes.
 	lbService = &corev1.Service{}
 	var lbAddress string
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		if err := kclient.Get(context.TODO(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, controller.LoadBalancerServiceName(ic), lbService); err != nil {
 			t.Logf("Get %q failed: %v, retrying ...", controller.LoadBalancerServiceName(ic), err)
 			return false, nil
 		}
@@ -321,7 +321,7 @@ func TestUnmanagedDNSToManagedDNSInternalIngressController(t *testing.T) {
 	}
 
 	// Ensure DNSRecord CR is present.
-	if err := kclient.Get(context.TODO(), wildcardRecordName, wildcardRecord); err != nil {
+	if err := kclient.Get(t.Context(), wildcardRecordName, wildcardRecord); err != nil {
 		t.Fatalf("failed to get wildcard dnsrecord %s: %v", wildcardRecordName, err)
 	}
 

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -68,8 +68,8 @@ func assertCRDExists(t *testing.T, crdname string) ([]string, error) {
 	name := types.NamespacedName{Namespace: "", Name: crdname}
 	crdVersions := []string{}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, name, crd); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, crd); err != nil {
 			t.Logf("failed to get crd %s: %v", name, err)
 			return false, nil
 		}
@@ -97,8 +97,8 @@ func deleteExistingCRD(t *testing.T, crdName string) error {
 	newCRD := &apiextensionsv1.CustomResourceDefinition{}
 	name := types.NamespacedName{Namespace: "", Name: crdName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, name, crd); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, crd); err != nil {
 			t.Logf("failed to get crd %s: %v", name, err)
 			return false, nil
 		}
@@ -145,8 +145,8 @@ func deleteExistingVAP(t *testing.T, vapName string) error {
 	name := types.NamespacedName{Name: vapName}
 
 	// Retrieve the object to be deleted.
-	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, name, vap); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, vap); err != nil {
 			t.Logf("failed to get vap %q: %v, retrying ...", vapName, err)
 			return false, nil
 		}
@@ -194,17 +194,17 @@ func createHttpRoute(t *testing.T, namespace, routeName, parentNamespace, hostna
 	// The http route, service, and pod are cleaned up when the namespace is automatically deleted.
 	// buildEchoReplicaSet builds a replicaset which creates a pod that listens on port 8080.
 	echoRs := buildEchoReplicaSet(backendRefname, namespace)
-	if err := createWithRetryOnError(t, context.TODO(), echoRs, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.TODO(), echoRs, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create replicaset %s/%s: %v", namespace, echoRs.Name, err)
 	}
 	// buildEchoService builds a service that targets port 8080.
 	echoService := buildEchoService(echoRs.Name, namespace, echoRs.Spec.Template.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.TODO(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.TODO(), echoService, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 
 	httpRoute := buildHTTPRoute(routeName, namespace, gateway.Name, parentNamespace, hostname, backendRefname)
-	if err := createOrGetWithRetry(t, context.Background(), httpRoute, 2*time.Minute); err != nil {
+	if err := createOrGetWithRetry(t, context.Background(), httpRoute, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create http route: %v", err)
 	}
 	return httpRoute, nil
@@ -215,7 +215,7 @@ func createHttpRoute(t *testing.T, namespace, routeName, parentNamespace, hostna
 func createGateway(t *testing.T, gatewayClass *gatewayapiv1.GatewayClass, name, namespace, domain string) (*gatewayapiv1.Gateway, error) {
 	t.Helper()
 	gateway := buildGateway(name, namespace, gatewayClass.Name, allNamespaces, domain)
-	if err := createOrGetWithRetry(t, context.Background(), gateway, 2*time.Minute); err != nil {
+	if err := createOrGetWithRetry(t, context.Background(), gateway, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create gateway: %v", err)
 	}
 	return gateway, nil
@@ -257,7 +257,7 @@ func createGatewayWithListeners(t *testing.T, gatewayClass *gatewayapiv1.Gateway
 		},
 	}
 
-	if err := createWithRetryOnError(t, context.TODO(), gateway, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.TODO(), gateway, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create gateway %s: %v", name, err.Error())
 	}
 
@@ -283,7 +283,7 @@ func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv
 		}
 	}
 	nsName := types.NamespacedName{Namespace: "", Name: name}
-	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(t.Context(), 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		if err := kclient.Create(ctx, gatewayClass); err != nil {
 			if kerrors.IsAlreadyExists(err) {
 				if err := kclient.Get(ctx, nsName, gatewayClass); err != nil {
@@ -307,7 +307,7 @@ func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv
 func createCRD(t *testing.T, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	t.Helper()
 	crd := buildGWAPICRDFromName(name)
-	if err := createOrGetWithRetry(t, context.Background(), crd, 2*time.Minute); err != nil {
+	if err := createOrGetWithRetry(t, context.Background(), crd, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create crd %q: %w", name, err)
 	}
 	return crd, nil
@@ -440,8 +440,8 @@ func assertSubscription(t *testing.T, namespace, subName string) error {
 	subscription := &operatorsv1alpha1.Subscription{}
 	nsName := types.NamespacedName{Namespace: namespace, Name: subName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, subscription); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, subscription); err != nil {
 			t.Logf("failed to get subscription %s, retrying...", subName)
 			return false, nil
 		}
@@ -458,8 +458,8 @@ func assertNoSubscription(t *testing.T, namespace, subName string) error {
 	subscription := &operatorsv1alpha1.Subscription{}
 	nsName := types.NamespacedName{Namespace: namespace, Name: subName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, subscription); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, subscription); err != nil {
 			if kerrors.IsNotFound(err) {
 				t.Logf("verified that subscription %s does not exist (as expected)", subName)
 				return true, nil
@@ -480,8 +480,8 @@ func deleteExistingSubscription(t *testing.T, namespace, subName string) error {
 	newSubscription := &operatorsv1alpha1.Subscription{}
 	nsName := types.NamespacedName{Namespace: namespace, Name: subName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, existingSubscription); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, existingSubscription); err != nil {
 			t.Logf("failed to get Subscription %s: %v", nsName.Name, err)
 			return false, nil
 		}
@@ -526,8 +526,8 @@ func assertOSSMOperator(t *testing.T) error {
 	ns := types.NamespacedName{Namespace: openshiftOperatorsNamespace, Name: openshiftIstioOperatorDeploymentName}
 
 	// Get the Istio operator deployment.
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, ns, dep); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, ns, dep); err != nil {
 			t.Logf("failed to get deployment %v, retrying...", ns)
 			return false, nil
 		}
@@ -562,8 +562,8 @@ func assertIstiodControlPlane(t *testing.T) error {
 	ns := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: openshiftIstiodDeploymentName}
 
 	// Get the Istiod deployment.
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, ns, dep); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, ns, dep); err != nil {
 			t.Logf("failed to get deployment %v, retrying...", ns)
 			return false, nil
 		}
@@ -631,8 +631,8 @@ func assertIstiodControlPlaneRemoved(t *testing.T) error {
 	dep := &appsv1.Deployment{}
 	ns := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: openshiftIstiodDeploymentName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, ns, dep); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, ns, dep); err != nil {
 			if kerrors.IsNotFound(err) {
 				t.Logf("verified that istiod deployment %v has been removed", ns)
 				return true, nil
@@ -663,8 +663,8 @@ func assertGatewayClassSuccessful(t *testing.T, name string) (*gatewayapiv1.Gate
 	// OSSM installation pipeline to complete first: Subscription creation,
 	// OSSM operator installation, Istio CR creation, and Istiod deployment.
 	// This chain can take several minutes, especially on slower platforms.
-	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, gwc); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, gwc); err != nil {
 			t.Logf("Failed to get gatewayclass %s: %v; retrying...", name, err)
 			return false, nil
 		}
@@ -701,8 +701,8 @@ func assertGatewaySuccessful(t *testing.T, namespace, name string) (*gatewayapiv
 	// Wait for the gateway to be accepted and programmed.
 	// Load balancer provisioning can take several minutes on some platforms.
 	// Therefore, a timeout of 5 minutes is set to accommodate potential delays.
-	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, gw); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, gw); err != nil {
 			t.Logf("Failed to get gateway %v: %v; retrying...", nsName, err)
 			return false, nil
 		}
@@ -735,7 +735,7 @@ func assertGatewaySuccessful(t *testing.T, namespace, name string) (*gatewayapiv
 		// Check the current status of the service to see where we are.
 		svc := &corev1.Service{}
 		svcNsName := types.NamespacedName{Namespace: namespace, Name: gw.Name + "-" + string(gw.Spec.GatewayClassName)}
-		if err := kclient.Get(context, svcNsName, svc); err != nil {
+		if err := kclient.Get(ctx, svcNsName, svc); err != nil {
 			t.Logf("Failed to get gateway service %v: %v; retrying...", svcNsName, err)
 			return false, nil
 		}
@@ -767,8 +767,8 @@ func assertHorizontalPodAutoscalerEnabled(t *testing.T, namespaceName, gatewayNa
 		Name:      gatewayName,
 	}
 	t.Logf("Getting HorizontalPodAutoscaler %s for Gateway %s...", hpaName, gatewayNamespacedName)
-	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, hpaName, &hpa); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, hpaName, &hpa); err != nil {
 			t.Logf("Failed to get HorizontalPodAutoscaler %s: %v; retrying...", hpaName, err)
 
 			return false, nil
@@ -798,24 +798,20 @@ func waitForGatewayListenerCondition(t *testing.T, gatewayName types.NamespacedN
 	expected := gatewayListenerConditionMap(conditions...)
 	current := map[string]string{}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, gatewayName, gateway); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, gatewayName, gateway); err != nil {
 			t.Logf("failed to get gateway %s, retrying...", gatewayName.Name)
 			return false, nil
 		}
 
-		listenerStatus := gatewayapiv1.ListenerStatus{}
 		for _, ls := range gateway.Status.Listeners {
 			if string(ls.Name) == listenerName {
-				listenerStatus = ls
-				current = gatewayListenerConditionMap(listenerStatus.Conditions...)
+				current = gatewayListenerConditionMap(ls.Conditions...)
 				return conditionsMatchExpected(expected, current), nil
 			}
 		}
-		if &listenerStatus == nil {
-			t.Logf("gateway %s's listener %s has not been updated with status, retrying...", gatewayName.Name, listenerName)
-			return false, nil
-		}
+
+		t.Logf("gateway %s's listener %s has not been updated with status, retrying...", gatewayName.Name, listenerName)
 		return false, nil
 	})
 
@@ -857,13 +853,13 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]b
 
 	var expectationsMet bool
 
-	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
 		haveExpectNotPresent := false
 		// expectationsMet starts true and gets set to false when some expectation is not met.
 		expectationsMet = true
 
 		dnsRecords := &v1.DNSRecordList{}
-		if err := kclient.List(context, dnsRecords, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
+		if err := kclient.List(ctx, dnsRecords, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
 			t.Logf("failed to list DNSRecords: %v, retrying...", err)
 			return false, nil
 		}
@@ -943,8 +939,8 @@ func assertHttpRouteSuccessful(t *testing.T, namespace, name string, gateway *ga
 	nsName := types.NamespacedName{Namespace: namespace, Name: name}
 
 	// Wait 1 minute for parent/s to update
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, httproute); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, httproute); err != nil {
 			t.Logf("Failed to get httproute %v: %v; retrying...", nsName, err)
 			return false, nil
 		}
@@ -1029,7 +1025,7 @@ func assertHttpRouteConnection(t *testing.T, hostname string, gateway *gatewayap
 		// if the hostname is actually an IP address, skip this.
 		if net.ParseIP(hostname) == nil {
 			t.Logf("Attempting to resolve %s...", hostname)
-			if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, dnsResolutionTimeout, false, func(context context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, dnsResolutionTimeout, false, func(ctx context.Context) (bool, error) {
 				_, err := net.LookupHost(hostname)
 				if err != nil {
 					t.Logf("%v waiting for HTTP route name %s to resolve (%v)", time.Now(), hostname, err)
@@ -1081,7 +1077,7 @@ func assertHttpRouteConnection(t *testing.T, hostname string, gateway *gatewayap
 		headers    http.Header
 	)
 	t.Logf("Probing %s...", hostname)
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		var err error
 		statusCode, headers, body, err = getHTTPResponse(client, hostname)
 		if err != nil {
@@ -1130,8 +1126,8 @@ func assertCatalogSource(t *testing.T, namespace, csName string) error {
 	catalogSource := &operatorsv1alpha1.CatalogSource{}
 	nsName := types.NamespacedName{Namespace: namespace, Name: csName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, catalogSource); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, catalogSource); err != nil {
 			t.Logf("Failed to get CatalogSource %s: %v.  Retrying...", csName, err)
 			return false, nil
 		}
@@ -1152,8 +1148,8 @@ func assertIstio(t *testing.T) error {
 	istio := &sailv1.Istio{}
 	nsName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: openshiftIstioName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 3*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, istio); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, istio); err != nil {
 			t.Logf("Failed to get Istio %s/%s: %v.  Retrying...", nsName.Namespace, nsName.Name, err)
 			return false, nil
 		}
@@ -1174,8 +1170,8 @@ func assertNoIstio(t *testing.T) error {
 	istio := &sailv1.Istio{}
 	nsName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: openshiftIstioName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, istio); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, istio); err != nil {
 			if kerrors.IsNotFound(err) {
 				t.Logf("Verified that Istio %s/%s does not exist (as expected)", nsName.Namespace, nsName.Name)
 				return true, nil
@@ -1200,8 +1196,8 @@ func deleteExistingIstio(t *testing.T) error {
 	newIstio := &sailv1.Istio{}
 	nsName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: openshiftIstioName}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, existingIstio); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, existingIstio); err != nil {
 			t.Logf("Failed to get Istio %s: %v", nsName.Name, err)
 			return false, nil
 		}
@@ -1248,8 +1244,8 @@ func assertGatewayClassFinalizer(t *testing.T, name string) error {
 	nsName := types.NamespacedName{Namespace: "", Name: name}
 	expectedFinalizer := "openshift.io/ingress-operator-sail-finalizer"
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, gwc); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, gwc); err != nil {
 			t.Logf("Failed to get GatewayClass %s: %v; retrying...", name, err)
 			return false, nil
 		}
@@ -1275,8 +1271,8 @@ func assertGatewayClassConditions(t *testing.T, name string) error {
 	gwc := &gatewayapiv1.GatewayClass{}
 	nsName := types.NamespacedName{Namespace: "", Name: name}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, nsName, gwc); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, nsName, gwc); err != nil {
 			t.Logf("Failed to get GatewayClass %s: %v; retrying...", name, err)
 			return false, nil
 		}
@@ -1331,8 +1327,8 @@ func assertDNSRecord(t *testing.T, recordName types.NamespacedName) error {
 	t.Helper()
 	dnsRecord := &v1.DNSRecord{}
 
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, recordName, dnsRecord); err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, recordName, dnsRecord); err != nil {
 			t.Logf("[%s] Failed to get DNSRecord %v: %v; retrying...", time.Now().Format(time.DateTime), recordName, err)
 			return false, nil
 		}
@@ -1365,8 +1361,8 @@ func assertVAP(t *testing.T, name string) error {
 	vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
 	// Re-creation of VAP can take some time especially after CVO is scaled back up.
 	// Use a large timeout of 5 minutes to avoid flakes.
-	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
-		if err := kclient.Get(context, types.NamespacedName{Name: name}, vap); err != nil {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, types.NamespacedName{Name: name}, vap); err != nil {
 			t.Logf("failed to get vap %q: %v, retrying...", name, err)
 			return false, nil
 		}
@@ -1380,15 +1376,15 @@ func scaleDeployment(t *testing.T, namespace, name string, replicas int32) error
 	t.Helper()
 
 	nsName := types.NamespacedName{Namespace: namespace, Name: name}
-	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 120*time.Second, false, func(context context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
 		depl := &appsv1.Deployment{}
-		if err := kclient.Get(context, nsName, depl); err != nil {
+		if err := kclient.Get(ctx, nsName, depl); err != nil {
 			t.Logf("failed to get deployment %q: %v, retrying...", nsName, err)
 			return false, nil
 		}
 		if *depl.Spec.Replicas != replicas {
 			depl.Spec.Replicas = &replicas
-			if err := kclient.Update(context, depl); err != nil {
+			if err := kclient.Update(ctx, depl); err != nil {
 				t.Logf("failed to update deployment %q: %v, retrying...", nsName, err)
 				return false, nil
 			}
@@ -1511,7 +1507,7 @@ func containsPolicyRules(destRules, srcRules []rbacv1.PolicyRule) bool {
 // and retry
 func updateGatewaySpecWithRetry(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*gatewayapiv1.GatewaySpec)) error {
 	gw := gatewayapiv1.Gateway{}
-	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		if err := kclient.Get(ctx, name, &gw); err != nil {
 			t.Logf("error getting gateway resource %v: %v, retrying...", name, err)
 			return false, nil

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -204,34 +204,19 @@ func createHttpRoute(t *testing.T, namespace, routeName, parentNamespace, hostna
 	}
 
 	httpRoute := buildHTTPRoute(routeName, namespace, gateway.Name, parentNamespace, hostname, backendRefname)
-	if err := kclient.Create(context.TODO(), httpRoute); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			name := types.NamespacedName{Namespace: namespace, Name: routeName}
-			if err = kclient.Get(context.TODO(), name, httpRoute); err == nil {
-				return httpRoute, nil
-			} else {
-				return nil, fmt.Errorf("failed to access existing http route: %v", err.Error())
-			}
-		} else {
-			return nil, fmt.Errorf("failed to create http route: %v", err.Error())
-		}
+	if err := createOrGetWithRetry(t, context.Background(), httpRoute, 2*time.Minute); err != nil {
+		return nil, fmt.Errorf("failed to create http route: %v", err)
 	}
 	return httpRoute, nil
 }
 
 // createGateway checks if the Gateway can be created.
 // If it can, it is returned.  If it can't an error is returned.
-func createGateway(gatewayClass *gatewayapiv1.GatewayClass, name, namespace, domain string) (*gatewayapiv1.Gateway, error) {
+func createGateway(t *testing.T, gatewayClass *gatewayapiv1.GatewayClass, name, namespace, domain string) (*gatewayapiv1.Gateway, error) {
+	t.Helper()
 	gateway := buildGateway(name, namespace, gatewayClass.Name, allNamespaces, domain)
-	if err := kclient.Create(context.TODO(), gateway); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			name := types.NamespacedName{Namespace: namespace, Name: name}
-			if err = kclient.Get(context.TODO(), name, gateway); err != nil {
-				return nil, fmt.Errorf("failed to get the existing gateway: %v", err.Error())
-			}
-		} else {
-			return nil, fmt.Errorf("failed to create gateway: %v", err.Error())
-		}
+	if err := createOrGetWithRetry(t, context.Background(), gateway, 2*time.Minute); err != nil {
+		return nil, fmt.Errorf("failed to create gateway: %v", err)
 	}
 	return gateway, nil
 }
@@ -319,15 +304,10 @@ func createGatewayClass(t *testing.T, name, controllerName string) (*gatewayapiv
 }
 
 // createCRD creates the CRD with the given name or retrieves it if already exists.
-func createCRD(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+func createCRD(t *testing.T, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	t.Helper()
 	crd := buildGWAPICRDFromName(name)
-	if err := kclient.Create(context.Background(), crd); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			if err := kclient.Get(context.Background(), types.NamespacedName{Name: name}, crd); err != nil {
-				return nil, fmt.Errorf("failed to get crd %q: %w", name, err)
-			}
-			return crd, nil
-		}
+	if err := createOrGetWithRetry(t, context.Background(), crd, 2*time.Minute); err != nil {
 		return nil, fmt.Errorf("failed to create crd %q: %w", name, err)
 	}
 	return crd, nil

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -816,7 +816,7 @@ func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
 	t.Helper()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := kclient.Delete(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+		if err := kclient.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
 			t.Logf("error deleting %s: %v, retrying...", obj.GetName(), err)
 			return false, nil
 		}
@@ -837,7 +837,7 @@ func verifyExternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -847,7 +847,7 @@ func verifyExternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -857,7 +857,7 @@ func verifyExternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -918,7 +918,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Fatalf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
+			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 		}
 	}()
 
@@ -928,7 +928,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Fatalf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
+			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 		}
 	}()
 
@@ -938,7 +938,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 	defer func() {
 		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Fatalf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
+			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 		}
 	}()
 
@@ -963,7 +963,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 			if errors.IsNotFound(err) {
 				return
 			}
-			t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
+			t.Errorf("failed to delete pod %q: %v", clientPodName, err)
 		}
 	}()
 
@@ -1004,12 +1004,14 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 		// If failed or succeeded, the pod is stopped, but didn't provide us 200 response, let's try again.
 		if clientPod.Status.Phase == corev1.PodFailed || clientPod.Status.Phase == corev1.PodSucceeded {
 			t.Logf("client pod %q has stopped...restarting. Curl Pod Logs:\n%s", clientPodName, curlPodLogs)
-			if err := kclient.Delete(context.TODO(), clientPod); err != nil && errors.IsNotFound(err) {
+			if err := kclient.Delete(context.TODO(), clientPod); err != nil && !errors.IsNotFound(err) {
 				t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
 			}
-			// Wait for deletion to prevent a race condition. Use PollInfinite since we are already in a Poll.
-			wait.PollInfinite(5*time.Second, func() (bool, error) {
-				err = kclient.Get(context.TODO(), clientPodName, clientPod)
+			// Wait for deletion to prevent a race condition.
+			deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer deleteCancel()
+			wait.PollUntilContextTimeout(deleteCtx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				err = kclient.Get(ctx, clientPodName, clientPod)
 				if !errors.IsNotFound(err) {
 					t.Logf("waiting for %q: to be deleted", clientPodName)
 					return false, nil

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -616,16 +616,41 @@ func updateIngressControllerWithRetryOnConflict(t *testing.T, name types.Namespa
 // there is a conflict error on update then the complete operation of
 // get, mutate, and update is retried until timeout is reached.
 func updateIngressConfigSpecWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*configv1.IngressSpec)) error {
+	t.Helper()
 	ingressConfig := configv1.Ingress{}
-	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		if err := kclient.Get(context.TODO(), name, &ingressConfig); err != nil {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, &ingressConfig); err != nil {
 			t.Logf("error getting ingress config %v: %v, retrying...", name, err)
 			return false, nil
 		}
 		mutateSpecFn(&ingressConfig.Spec)
-		if err := kclient.Update(context.TODO(), &ingressConfig); err != nil {
+		if err := kclient.Update(ctx, &ingressConfig); err != nil {
 			if errors.IsConflict(err) {
 				t.Logf("conflict when updating ingress config %v: %v, retrying...", name, err)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// updateIngressConfigSstatusWithRetryOnConflict gets a fresh copy of the
+// name ingress config, calls updateSpecFn() where callers can modify
+// fields of the status, and then updates the ingress config object. If
+// there is a conflict error on update then the complete operation of
+// get, mutate, and update is retried until timeout is reached.
+func updateIngressConfigSstatusWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*configv1.IngressStatus)) error {
+	ingressConfig := configv1.Ingress{}
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, name, &ingressConfig); err != nil {
+			t.Logf("error getting ingress config %v: %v, retrying...", name, err)
+			return false, nil
+		}
+		mutateSpecFn(&ingressConfig.Status)
+		if err := kclient.Status().Update(ctx, &ingressConfig); err != nil {
+			if errors.IsConflict(err) {
+				t.Logf("conflict when updating ingress status %v: %v, retrying...", name, err)
 				return false, nil
 			}
 			return false, err
@@ -813,15 +838,17 @@ func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 
 // deleteWithRetryOnError will try to delete the object until the timeout occurs.
 // Use for retrying operations that may be flaky due to network issues.
-func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
+func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) {
 	t.Helper()
-	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		if err := kclient.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
 			t.Logf("error deleting %s: %v, retrying...", obj.GetName(), err)
 			return false, nil
 		}
 		return true, nil
-	})
+	}); err != nil {
+		t.Errorf("failed waiting resource %s/%s to be deleted: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
 }
 
 // verifyExternalIngressController verifies connectivity between the router
@@ -835,31 +862,19 @@ func verifyExternalIngressController(t *testing.T, name types.NamespacedName, ho
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	// If we have a DNS as an external IP address, make sure we can resolve it before moving on.
 	// This just limits the number of "could not resolve host" errors which can be confusing.
@@ -916,31 +931,19 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	if err := kclient.Create(context.TODO(), echoPod); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoPod); err != nil {
-			t.Errorf("failed to delete pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
 	if err := kclient.Create(context.TODO(), echoService); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoService); err != nil {
-			t.Errorf("failed to delete service %s/%s: %v", echoService.Namespace, echoService.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
 	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), echoRoute); err != nil {
-			t.Errorf("failed to delete route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
 
 	// Since we've created a new IngressController, and we are about to use a curl pod to query the
 	// wildcard DNS record, we need to wait for platforms that require a warmup period for internal queries.
@@ -958,18 +961,16 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	if err := kclient.Create(context.TODO(), clientPod); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
-	defer func() {
-		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			t.Errorf("failed to delete pod %q: %v", clientPodName, err)
-		}
-	}()
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
 
 	var curlPodLogs string
-	err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
-		if err := kclient.Get(context.TODO(), clientPodName, clientPod); err != nil {
+
+	// This loop will try, for 10 minutes, to get the client pod used to test the connectivity
+	// and execute the test until it passes.
+	// In case there is an error with the Pod creation, it will enter on another loop
+	// of maximum 5 minutes to delete and wait for this pod to be deleted before continuing
+	err = wait.PollUntilContextTimeout(t.Context(), 10*time.Second, 10*time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, clientPodName, clientPod); err != nil {
 			t.Logf("error getting client pod %q: %v, retrying...", clientPodName, err)
 			return false, nil
 		}
@@ -1007,10 +1008,10 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 			if err := kclient.Delete(context.TODO(), clientPod); err != nil && !errors.IsNotFound(err) {
 				t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
 			}
-			// Wait for deletion to prevent a race condition.
-			deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer deleteCancel()
-			wait.PollUntilContextTimeout(deleteCtx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+
+			// Wait for the Pod to be deleted. In case it is not deleted,
+			// try getting again until the Pod is gone, before moving
+			wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 				err = kclient.Get(ctx, clientPodName, clientPod)
 				if !errors.IsNotFound(err) {
 					t.Logf("waiting for %q: to be deleted", clientPodName)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -635,19 +635,19 @@ func updateIngressConfigSpecWithRetryOnConflict(t *testing.T, name types.Namespa
 	})
 }
 
-// updateIngressConfigSstatusWithRetryOnConflict gets a fresh copy of the
-// name ingress config, calls updateSpecFn() where callers can modify
+// updateIngressConfigStatusWithRetryOnConflict gets a fresh copy of the
+// named ingress config, calls mutateStatusFn() where callers can modify
 // fields of the status, and then updates the ingress config object. If
 // there is a conflict error on update then the complete operation of
 // get, mutate, and update is retried until timeout is reached.
-func updateIngressConfigSstatusWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateSpecFn func(*configv1.IngressStatus)) error {
+func updateIngressConfigStatusWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateStatusFn func(*configv1.IngressStatus)) error {
 	ingressConfig := configv1.Ingress{}
 	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		if err := kclient.Get(ctx, name, &ingressConfig); err != nil {
 			t.Logf("error getting ingress config %v: %v, retrying...", name, err)
 			return false, nil
 		}
-		mutateSpecFn(&ingressConfig.Status)
+		mutateStatusFn(&ingressConfig.Status)
 		if err := kclient.Status().Update(ctx, &ingressConfig); err != nil {
 			if errors.IsConflict(err) {
 				t.Logf("conflict when updating ingress status %v: %v, retrying...", name, err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -837,6 +837,28 @@ func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 	})
 }
 
+// createOrGetWithRetry creates the given object. If the object already exists,
+// it fetches the existing object to populate server-side fields. If there is a
+// transient error, the operation is retried until the timeout is reached.
+func createOrGetWithRetry(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
+	t.Helper()
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		if err := kclient.Create(ctx, obj); err != nil {
+			if errors.IsAlreadyExists(err) {
+				key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+				if err := kclient.Get(ctx, key, obj); err != nil {
+					t.Logf("error getting existing %s: %v, retrying...", obj.GetName(), err)
+					return false, nil
+				}
+				return true, nil
+			}
+			t.Logf("error creating %s: %v, retrying...", obj.GetName(), err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 // deleteWithRetryOnError will try to delete the object until the timeout occurs.
 // Use for retrying operations that may be flaky due to network issues.
 func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) {
@@ -1023,7 +1045,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 				t.Logf("timed out waiting for pod %q to be deleted; will attempt recreation: %v", clientPodName, err)
 			}
 			clientPod = clientPodSpec.DeepCopy()
-			if err := kclient.Create(context.TODO(), clientPod); err != nil {
+			if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 			}
 			return false, nil
@@ -1128,7 +1150,7 @@ func createNamespace(t *testing.T, name string) *corev1.Namespace {
 
 	t.Logf("Creating namespace %q...", name)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if err := kclient.Create(context.TODO(), ns); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() {
@@ -1137,9 +1159,7 @@ func createNamespace(t *testing.T, name string) *corev1.Namespace {
 			dumpEventsInNamespace(t, name)
 		}
 		t.Logf("Deleting namespace %q...", name)
-		if err := kclient.Delete(context.TODO(), ns); err != nil {
-			t.Errorf("failed to delete namespace %s: %v", ns.Name, err)
-		}
+		deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute)
 	})
 
 	saName := types.NamespacedName{

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -641,6 +641,7 @@ func updateIngressConfigSpecWithRetryOnConflict(t *testing.T, name types.Namespa
 // there is a conflict error on update then the complete operation of
 // get, mutate, and update is retried until timeout is reached.
 func updateIngressConfigStatusWithRetryOnConflict(t *testing.T, name types.NamespacedName, timeout time.Duration, mutateStatusFn func(*configv1.IngressStatus)) error {
+	t.Helper()
 	ingressConfig := configv1.Ingress{}
 	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		if err := kclient.Get(ctx, name, &ingressConfig); err != nil {
@@ -1011,14 +1012,16 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 
 			// Wait for the Pod to be deleted. In case it is not deleted,
 			// try getting again until the Pod is gone, before moving
-			wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 				err = kclient.Get(ctx, clientPodName, clientPod)
 				if !errors.IsNotFound(err) {
 					t.Logf("waiting for %q: to be deleted", clientPodName)
 					return false, nil
 				}
 				return true, nil
-			})
+			}); err != nil {
+				t.Logf("timed out waiting for pod %q to be deleted; will attempt recreation: %v", clientPodName, err)
+			}
 			clientPod = clientPodSpec.DeepCopy()
 			if err := kclient.Create(context.TODO(), clientPod); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -677,7 +677,7 @@ func updateAndVerifyInfrastructureConfigWithRetry(t *testing.T, name types.Names
 			return false, nil
 		}
 		mutateSpecFn(&infraConfig.Spec)
-		if err := kclient.Update(context.TODO(), &infraConfig); err != nil {
+		if err := kclient.Update(ctx, &infraConfig); err != nil {
 			t.Logf("error updating infrastructure config %v: %v, retrying...", name, err)
 			return false, nil
 		}
@@ -760,7 +760,7 @@ func waitForCCMAvailableAndUpdated(t *testing.T, timeout time.Duration, oldConfi
 	// is successful
 	ccmDeployment := appsv1.Deployment{}
 	if err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, timeout, false, func(ctx context.Context) (done bool, err error) {
-		if err := kclient.Get(context.TODO(), ccmDeploymentName, &ccmDeployment); err != nil {
+		if err := kclient.Get(ctx, ccmDeploymentName, &ccmDeployment); err != nil {
 			t.Logf("error getting CCM deployment: %v", err)
 			return false, nil
 		}
@@ -891,22 +891,22 @@ func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 func verifyExternalIngressController(t *testing.T, name types.NamespacedName, hostname, address string) {
 	t.Helper()
 	echoPod := buildEchoPod(name.Name, name.Namespace)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	// If we have a DNS as an external IP address, make sure we can resolve it before moving on.
 	// This just limits the number of "could not resolve host" errors which can be confusing.
@@ -960,22 +960,22 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 
 	echoPod := buildEchoPod(name.Name, name.Namespace)
-	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, DefaultRetryTimeout) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, DefaultRetryTimeout) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
-	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, DefaultRetryTimeout) })
 
 	// Since we've created a new IngressController, and we are about to use a curl pod to query the
 	// wildcard DNS record, we need to wait for platforms that require a warmup period for internal queries.
@@ -990,10 +990,10 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	clientPodName := types.NamespacedName{Namespace: name.Namespace, Name: "curl-" + name.Name}
 	clientPodSpec := buildCurlPod(clientPodName.Name, clientPodName.Namespace, image, address, echoRoute.Spec.Host, extraArgs...)
 	clientPod := clientPodSpec.DeepCopy()
-	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
-	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })
+	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
 	var curlPodLogs string
 
@@ -1014,7 +1014,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 		readCloser, err := client.CoreV1().Pods(clientPod.Namespace).GetLogs(clientPod.Name, &corev1.PodLogOptions{
 			Container: "curl",
 			Follow:    false,
-		}).Stream(context.TODO())
+		}).Stream(ctx)
 		if err != nil {
 			t.Logf("failed to read output from pod %s: %v", clientPod.Name, err)
 			return false, nil
@@ -1037,13 +1037,13 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 		// If failed or succeeded, the pod is stopped, but didn't provide us 200 response, let's try again.
 		if clientPod.Status.Phase == corev1.PodFailed || clientPod.Status.Phase == corev1.PodSucceeded {
 			t.Logf("client pod %q has stopped...restarting. Curl Pod Logs:\n%s", clientPodName, curlPodLogs)
-			if err := kclient.Delete(context.TODO(), clientPod); err != nil && !errors.IsNotFound(err) {
+			if err := kclient.Delete(ctx, clientPod); err != nil && !errors.IsNotFound(err) {
 				t.Fatalf("failed to delete pod %q: %v", clientPodName, err)
 			}
 
 			// Wait for the Pod to be deleted. In case it is not deleted,
 			// try getting again until the Pod is gone, before moving
-			if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, DefaultRetryTimeout, true, func(ctx context.Context) (bool, error) {
 				err = kclient.Get(ctx, clientPodName, clientPod)
 				if !errors.IsNotFound(err) {
 					t.Logf("waiting for %q: to be deleted", clientPodName)
@@ -1054,7 +1054,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 				t.Logf("timed out waiting for pod %q to be deleted; will attempt recreation: %v", clientPodName, err)
 			}
 			clientPod = clientPodSpec.DeepCopy()
-			if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
+			if err := createWithRetryOnError(t, ctx, clientPod, DefaultRetryTimeout); err != nil {
 				t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 			}
 			return false, nil
@@ -1098,7 +1098,7 @@ func assertDeletedWaitForCleanup(t *testing.T, cl client.Client, thing client.Ob
 		Namespace: thing.GetNamespace(),
 	}
 	assertDeleted(t, cl, thing)
-	if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, DefaultRetryTimeout, func() (bool, error) {
 		if err := cl.Get(context.TODO(), thingName, thing); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -1159,7 +1159,7 @@ func createNamespace(t *testing.T, name string) *corev1.Namespace {
 
 	t.Logf("Creating namespace %q...", name)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if err := createWithRetryOnError(t, context.Background(), ns, 2*time.Minute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create namespace: %v", err)
 	}
 	t.Cleanup(func() {
@@ -1168,7 +1168,7 @@ func createNamespace(t *testing.T, name string) *corev1.Namespace {
 			dumpEventsInNamespace(t, name)
 		}
 		t.Logf("Deleting namespace %q...", name)
-		deleteWithRetryOnError(t, context.Background(), ns, 2*time.Minute)
+		deleteWithRetryOnError(t, context.Background(), ns, DefaultRetryTimeout)
 	})
 
 	saName := types.NamespacedName{
@@ -1285,7 +1285,7 @@ func recreateIngressControllerService(t *testing.T, ic *operatorv1.IngressContro
 
 	// Wait for the service to be recreated by Ingress Operator.
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
-		if err := kclient.Get(context.Background(), controller.LoadBalancerServiceName(ic), lbService); err != nil {
+		if err := kclient.Get(ctx, controller.LoadBalancerServiceName(ic), lbService); err != nil {
 			t.Logf("failed to get service %s/%s: %v, retrying ...", serviceName.Namespace, serviceName.Namespace, err)
 			return false, nil
 		}
@@ -1342,7 +1342,7 @@ func waitForIngressControllerServiceDeleted(t *testing.T, ic *operatorv1.Ingress
 	serviceName := controller.LoadBalancerServiceName(ic)
 
 	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
-		if err := kclient.Get(context.TODO(), serviceName, lbService); err != nil {
+		if err := kclient.Get(ctx, serviceName, lbService); err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -860,19 +860,19 @@ func deleteWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object
 func verifyExternalIngressController(t *testing.T, name types.NamespacedName, hostname, address string) {
 	t.Helper()
 	echoPod := buildEchoPod(name.Name, name.Namespace)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -929,19 +929,19 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	}
 
 	echoPod := buildEchoPod(name.Name, name.Namespace)
-	if err := kclient.Create(context.TODO(), echoPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", echoPod.Namespace, echoPod.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoPod, 2*time.Minute) })
 
 	echoService := buildEchoService(echoPod.Name, echoPod.Namespace, echoPod.ObjectMeta.Labels)
-	if err := kclient.Create(context.TODO(), echoService); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoService, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create service %s/%s: %v", echoService.Namespace, echoService.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoService, 2*time.Minute) })
 
 	echoRoute := buildRouteWithHost(echoPod.Name, echoPod.Namespace, echoService.Name, hostname)
-	if err := kclient.Create(context.TODO(), echoRoute); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create route %s/%s: %v", echoRoute.Namespace, echoRoute.Name, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), echoRoute, 2*time.Minute) })
@@ -959,7 +959,7 @@ func verifyInternalIngressController(t *testing.T, name types.NamespacedName, ho
 	clientPodName := types.NamespacedName{Namespace: name.Namespace, Name: "curl-" + name.Name}
 	clientPodSpec := buildCurlPod(clientPodName.Name, clientPodName.Namespace, image, address, echoRoute.Spec.Host, extraArgs...)
 	clientPod := clientPodSpec.DeepCopy()
-	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+	if err := createWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute); err != nil {
 		t.Fatalf("failed to create pod %q: %v", clientPodName, err)
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, 2*time.Minute) })

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -826,10 +826,19 @@ func updateInfrastructureConfigStatusWithRetryOnConflict(t *testing.T, timeout t
 
 // createWithRetryOnError creates the given object. If there is an error on create
 // apart from "AlreadyExists" then the create is retried until the timeout is reached.
+// AlreadyExists is treated as success because this helper is used in verification
+// functions (verifyExternalIngressController, verifyInternalIngressController) that
+// may be called multiple times for the same IngressController. For first-time
+// resource creation where AlreadyExists indicates test pollution, prefer using
+// kclient.Create directly or createOrGetWithRetry (which populates server-side fields).
 func createWithRetryOnError(t *testing.T, ctx context.Context, obj client.Object, timeout time.Duration) error {
 	t.Helper()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := kclient.Create(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+		if err := kclient.Create(ctx, obj); err != nil {
+			if errors.IsAlreadyExists(err) {
+				t.Logf("resource %s already exists, treating as success", obj.GetName())
+				return true, nil
+			}
 			t.Logf("error creating %s: %v, retrying...", obj.GetName(), err)
 			return false, nil
 		}


### PR DESCRIPTION
**What**

  Fix multiple correctness bugs and resource leak patterns in e2e tests that cause flakes, hangs, and test infrastructure pollution.

  **Why**

  A full codebase review identified several categories of e2e test defects:
  - Inverted error checks that silently swallow real failures or retry on the wrong conditions, masking bugs in the operator.
  - An unbounded wait.PollInfinite call that can hang a test run forever if pod deletion stalls.
  - A data race on a shared mutable counter (podCount) accessed by parallel tests without synchronization.
  - 75 instances of t.Fatalf called inside defer func() blocks, which invokes runtime.Goexit() and prevents subsequent defers from executing — leaking pods, services, routes, and namespaces in the test cluster.

  **Changes**

  - Fix inverted error check in deleteWithRetryOnError (util_test.go): Changed !errors.IsAlreadyExists(err) to !errors.IsNotFound(err) so that delete retries correctly ignore "not found" (already deleted) rather than "already
   exists" (nonsensical for delete).
  - Fix inverted error check in verifyInternalIngressController (util_test.go): Added missing negation ! before errors.IsNotFound(err) so cleanup delete correctly tolerates already-gone resources.
  - Replace wait.PollInfinite with bounded timeout (util_test.go): Switched to wait.PollUntilContextTimeout with a 2-minute deadline to prevent infinite hangs when pod deletion stalls.
  - Fix data race on shared podCount (set_delete_test.go): Changed var podCount int with non-atomic podCount++ to atomic.Int32 with podCount.Add(1), eliminating the race between parallel
  TestSetIngressControllerResponseHeaders and TestSetRouteResponseHeaders.
  - Replace t.Fatalf with t.Errorf in all defer cleanup blocks (10 files, 75 locations): t.Fatalf in a deferred function calls runtime.Goexit(), which aborts the goroutine and skips all remaining defers — leaking test
  resources. Switched to t.Errorf which logs the failure but allows cleanup to complete.