### PR TITLE
[release-4.20] OCPBUGS-85155: Fix e2e tests to work on platforms with unmanaged DNS

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -460,6 +460,10 @@ func testGatewayAPIRBAC(t *testing.T) {
 }
 
 func testGatewayAPIDNS(t *testing.T) {
+	if !isDNSManagementSupported(t) {
+		t.Skip("this test can be executed just on platforms that support managed DNS")
+	}
+
 	domain := "gws." + dnsConfig.Spec.BaseDomain
 
 	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
@@ -591,6 +595,10 @@ func testGatewayAPIDNS(t *testing.T) {
 }
 
 func testGatewayAPIDNSListenerUpdate(t *testing.T) {
+	if !isDNSManagementSupported(t) {
+		t.Skip("this test can be executed just on platforms that support managed DNS")
+	}
+
 	gatewayClass, err := createGatewayClass(operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
 	if err != nil {
 		t.Fatalf("failed to create gatewayclass: %v", err)

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"slices"
@@ -879,14 +879,6 @@ func assertHttpRouteSuccessful(t *testing.T, namespace, name string, gateway *ga
 func assertHttpRouteConnection(t *testing.T, hostname string, gateway *gatewayapiv1.Gateway) error {
 	domain := ""
 
-	// Create the http client to check the header.
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
 	// Get gateway listener hostname to use for dnsRecord.
 	if len(gateway.Spec.Listeners) > 0 {
 		if gateway.Spec.Listeners[0].Hostname != nil && len(string(*gateway.Spec.Listeners[0].Hostname)) > 0 {
@@ -896,28 +888,66 @@ func assertHttpRouteConnection(t *testing.T, hostname string, gateway *gatewayap
 			}
 		}
 	}
-	// Obtain the standard formatting of the dnsRecord.
-	dnsRecordName := operatorcontroller.GatewayDNSRecordName(gateway, domain)
 
-	t.Logf("Making sure DNSRecord %v for domain %q is ready to use...", dnsRecordName, domain)
-	if err := assertDNSRecord(t, dnsRecordName); err != nil {
-		return err
+	managedDns := isDNSManagementSupported(t)
+
+	// On-prem platforms the DNS may not be managed, so we cannot check if it is available
+	if managedDns {
+		// Obtain the standard formatting of the dnsRecord.
+		dnsRecordName := operatorcontroller.GatewayDNSRecordName(gateway, domain)
+		t.Logf("Making sure DNSRecord %v for domain %q is ready to use...", dnsRecordName, domain)
+		if err := assertDNSRecord(t, dnsRecordName); err != nil {
+			return err
+		}
+
+		// Wait and check that the dns name resolves first. Takes a long time, so
+		// if the hostname is actually an IP address, skip this.
+		if net.ParseIP(hostname) == nil {
+			t.Logf("Attempting to resolve %s...", hostname)
+			if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, dnsResolutionTimeout, false, func(context context.Context) (bool, error) {
+				_, err := net.LookupHost(hostname)
+				if err != nil {
+					t.Logf("%v waiting for HTTP route name %s to resolve (%v)", time.Now(), hostname, err)
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Fatalf("Failed to resolve host name %s: %v", hostname, err)
+			}
+		}
 	}
 
-	// Wait and check that the dns name resolves first. Takes a long time, so
-	// if the hostname is actually an IP address, skip this.
-	if net.ParseIP(hostname) == nil {
-		t.Logf("Attempting to resolve %s...", hostname)
-		if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, dnsResolutionTimeout, false, func(context context.Context) (bool, error) {
-			_, err := net.LookupHost(hostname)
-			if err != nil {
-				t.Logf("%v waiting for HTTP route name %s to resolve (%v)", time.Now(), hostname, err)
-				return false, nil
-			}
-			return true, nil
-		}); err != nil {
-			t.Fatalf("Failed to resolve host name %s: %v", hostname, err)
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	if !managedDns {
+		if len(gateway.Status.Addresses) == 0 ||
+			gateway.Status.Addresses[0].Type == nil ||
+			*gateway.Status.Addresses[0].Type != gatewayapiv1.IPAddressType ||
+			gateway.Status.Addresses[0].Value == "" {
+			t.Fatalf("gateway test without managed DNS needs at least one address status set, got %v", gateway.Status.Addresses)
 		}
+
+		targetIP := gateway.Status.Addresses[0].Value
+		dialer := &net.Dialer{
+			Timeout: 15 * time.Second,
+		}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			destination := net.JoinHostPort(targetIP, port)
+			return dialer.DialContext(ctx, network, destination)
+		}
+	}
+
+	// Create the http client to check the header.
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
 	}
 
 	var (
@@ -960,7 +990,7 @@ func getHTTPResponse(client *http.Client, name string) (int, http.Header, string
 
 	// Close response body.
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return 0, nil, "", fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -689,11 +689,12 @@ func isDNSManagementSupported(t *testing.T) bool {
 		Name: "cluster",
 	}
 	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, timeout, false, func(ctx context.Context) (done bool, err error) {
-		if err := kclient.Get(ctx, types.NamespacedName{Name: "cluster"}, dnsConfig); err != nil {
-			t.Logf("error getting infrastructure config %v: %v, retrying...", name, err)
+		if err := kclient.Get(ctx, name, dnsConfig); err != nil {
+			t.Logf("error getting dns config %v: %v, retrying...", name, err)
 			return false, nil
 		}
-		dnsManaged = dnsConfig.Spec.PrivateZone != nil || dnsConfig.Spec.PublicZone != nil
+		dnsManaged = (dnsConfig.Spec.PrivateZone != nil && dnsConfig.Spec.PrivateZone.ID != "") ||
+			(dnsConfig.Spec.PublicZone != nil && dnsConfig.Spec.PublicZone.ID != "")
 		return true, nil
 	})
 	if err != nil {


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/cluster-ingress-operator/pull/1342

On on-prem platforms we cannot assure that the DNS record will always work. On some platforms the DNS controller is created with a fake controller, and DNSRecords never gets ready. In these cases, what we need is that the tests rely on the Gateway status address as a name and connect to it directly instead of trying to resolve the DNS.

This change creates a new function to verify if the test is running on a platform with unmanaged DNS, and in this case it skips verifying DNSRecord and makes the resolution of DNS records be hardcoded to use the gateway address on the http client

