### PR TITLE
NE-2664: deploy haproxy as sidecar

### DIFF
--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -10,17 +10,75 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      # manually configure the service account, so we can configure it only in the router container.
+      automountServiceAccountToken: false
       serviceAccountName: router
       # nodeSelector is set at runtime.
       priorityClassName: system-cluster-critical
+      shareProcessNamespace: true
+      initContainers:
+        - name: init-router
+          # image is set at runtime.
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+          command: ["/bin/bash", "-c", "cp -R -p /var/lib/haproxy/* /mnt/config/"]
+          volumeMounts:
+          - mountPath: /mnt/config
+            name: haproxy-config
+        - name: haproxy
+          # image is set at runtime.
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          securityContext:
+            # See https://bugzilla.redhat.com/2007246
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          command: ["/var/lib/haproxy/start-haproxy"]
+          # admin.sock should follow routerHAProxyAdminSocket const
+          args: ["-W", "-db", "-S", "/var/lib/haproxy/run/admin.sock,mode,600", "-f", "/var/lib/haproxy/conf/haproxy.config"]
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/haproxy.sock"]
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            terminationGracePeriodSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            exec:
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/haproxy.sock"]
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 120
+            exec:
+              # admin.sock should follow routerHAProxyAdminSocket const
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/admin.sock"]
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /var/lib/haproxy
+            name: haproxy-config
+          - mountPath: /etc/pki/tls/private
+            name: default-certificate
+            readOnly: true
+          - mountPath: /var/run/configmaps/service-ca
+            name: service-ca-bundle
+            readOnly: true
       containers:
         - name: router
           # image is set at runtime.
           imagePullPolicy: IfNotPresent
           securityContext:
-            # See https://bugzilla.redhat.com/2007246
-            allowPrivilegeEscalation: true
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           # Merged at runtime.
           env:
@@ -60,14 +118,19 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 25m
+              memory: 64Mi
           volumeMounts:
+          - mountPath: /var/lib/haproxy
+            name: haproxy-config
           - mountPath: /etc/pki/tls/private
             name: default-certificate
             readOnly: true
           - mountPath: /var/run/configmaps/service-ca
             name: service-ca-bundle
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
             readOnly: true
       tolerations:
       # Ensure the pod isn't deleted during serial NoExecuteTaintManager tests.
@@ -82,6 +145,8 @@ spec:
         secret:
           defaultMode: 420
           # SecretName is set at run-time.
+      - name: haproxy-config
+        emptyDir: {}
       - name: service-ca-bundle
         configMap:
           defaultMode: 420
@@ -90,3 +155,20 @@ spec:
             path: service-ca.crt
           name: service-ca-bundle
           optional: false
+      - name: kube-api-access
+        projected:
+          defaultMode: 0400
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+          - downwardAPI:
+              items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -159,6 +159,12 @@ const (
 	StatsPortName = "metrics"
 
 	haproxyMaxTimeoutMilliseconds = 2147483647 * time.Millisecond
+
+	// routerHAProxyAdminSocket has the path to the unix socket of the master process CLI.
+	// This socket is used to issue reload, grab HAProxy version, list and manage active processes.
+	//
+	// NOTE: it is hardcoded in the deployment.yaml manifest, update there if updating here.
+	routerHAProxyAdminSocket = "/var/lib/haproxy/run/admin.sock"
 )
 
 // ensureRouterDeployment ensures the router deployment exists for a given
@@ -321,6 +327,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 
 	volumes := deployment.Spec.Template.Spec.Volumes
 	routerVolumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	haproxyVolumeMounts := deployment.Spec.Template.Spec.InitContainers[1].VolumeMounts
 
 	desiredReplicas := determineDeploymentReplicas(ci, ingressConfig, infraConfig)
 	deployment.Spec.Replicas = &desiredReplicas
@@ -550,6 +557,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			MountPath: "/var/lib/haproxy/conf/error_code_pages",
 		}
 		routerVolumeMounts = append(routerVolumeMounts, httpErrorCodeVolumeMount)
+		haproxyVolumeMounts = append(haproxyVolumeMounts, httpErrorCodeVolumeMount)
 		if len(configmapName.Name) != 0 {
 			env = append(env, corev1.EnvVar{
 				Name:  "ROUTER_ERRORFILE_503",
@@ -813,7 +821,17 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		env = append(env, corev1.EnvVar{Name: "ROUTE_LABELS", Value: routeSelector.String()})
 	}
 
+	// init image: just needs bash, reusing router's image is fine since we already need to download it anyway.
+	deployment.Spec.Template.Spec.InitContainers[0].Image = config.IngressControllerImage
+
+	// router image.
 	deployment.Spec.Template.Spec.Containers[0].Image = config.IngressControllerImage
+
+	// haproxy image: using router's image for now, but it needs its own image.
+	// HAProxy images: https://redhat.atlassian.net/browse/NE-2218
+	// API field: https://redhat.atlassian.net/browse/NE-2217
+	deployment.Spec.Template.Spec.InitContainers[1].Image = config.IngressControllerImage
+
 	deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
 
 	var (
@@ -966,6 +984,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			)
 			volumes = append(volumes, rsyslogConfigVolume, rsyslogSocketVolume)
 			routerVolumeMounts = append(routerVolumeMounts, rsyslogSocketVolumeMount)
+			haproxyVolumeMounts = append(haproxyVolumeMounts, rsyslogSocketVolumeMount)
 			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, syslogContainer)
 
 		case accessLogging.Destination.Type == operatorv1.SyslogLoggingDestinationType:
@@ -1271,6 +1290,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = routerVolumeMounts
+	deployment.Spec.Template.Spec.InitContainers[1].VolumeMounts = haproxyVolumeMounts
 
 	// If MIMETypes were supplied, expose the RouterEnableCompression and RouterCompressionMIMETypes
 	// environment variables.
@@ -1318,6 +1338,12 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			Value: "true",
 		})
 	}
+
+	// ROUTER_HAPROXY_ADMIN_UNIX_SOCKET envvar defines where the router should find the HAProxy's admin socket.
+	env = append(env, corev1.EnvVar{
+		Name:  "ROUTER_HAPROXY_ADMIN_UNIX_SOCKET",
+		Value: routerHAProxyAdminSocket,
+	})
 
 	// TODO: The only connections from the router that may need the cluster-wide proxy are those for downloading CRLs,
 	// which, as of writing this, will always be http. If https becomes necessary, the router will need to mount the
@@ -1600,6 +1626,30 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 		return containers[i].Name < containers[j].Name
 	})
 	hashableDeployment.Spec.Template.Spec.Containers = containers
+	initContainers := make([]corev1.Container, len(deployment.Spec.Template.Spec.InitContainers))
+	for i, initContainer := range deployment.Spec.Template.Spec.InitContainers {
+		env := initContainer.Env
+		sort.Slice(env, func(i, j int) bool {
+			return env[i].Name < env[j].Name
+		})
+		initContainers[i] = corev1.Container{
+			Command:         initContainer.Command,
+			Env:             env,
+			Image:           initContainer.Image,
+			ImagePullPolicy: initContainer.ImagePullPolicy,
+			Name:            initContainer.Name,
+			LivenessProbe:   hashableProbe(initContainer.LivenessProbe),
+			ReadinessProbe:  hashableProbe(initContainer.ReadinessProbe),
+			StartupProbe:    hashableProbe(initContainer.StartupProbe),
+			SecurityContext: initContainer.SecurityContext,
+			Ports:           initContainer.Ports,
+			RestartPolicy:   initContainer.RestartPolicy,
+		}
+	}
+	sort.Slice(initContainers, func(i, j int) bool {
+		return initContainers[i].Name < initContainers[j].Name
+	})
+	hashableDeployment.Spec.Template.Spec.InitContainers = initContainers
 	hashableDeployment.Spec.Template.Spec.DNSPolicy = deployment.Spec.Template.Spec.DNSPolicy
 	hashableDeployment.Spec.Template.Spec.HostNetwork = deployment.Spec.Template.Spec.HostNetwork
 	volumes := make([]corev1.Volume, len(deployment.Spec.Template.Spec.Volumes))
@@ -1782,6 +1832,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 		containers[i+1] = *container.DeepCopy()
 	}
 	updated.Spec.Template.Spec.Containers = containers
+	updated.Spec.Template.Spec.InitContainers = expected.Spec.Template.Spec.InitContainers
 	updated.Spec.Template.Spec.DNSPolicy = expected.Spec.Template.Spec.DNSPolicy
 	updated.Spec.Template.Labels = expected.Spec.Template.Labels
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -31,6 +33,11 @@ import (
 const (
 	ingressControllerImage = "quay.io/openshift/router:latest"
 	routerContainerName    = "router"
+
+	routerInitContainerName        = "init-router"
+	routerHAProxyContainerName     = "haproxy"
+	routerHAProxyConfigVolume      = "haproxy-config"
+	routerServiceAccountVolumeName = "kube-api-access"
 )
 
 var toleration = corev1.Toleration{
@@ -59,10 +66,10 @@ func checkDeploymentHasEnvSorted(t *testing.T, deployment *appsv1.Deployment) {
 	}
 }
 
-func checkDeploymentHasContainer(t *testing.T, deployment *appsv1.Deployment, name string, expect bool) {
+func checkDeploymentHasContainer(t *testing.T, containers []corev1.Container, name string, expect bool) {
 	t.Helper()
 
-	for _, container := range deployment.Spec.Template.Spec.Containers {
+	for _, container := range containers {
 		if container.Name == name {
 			if expect {
 				return
@@ -75,20 +82,38 @@ func checkDeploymentHasContainer(t *testing.T, deployment *appsv1.Deployment, na
 	}
 }
 
-func checkRouterContainerSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
+func getHAProxyContainer(t *testing.T, deployment *appsv1.Deployment) *corev1.Container {
 	t.Helper()
-	checkDeploymentHasContainer(t, deployment, routerContainerName, true)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.InitContainers, routerHAProxyContainerName, true)
 
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == routerContainerName {
-			if allowPrivEsc := container.SecurityContext.AllowPrivilegeEscalation; allowPrivEsc == nil || !*allowPrivEsc {
-				t.Errorf("%s container does not have securityContext.allowPrivilegeEscalation: true", routerContainerName)
-			}
-			if readOnlyFS := container.SecurityContext.ReadOnlyRootFilesystem; readOnlyFS == nil || *readOnlyFS {
-				t.Errorf("%s container does not have securityContext.readOnlyRootFilesystem: false", routerContainerName)
-			}
+	for _, container := range deployment.Spec.Template.Spec.InitContainers {
+		if container.Name == routerHAProxyContainerName {
+			return &container
 		}
 	}
+
+	t.Errorf("haproxy container not found")
+	return nil
+}
+
+func checkHAProxyContainerSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	container := getHAProxyContainer(t, deployment)
+
+	if allowPrivEsc := container.SecurityContext.AllowPrivilegeEscalation; allowPrivEsc == nil || !*allowPrivEsc {
+		t.Errorf("%s container does not have securityContext.allowPrivilegeEscalation: true", routerContainerName)
+	}
+	if readOnlyFS := container.SecurityContext.ReadOnlyRootFilesystem; readOnlyFS == nil || !*readOnlyFS {
+		t.Errorf("%s container does not have securityContext.readOnlyRootFilesystem: true", routerContainerName)
+	}
+}
+
+func checkHAProxyContainerSocketRef(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	container := getHAProxyContainer(t, deployment)
+
+	require.Equal(t, container.Args, []string{"-W", "-db", "-S", routerHAProxyAdminSocket + ",mode,600", "-f", "/var/lib/haproxy/conf/haproxy.config"}, "containers[haproxy].Args")
+	require.Equal(t, container.StartupProbe.Exec.Command, []string{"/bin/sh", "-c", "echo show version | socat - " + routerHAProxyAdminSocket}, "containers[haproxy].startupProbe.exec.command")
 }
 
 func checkDeploymentHash(t *testing.T, deployment *appsv1.Deployment) {
@@ -540,7 +565,8 @@ func Test_desiredRouterDeployment(t *testing.T) {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
 
-	checkRouterContainerSecurityContext(t, deployment)
+	checkHAProxyContainerSecurityContext(t, deployment)
+	checkHAProxyContainerSocketRef(t, deployment)
 	checkDeploymentHash(t, deployment)
 
 	if deployment.Spec.Replicas == nil {
@@ -648,6 +674,43 @@ func assertVolumeHasDefaultMode(t *testing.T, expected int32, actual *int32, vol
 	}
 }
 
+func assertVolumeHasServiceAccount(t *testing.T, volume corev1.Volume) {
+	t.Helper()
+
+	if !assert.NotNil(t, volume.Projected) {
+		return
+	}
+
+	assertVolumeHasDefaultMode(t, int32(0400), volume.Projected.DefaultMode, volume.Name)
+
+	require.Len(t, volume.Projected.Sources, 3, "expected 3 projected sources")
+
+	var hasToken, hasConfigMap, hasDownwardAPI bool
+	for _, source := range volume.Projected.Sources {
+		switch {
+		case source.ServiceAccountToken != nil:
+			assert.Equal(t, ptr.To(int64(3600)), source.ServiceAccountToken.ExpirationSeconds)
+			assert.Equal(t, "token", source.ServiceAccountToken.Path)
+			hasToken = true
+		case source.ConfigMap != nil:
+			assert.Equal(t, "kube-root-ca.crt", source.ConfigMap.Name)
+			assert.Equal(t, []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}}, source.ConfigMap.Items)
+			hasConfigMap = true
+		case source.DownwardAPI != nil:
+			volumeFile := []corev1.DownwardAPIVolumeFile{{
+				Path: "namespace",
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace"},
+			}}
+			assert.Equal(t, volumeFile, source.DownwardAPI.Items)
+			hasDownwardAPI = true
+		}
+	}
+	assert.True(t, hasToken, "missing ServiceAccountToken source")
+	assert.True(t, hasConfigMap, "missing ConfigMap source")
+	assert.True(t, hasDownwardAPI, "missing DownwardAPI source")
+}
+
 // checkProbes asserts that the given container specifies liveness, readiness,
 // and startup probes, and that these probes have the expected parameters.  If
 // useLocalhost is true, checkProbes asserts that the probe's HTTP action
@@ -695,18 +758,67 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
 
-	expectedVolumeSecretPairs := map[string]string{
-		"default-certificate": fmt.Sprintf("router-certs-%s", ic.Name),
-		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
-		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
-	}
 	expectedVolumes := []string{
 		"default-certificate",
 		"metrics-certs",
 		"stats-auth",
 		"service-ca-bundle",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
+	hasDesiredRouterDeploymentSpecTemplate(t, ic, deployment, expectedVolumes)
+}
+
+func TestDesiredRouterDeploymentSpecTemplateSidecar(t *testing.T) {
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
+	if err != nil {
+		t.Fatalf("invalid router Deployment: %v", err)
+	}
+
+	require.Len(t, deployment.Spec.Template.Spec.InitContainers, 2, "len(initContainers)")
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "len(containers)")
+
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.InitContainers, routerHAProxyContainerName, true)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.InitContainers, routerInitContainerName, true)
+
+	envvars := []envData{
+		{name: "ROUTER_HAPROXY_ADMIN_UNIX_SOCKET", expectPresent: true, expectedValue: routerHAProxyAdminSocket},
+	}
+	if err := checkDeploymentEnvironment(t, deployment, envvars); err != nil {
+		t.Error(err)
+	}
+
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+		routerServiceAccountVolumeName, // available in the pod but not mounted in the container
+		routerHAProxyConfigVolume,
+	}
+	hasDesiredRouterDeploymentSpecTemplate(t, ic, deployment, expectedVolumes)
+
+	haproxyContainer := deployment.Spec.Template.Spec.InitContainers[1]
+
+	// restartPolicy == Always configures an init container as a sidecar
+	require.Equal(t, haproxyContainer.RestartPolicy, ptr.To(corev1.ContainerRestartPolicyAlways))
+
+	kubeAPIAccessMounted := slices.ContainsFunc(haproxyContainer.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.Name == routerServiceAccountVolumeName
+	})
+	require.Falsef(t, kubeAPIAccessMounted, "haproxy sidecar is unexpectedly mounting volume %q", routerServiceAccountVolumeName)
+}
+
+// hasDesiredRouterDeploymentSpecTemplate has common configuration for router deployments, with and without an HAProxy sidecar
+func hasDesiredRouterDeploymentSpecTemplate(t *testing.T, ic *operatorv1.IngressController, deployment *appsv1.Deployment, expectedVolumes []string) {
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
+
+	expectedVolumeSecretPairs := map[string]string{
+		"default-certificate": fmt.Sprintf("router-certs-%s", ic.Name),
+		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
+		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
+	}
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
 		if secretName, ok := expectedVolumeSecretPairs[volume.Name]; ok {
 			if volume.Secret.SecretName != secretName {
@@ -718,6 +830,9 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		switch volume.Name {
 		case "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
@@ -757,7 +872,7 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 
 	checkProbes(t, &deployment.Spec.Template.Spec.Containers[0], false)
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, false)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, false)
 
 	checkDeploymentHasEnvSorted(t, deployment)
 }
@@ -856,6 +971,8 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		"error-pages",
 		"rsyslog-config",
 		"rsyslog-socket",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -864,13 +981,16 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
 		case "error-pages", "rsyslog-config", "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		case "rsyslog-socket":
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, true)
 	tests := []envData{
 		{"ROUTER_HAPROXY_CONFIG_MANAGER", false, ""},
 		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "leastconn"},
@@ -1084,6 +1204,8 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		"metrics-certs",
 		"stats-auth",
 		"service-ca-bundle",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -1097,12 +1219,15 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		switch volume.Name {
 		case "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, false)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, false)
 	tests := []envData{
 		{"ROUTER_LOG_FACILITY", true, "local2"},
 		{"ROUTER_LOG_MAX_LENGTH", true, "4096"},
@@ -1300,6 +1425,8 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 		"stats-auth",
 		"service-ca-bundle",
 		"client-ca",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -1311,6 +1438,9 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 		case "client-ca":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
 			assert.Equal(t, "router-client-ca-default", volume.VolumeSource.ConfigMap.LocalObjectReference.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2277,6 +2277,46 @@ $ModLoad omstdout.so
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
+	routerPod, err := getRouterPod(context.TODO(), ic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// makes a HTTP request to the router so the log scanner has something to collect.
+	clientPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ping-router",
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "curl",
+					Image:   routerPod.Spec.Containers[0].Image,
+					Command: []string{"/bin/curl"},
+					Args: []string{
+						"-ksS", "http://" + routerPod.Status.PodIP,
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+		}
+	}()
+
 	// Scan the syslog logs to make sure some requests get logged;
 	// the kubelet's health probes should get logged.
 	kubeConfig, err := config.GetConfig()
@@ -2363,26 +2403,10 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	// Get the deployment's pods.  We will use these to curl a route and to
-	// scan access logs.
-	deployment := &appsv1.Deployment{}
-	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-	}
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	// We will use the router's pod to curl a route and to scan access logs.
+	routerPod, err := getRouterPod(context.TODO(), ic)
 	if err != nil {
-		t.Fatalf("router deployment has invalid spec.selector: %v", err)
-	}
-	podList := &corev1.PodList{}
-	if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		t.Fatalf("failed to list pods for ingresscontroller: %v", err)
-	}
-	if len(podList.Items) != 1 {
-		var podNames []string
-		for i := range podList.Items {
-			podNames = append(podNames, podList.Items[i].Name)
-		}
-		t.Fatalf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+		t.Fatal(err)
 	}
 
 	// Make a request to the console route.
@@ -2394,19 +2418,22 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "loggingmaxlengthtest",
-			Namespace: podList.Items[0].Namespace,
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:    "curl",
-					Image:   podList.Items[0].Spec.Containers[0].Image,
+					Image:   routerPod.Spec.Containers[0].Image,
 					Command: []string{"/bin/curl"},
 					Args: []string{
 						"-k",
 						"-o", "/dev/null", "-s",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
+						route.Spec.Host + ":443:" + routerPod.Status.PodIP,
 						"https://" + route.Spec.Host,
 					},
 				},
@@ -2419,6 +2446,16 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
+	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: clientPod.Namespace})
+	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
+			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+		}
+	}()
+
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
 		t.Fatalf("failed to get kube config: %v", err)
@@ -2429,18 +2466,17 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	}
 
 	err = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-		pod := podList.Items[0]
-		readCloser, err := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		readCloser, err := client.CoreV1().Pods(routerPod.Namespace).GetLogs(routerPod.Name, &corev1.PodLogOptions{
 			Container: "logs",
 			Follow:    false,
 		}).Stream(context.TODO())
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		data, err := io.ReadAll(readCloser)
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		scanner := bufio.NewScanner(bytes.NewBuffer(data))
@@ -2458,7 +2494,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			// the POD name can be different for each test and how the name is build can be changed in the future, so it is not possible to
 			// set a fixed value for the test
 			if strings.Contains(line, "8192abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=") && (length >= 8100 && length <= 8400) {
-				t.Logf("found log message for maxLength and the length is equals to 8192 chars in pod %s logs", pod.Name)
+				t.Logf("found log message for maxLength and the length is equals to 8192 chars in pod %s logs", routerPod.Name)
 				found = true
 				break
 			}
@@ -2498,26 +2534,10 @@ func TestContainerLoggingMinLength(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	// Get the deployment's pods.  We will use these to curl a route and to
-	// scan access logs.
-	deployment := &appsv1.Deployment{}
-	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-	}
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	// We will use the router's pod to curl a route and to scan access logs.
+	routerPod, err := getRouterPod(context.TODO(), ic)
 	if err != nil {
-		t.Fatalf("router deployment has invalid spec.selector: %v", err)
-	}
-	podList := &corev1.PodList{}
-	if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		t.Fatalf("failed to list pods for ingresscontroller: %v", err)
-	}
-	if len(podList.Items) != 1 {
-		var podNames []string
-		for i := range podList.Items {
-			podNames = append(podNames, podList.Items[i].Name)
-		}
-		t.Fatalf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+		t.Fatal(err)
 	}
 
 	// Make a request to the console route.
@@ -2529,19 +2549,22 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "loggingminlengthtest",
-			Namespace: podList.Items[0].Namespace,
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:    "curl",
-					Image:   podList.Items[0].Spec.Containers[0].Image,
+					Image:   routerPod.Spec.Containers[0].Image,
 					Command: []string{"/bin/curl"},
 					Args: []string{
 						"-k",
 						"-o", "/dev/null", "-s",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
+						route.Spec.Host + ":443:" + routerPod.Status.PodIP,
 						"https://" + route.Spec.Host,
 					},
 				},
@@ -2554,6 +2577,16 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
+	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: clientPod.Namespace})
+	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
+			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+		}
+	}()
+
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
 		t.Fatalf("failed to get kube config: %v", err)
@@ -2564,18 +2597,17 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	}
 
 	err = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-		pod := podList.Items[0]
-		readCloser, err := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		readCloser, err := client.CoreV1().Pods(routerPod.Namespace).GetLogs(routerPod.Name, &corev1.PodLogOptions{
 			Container: "logs",
 			Follow:    false,
 		}).Stream(context.TODO())
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		data, err := io.ReadAll(readCloser)
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		scanner := bufio.NewScanner(bytes.NewBuffer(data))
@@ -2593,7 +2625,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			// the POD name can be different for each test and how the name is build can be changed in the future, so it is not possible to
 			// set a fixed value for the test
 			if strings.Contains(line, "0480abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=") && (length >= 450 && length <= 650) {
-				t.Logf("found log message for minLength and the length is equals to 480 chars in pod %s logs", pod.Name)
+				t.Logf("found log message for minLength and the length is equals to 480 chars in pod %s logs", routerPod.Name)
 				found = true
 				break
 			}
@@ -4102,6 +4134,40 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 		}
 		return false, nil
 	})
+}
+
+func getRouterPod(ctx context.Context, ic *operatorv1.IngressController) (*corev1.Pod, error) {
+	deployment := &appsv1.Deployment{}
+	if err := kclient.Get(ctx, controller.RouterDeploymentName(ic), deployment); err != nil {
+		return nil, fmt.Errorf("failed to get ingresscontroller deployment: %w", err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("router deployment has invalid spec.selector: %w", err)
+	}
+
+	// wait for router to have one single pod, in case of unexpected events like node reload
+	var routerPod *corev1.Pod
+	var pollErr error
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		podList := &corev1.PodList{}
+		if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			pollErr = fmt.Errorf("failed to list pods for ingresscontroller: %w", err)
+			return false, nil
+		}
+		if len(podList.Items) != 1 {
+			var podNames []string
+			for i := range podList.Items {
+				podNames = append(podNames, podList.Items[i].Name)
+			}
+			pollErr = fmt.Errorf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+			return false, nil
+		}
+		routerPod = &podList.Items[0]
+		pollErr = nil
+		return true, nil
+	})
+	return routerPod, pollErr
 }
 
 func newNodePortController(name types.NamespacedName, domain string) *operatorv1.IngressController {


### PR DESCRIPTION
Adding a new container to deploy HAProxy. This is a first but fully functional implementation that allows starting e2e and exploratory testsusing the new topology.

Key differences from the final version:

* The same image is used both on router and haproxy containers; and
* It is not possible to select HAProxy version.

This is due to some other and still pending stories that will handle both a new API field and building HAProxy image for all supported versions.

This update depends on https://github.com/openshift/router/pull/772

e2e tests updated in order to send a HTTP request to the router, because on the single container / embedded HAProxy, it is the reload-haproxy script the one sending the HTTP request the e2e test expects, and the new implementation does not use the reload script anymore.

https://redhat.atlassian.net/browse/NE-2664

## Why

[enhancements#1965](https://github.com/openshift/enhancements/pull/1965/changes) describes a new feature allowing users to choose a HAProxy version from IngressController API. Separating HAProxy on its own container is a simple and secure way to achieve this, with minimal disruption on the topology.