### PR TITLE
OCPBUGS-55050: Remove resources limits from Gateway API proxy containers

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -81,6 +81,9 @@ const (
 	// can be specified.  This annotation is only intended for use by
 	// OpenShift developers.
 	istioVersionOverrideAnnotationKey = "unsupported.do-not-use.openshift.io/istio-version"
+	// gatewayProxyContainerName is the name of the proxy container
+	// in gateway deployments managed by Istio.
+	gatewayProxyContainerName = "istio-proxy"
 	// sailLibraryFinalizer is added to GatewayClasses using Sail Library installation.
 	// When a GatewayClass with this finalizer is deleted:
 	// 1. Sail Library mode: Uninstall Istio if this is the last GatewayClass, then remove finalizer

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -184,18 +183,18 @@ func Test_Reconcile(t *testing.T) {
 	}
 
 	gatewayclassesConfig := func(config string, gatewayclasses ...string) json.RawMessage {
-		return json.RawMessage(fmt.Appendf(nil, `{%s}`, strings.Join(func() []string {
-			var result []string
-
-			for _, name := range gatewayclasses {
-				result = append(result, fmt.Sprintf(`"%s":%s`, name, config))
-			}
-
-			return result
-		}(), ",")))
+		payload := make(map[string]json.RawMessage, len(gatewayclasses))
+		for _, name := range gatewayclasses {
+			payload[name] = json.RawMessage(config)
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("an error occurred during json creation for gatewayclassesConfig: %s", err)
+		}
+		return b
 	}
-	hpaConfig := func(minReplicas int) string {
-		return fmt.Sprintf(`{"horizontalPodAutoscaler":{"spec":{"maxReplicas":10,"minReplicas":%d}}}`, minReplicas)
+	gatewayclassConfig := func(minReplicas int) string {
+		return fmt.Sprintf(`{"deployment":{"spec":{"template":{"spec":{"containers":[{"name":"istio-proxy","resources":{"limits":null}}]}}}},"horizontalPodAutoscaler":{"spec":{"maxReplicas":10,"minReplicas":%d}}}`, minReplicas)
 	}
 
 	istioRevision := func() *sailv1.IstioRevision {
@@ -351,7 +350,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -366,7 +365,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(1), "openshift-default")),
+				istio("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -390,7 +389,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default", "openshift-internal")),
+				istio("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default", "openshift-internal")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -406,7 +405,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -426,7 +425,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -446,7 +445,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -463,7 +462,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("redhat-operators", "stable", "servicemeshoperator3.v3.0.1"),
-				istio("v1.24-latest", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24-latest", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -483,7 +482,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expectCreate: []client.Object{
 				subscription("foo", "bar", "baz"),
-				istio("quux", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("quux", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 				manifests.IstiodAllowNetworkPolicy(),
 			},
 			expectUpdate: []client.Object{},
@@ -573,11 +572,11 @@ func Test_Reconcile(t *testing.T) {
 				infraConfig(configv1.HighlyAvailableTopologyMode),
 				gatewayClass("openshift-default", true, nil, nil, false),
 				istioCRD(),
-				istio("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 			},
 			expectPatched: []client.Object{},
 			expectDelete: []client.Object{
-				istio("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+				istio("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 			},
 			expectedResult: reconcile.Result{
 				RequeueAfter: 5 * time.Second,
@@ -618,7 +617,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: installs Istio (single replica)",
@@ -634,7 +633,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(1), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: installs Istio (highly available)",
@@ -650,7 +649,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: installs Istio with system proxy configuration",
@@ -667,7 +666,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: installs Istio for multiple gatewayclasses in single-topology mode with system proxy configuration",
@@ -694,7 +693,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(hpaConfig(1), "openshift-default", "openshift-internal", "openshift-custom")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default", "openshift-internal", "openshift-custom")),
 		},
 		{
 			name:              "Sail Library: experimental InferencePool CRD",
@@ -715,7 +714,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: stable InferencePool CRD",
@@ -736,7 +735,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: Istio version override",
@@ -756,7 +755,7 @@ func Test_Reconcile(t *testing.T) {
 					"unsupported.do-not-use.openshift.io/istio-version": "v1.24-latest",
 				}, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false, nil, gatewayclassesConfig(hpaConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
 		},
 		{
 			name:              "Sail Library: full removal of last GatewayClass",

--- a/pkg/operator/controller/gatewayclass/istio_olm.go
+++ b/pkg/operator/controller/gatewayclass/istio_olm.go
@@ -237,10 +237,10 @@ func desiredIstio(name types.NamespacedName, ownerRef metav1.OwnerReference, ist
 		}
 
 		if extraConfig.infraConfig != nil {
-			if hpaConfig, err := buildHorizontalPodAutoscalerConfig(extraConfig.infraConfig, gatewayclasses); err != nil {
+			if gwClassConfig, err := buildGatewayClassesConfig(extraConfig.infraConfig, gatewayclasses); err != nil {
 				return nil, err
 			} else {
-				istio.Spec.Values.GatewayClasses = hpaConfig
+				istio.Spec.Values.GatewayClasses = gwClassConfig
 			}
 		}
 	}

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer.go
@@ -210,10 +210,10 @@ func openshiftValues(enableInferenceExtension bool, operandNamespace string, gat
 			}
 		}
 		if extraConfig.infraConfig != nil {
-			if hpaConfig, err := buildHorizontalPodAutoscalerConfig(extraConfig.infraConfig, gatewayclasses); err != nil {
-				return nil, fmt.Errorf("failed to build HPA config: %w", err)
+			if gwClassConfig, err := buildGatewayClassesConfig(extraConfig.infraConfig, gatewayclasses); err != nil {
+				return nil, fmt.Errorf("failed to build gateway class config: %w", err)
 			} else {
-				val.GatewayClasses = hpaConfig
+				val.GatewayClasses = gwClassConfig
 			}
 		}
 	}
@@ -244,10 +244,9 @@ func buildProxyMetadata(proxyConfig *configv1.Proxy) map[string]string {
 	return proxyMetadata
 }
 
-// buildHorizontalPodAutoscalerConfig returns Istio configuration for the
-// horizontal pod autoscaler given an infrastructure config and a slice of
-// gatewayclasses.
-func buildHorizontalPodAutoscalerConfig(infraConfig *configv1.Infrastructure, gatewayclasses []gatewayapiv1.GatewayClass) (json.RawMessage, error) {
+// buildGatewayClassesConfig returns Istio per-gatewayclass configuration
+// overlays given an infrastructure config and a slice of gatewayclasses.
+func buildGatewayClassesConfig(infraConfig *configv1.Infrastructure, gatewayclasses []gatewayapiv1.GatewayClass) (json.RawMessage, error) {
 	const maxReplicas = 10
 
 	var minReplicas = 2
@@ -260,6 +259,26 @@ func buildHorizontalPodAutoscalerConfig(infraConfig *configv1.Infrastructure, ga
 			"spec": map[string]any{
 				"minReplicas": minReplicas,
 				"maxReplicas": maxReplicas,
+			},
+		},
+		"deployment": map[string]any{
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []map[string]any{
+							{
+								"name": gatewayProxyContainerName,
+								// OCPBUGS-55050: Managed cluster should set requests but not limits
+								// Istio sets resource limits by default, that come from the helm chart.
+								// This change enforces the resources.limits to be null, so we drop this value
+								// during the Proxy deployment
+								"resources": map[string]any{
+									"limits": nil,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1574,6 +1574,7 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 		expectedMinReplicas = 1
 	}
 	assertHorizontalPodAutoscalerEnabled(t, operatorcontroller.DefaultOperandNamespace, testGatewayName, operatorcontroller.OpenShiftDefaultGatewayClassName, expectedMinReplicas)
+	assertProxyDeployCustomConfigurations(t, operatorcontroller.DefaultOperandNamespace, testGatewayName, operatorcontroller.OpenShiftDefaultGatewayClassName)
 
 	t.Log("Making sure the httproute is created and accepted...")
 	_, err = assertHttpRouteSuccessful(t, ns.Name, "test-httproute", gateway)

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -811,6 +811,46 @@ func assertHorizontalPodAutoscalerEnabled(t *testing.T, namespaceName, gatewayNa
 	}
 }
 
+// assertProxyDeployCustomConfigurations verifies that the deployment sets
+// the right custom configurations on pods.
+func assertProxyDeployCustomConfigurations(t *testing.T, namespaceName, gatewayName, gatewayclassName string) {
+	t.Helper()
+
+	deploymentName := types.NamespacedName{
+		Namespace: namespaceName,
+		Name:      fmt.Sprintf("%s-%s", gatewayName, gatewayclassName),
+	}
+	t.Logf("Verifying resource limit is null on the proxy containers of the deployment %s...", deploymentName)
+	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		var dep appsv1.Deployment
+		if err := kclient.Get(ctx, deploymentName, &dep); err != nil {
+			t.Logf("Failed to get Deployment %s: %v; retrying...", deploymentName, err)
+			return false, nil
+		}
+
+		foundIstioProxy := false
+		for _, c := range dep.Spec.Template.Spec.Containers {
+			if c.Name == "istio-proxy" {
+				foundIstioProxy = true
+				if c.Resources.Limits != nil {
+					t.Log("Container 'istio-proxy' has resources.limits, expected no limits set; retrying...")
+					return false, nil
+				}
+			}
+		}
+
+		// We need to be sure that the istio-proxy exists, and that it has no resources.limits.
+		// If we cannot find istio-proxy, we must try again
+		if !foundIstioProxy {
+			t.Log("Container 'istio-proxy' was not found; retrying...")
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("Failed to verify the proxy configuration on deployment %s: %v", deploymentName, err)
+	}
+}
+
 func waitForGatewayListenerCondition(t *testing.T, gatewayName types.NamespacedName, listenerName string, conditions ...metav1.Condition) error {
 	t.Helper()
 


### PR DESCRIPTION
When a Gateway is deployed, Istio will create a deployment containing resources limits set, which is not expected on Openshift components. These resource limits are added as part of the default helm template used by Istio controller when creating the deployments and Pods.

An attempt to make Istio/Sail Library to have a default configuration on resource limits is not possible, given the Kubernetes resources struct has omitempty, which means when something is null omit, and when it ommits it considers that a user passing null has 'no opinion' as opposed to 'I want to set it null'.

This way, the  only way of fixing it is by telling the Gateway customization, via the Gateway Class that we want to enforce the resource to be null, and then when Istio deploys this Gateway instance it will remove the resources.limits field from the proxy pods

The majority of this PR was originally copied from https://github.com/openshift/cluster-ingress-operator/pull/1428