### PR TITLE
NE-2692: Replace iptables with nftables in TestConnectTimeout e2e test

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3299,13 +3299,13 @@ func TestConnectTimeout(t *testing.T) {
 		t.Fatal("failed to determine ingress operator deployment's image: ", err)
 	}
 
-	iptablesImage, err := getIptablesImage(t, kclient, 1*time.Minute)
+	nftImage, err := getNftImage(t, kclient, 1*time.Minute)
 	if err != nil {
-		t.Fatal("failed to determine image with iptables tool: ", err)
+		t.Fatal("failed to determine image with nft tool: ", err)
 	}
 
 	// Create a pod with an HTTP application that delays the connection and sends echo responses.
-	httpdPod := buildDelayConnectHTTPPod("connect-timeout-http", operatorcontroller.DefaultOperandNamespace, iptablesImage, operatorImage)
+	httpdPod := buildDelayConnectHTTPPod("connect-timeout-http", operatorcontroller.DefaultOperandNamespace, nftImage, operatorImage)
 	if err := createWithRetryOnError(t, ctx, httpdPod, DefaultRetryTimeout); err != nil {
 		t.Fatalf("failed to create pod %s/%s: %v", httpdPod.Namespace, httpdPod.Name, err)
 	}

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -276,13 +276,13 @@ func buildDelayConnectHTTPPod(name, namespace, initImage, image string) *corev1.
 			InitContainers: []corev1.Container{
 				{
 					Image: initImage,
-					Name:  "init-iptables",
-					// Integrate with the iptables rules to handle incoming traffic for the echo container.
+					Name:  "init-nftables",
+					// Set up nftables rules to redirect incoming SYN packets to a netfilter queue.
 					// The echo container opens the netfilter queue with the same number to delay incoming SYN packets.
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"iptables -I INPUT -p tcp --dport 8080 -m conntrack --ctstate NEW -j NFQUEUE --queue-num 100",
+						"nft add table inet cio_test && nft add chain inet cio_test input '{ type filter hook input priority 0; policy accept; }' && nft add rule inet cio_test input tcp dport 8080 ct state new queue num 100",
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &t,
@@ -442,8 +442,8 @@ func getIngressOperatorDeploymentImage(t *testing.T, client client.Client, timeo
 	return "", fmt.Errorf("image not found")
 }
 
-// getIptablesImage returns the image with the iptables tool installed in it.
-func getIptablesImage(t *testing.T, client client.Client, timeout time.Duration) (string, error) {
+// getNftImage returns an image with the nft tool installed in it.
+func getNftImage(t *testing.T, client client.Client, timeout time.Duration) (string, error) {
 	t.Helper()
 	daemonset, err := getDaemonSet(t, client, types.NamespacedName{Namespace: "openshift-ovn-kubernetes", Name: "ovnkube-node"}, timeout)
 	if err != nil {

--- a/test/http/serve-delay-connect.go
+++ b/test/http/serve-delay-connect.go
@@ -52,10 +52,10 @@ func NewServeDelayConnectCommand() *cobra.Command {
 
 // serveDelayConnect registers a handler on the specified netfilter queue and
 // starts an HTTP server on the given port. The handler delays SYN packet
-// acceptance by the specified delay. Use the following iptables command to configure the handler:
-// iptables -I INPUT -p tcp --dport 8080 -m conntrack --ctstate NEW -j NFQUEUE --queue-num 100
-// or this one for ipv6 stack:
-// ip6tables -I INPUT -p tcp --dport 8080 -m conntrack --ctstate NEW -j NFQUEUE --queue-num 100
+// acceptance by the specified delay. Use the following nft commands to configure the handler:
+// nft add table inet cio_test
+// nft add chain inet cio_test input '{ type filter hook input priority 0; policy accept; }'
+// nft add rule inet cio_test input tcp dport 8080 ct state new queue num 100
 func serveDelayConnect(queueNum uint16, delay time.Duration, port string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

RHEL 10 removes the `iptables` binary entirely, and the `iptables-nft` compatibility shim is deprecated in RHEL 9. The `TestConnectTimeout` e2e test uses `iptables` to set up an NFQUEUE rule for delaying SYN packets to simulate a slow backend. This PR replaces the `iptables` command with native `nft` equivalents.

A spike audit of all NID codebases ([NE-2691](https://redhat.atlassian.net/browse/NE-2691)) confirmed this is the **only** iptables dependency across all NID-owned components. No production code is affected.

## Changes

- Replace `iptables -I INPUT ... -j NFQUEUE` with equivalent `nft add rule` commands in the init container
- Rename `getIptablesImage()` → `getNftImage()` and `init-iptables` → `init-nftables`
- Update documentation comments in `serve-delay-connect.go` to show `nft` syntax

The underlying NFQUEUE mechanism is unchanged, it's a netfilter kernel feature that works identically with both iptables and nftables.
