### PR TITLE
OCPBUGS-74373: Remove restriction of unmanaged x-k8s.io

### DIFF
--- a/manifests/01-validating-admission-policy-ibm-cloud-managed.yaml
+++ b/manifests/01-validating-admission-policy-ibm-cloud-managed.yaml
@@ -20,7 +20,7 @@ spec:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"
       # When the operation is DELETE, the "object" variable is null.
-      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io' || (request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.x-k8s.io'"
+      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io'"
   # Validations are evaluated in the the order of their declaration.
   validations:
     # Verify that the request was sent by the ingress operator's service account.

--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"
       # When the operation is DELETE, the "object" variable is null.
-      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io' || (request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.x-k8s.io'"
+      expression: "(request.operation == 'DELETE' ? oldObject : object).spec.group == 'gateway.networking.k8s.io'"
   # Validations are evaluated in the the order of their declaration.
   validations:
     # Verify that the request was sent by the ingress operator's service account.

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	controllerName                        = "gatewayapi_controller"
-	experimentalGatewayAPIGroupName       = "gateway.networking.x-k8s.io"
 	gatewayAPICRDIndexFieldName           = "gatewayAPICRD"
 	unmanagedGatewayAPICRDIndexFieldValue = "unmanaged"
 )
@@ -68,8 +67,8 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	}
 
 	isGatewayAPICRD := func(o client.Object) bool {
-		crd := o.(*apiextensionsv1.CustomResourceDefinition)
-		return crd.Spec.Group == gatewayapiv1.GroupName || crd.Spec.Group == experimentalGatewayAPIGroupName
+		crd, ok := o.(*apiextensionsv1.CustomResourceDefinition)
+		return ok && crd.Spec.Group == gatewayapiv1.GroupName
 	}
 	crdPredicate := predicate.NewPredicateFuncs(isGatewayAPICRD)
 

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -160,8 +160,8 @@ func Test_Reconcile(t *testing.T) {
 			olmEnabled:                  true,
 			existingObjects: []runtime.Object{
 				co("ingress"),
-				crd("listenersets.gateway.networking.x-k8s.io"),
-				crd("backendtrafficpolicies.gateway.networking.x-k8s.io"),
+				crd("invalid.test.gateway.networking.k8s.io"),
+				crd("another.test.gateway.networking.k8s.io"),
 			},
 			existingStatusSubresource: []client.Object{
 				co("ingress"),
@@ -178,7 +178,7 @@ func Test_Reconcile(t *testing.T) {
 			expectUpdate: []client.Object{},
 			expectDelete: []client.Object{},
 			expectStatusUpdate: []client.Object{
-				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"backendtrafficpolicies.gateway.networking.x-k8s.io,listenersets.gateway.networking.x-k8s.io"}`),
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"another.test.gateway.networking.k8s.io,invalid.test.gateway.networking.k8s.io"}`),
 			},
 			expectStartCtrl: true,
 		},
@@ -189,7 +189,7 @@ func Test_Reconcile(t *testing.T) {
 			marketplaceEnabled:          true,
 			olmEnabled:                  true,
 			existingObjects: []runtime.Object{
-				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"listenersets.gateway.networking.x-k8s.io"}`),
+				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"invalid.test.gateway.networking.k8s.io"}`),
 			},
 			existingStatusSubresource: []client.Object{
 				co("ingress"),
@@ -254,7 +254,7 @@ func Test_Reconcile(t *testing.T) {
 				WithStatusSubresource(tc.existingStatusSubresource...).
 				WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
 					// Assume that all experimental CRDs are unmanaged.
-					if strings.Contains(o.GetName(), "gateway.networking.x-k8s.io") {
+					if strings.Contains(o.GetName(), "test.gateway.networking.k8s.io") {
 						return []string{"unmanaged"}
 					}
 					return []string{}

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -253,7 +253,7 @@ func Test_Reconcile(t *testing.T) {
 				WithRuntimeObjects(tc.existingObjects...).
 				WithStatusSubresource(tc.existingStatusSubresource...).
 				WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
-					// Assume that all experimental CRDs are unmanaged.
+					// Assume that test.gateway group CRD is unmanaged.
 					if strings.Contains(o.GetName(), "test.gateway.networking.k8s.io") {
 						return []string{"unmanaged"}
 					}

--- a/pkg/operator/controller/gatewayapi/crds.go
+++ b/pkg/operator/controller/gatewayapi/crds.go
@@ -82,7 +82,7 @@ func (r *reconciler) ensureGatewayAPICRDs(ctx context.Context) error {
 
 // listUnmanagedGatewayAPICRDs returns a list of unmanaged Gateway API CRDs
 // which exist in the cluster. A Gateway API CRD has "gateway.networking.k8s.io"
-// or "gateway.networking.x-k8s.io" in its "spec.group" field.
+// in its "spec.group" field.
 func (r *reconciler) listUnmanagedGatewayAPICRDs(ctx context.Context) ([]string, error) {
 	gatewayAPICRDs := &apiextensionsv1.CustomResourceDefinitionList{}
 	if err := r.cache.List(ctx, gatewayAPICRDs, client.MatchingFields{gatewayAPICRDIndexFieldName: unmanagedGatewayAPICRDIndexFieldValue}); err != nil {

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -775,13 +775,13 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				IngressControllers: []operatorv1.IngressController{
 					icWithStatus("default", false),
 				},
-				unmanagedGatewayAPICRDNames: "listenersets.gateway.networking.x-k8s.io",
+				unmanagedGatewayAPICRDNames: "notvalid.gateway.networking.k8s.io",
 			},
 			expectCondition: configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionTrue,
 				Reason:  "GatewayAPICRDsDegraded",
-				Message: "Unmanaged Gateway API CRDs found: listenersets.gateway.networking.x-k8s.io.",
+				Message: "Unmanaged Gateway API CRDs found: notvalid.gateway.networking.k8s.io.",
 			},
 		},
 		{
@@ -790,13 +790,13 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				IngressControllers: []operatorv1.IngressController{
 					icWithStatus("default", true),
 				},
-				unmanagedGatewayAPICRDNames: "listenersets.gateway.networking.x-k8s.io",
+				unmanagedGatewayAPICRDNames: "notvalid.gateway.networking.k8s.io",
 			},
 			expectCondition: configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionTrue,
 				Reason:  "IngressDegradedAndGatewayAPICRDsDegraded",
-				Message: `The "default" ingress controller reports Degraded=True: dummy: dummy.` + "\n" + `Unmanaged Gateway API CRDs found: listenersets.gateway.networking.x-k8s.io.`,
+				Message: `The "default" ingress controller reports Degraded=True: dummy: dummy.` + "\n" + `Unmanaged Gateway API CRDs found: notvalid.gateway.networking.k8s.io.`,
 			},
 		},
 		{

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -53,8 +53,8 @@ var crdNames = []string{
 	"referencegrants.gateway.networking.k8s.io",
 }
 
-var xcrdNames = []string{
-	"listenersets.gateway.networking.x-k8s.io",
+var testCRDNames = []string{
+	"tests.gateway.networking.k8s.io",
 }
 
 // Global variables for testing.
@@ -336,11 +336,10 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 	// of the update verb for the experimental Gateway API group.
 	// Since an API `Get` is called before the update, the CRD must exist in the cluster,
 	// just like standard Gateway API CRDs.
-	bypassVAP(t, ensureExperimentalCRDs)
+	bypassVAP(t, ensureTestCRDs)
 	t.Cleanup(func() {
-		bypassVAP(t, deleteExperimentalCRDs)
+		bypassVAP(t, deleteTestCRDs)
 	})
-
 	// Get kube client which impersonates ingress operator's service account.
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
@@ -356,7 +355,7 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 
 	// Create test CRDs.
 	var testCRDs []*apiextensionsv1.CustomResourceDefinition
-	for _, name := range append(crdNames, xcrdNames...) {
+	for _, name := range append(crdNames, testCRDNames...) {
 		testCRDs = append(testCRDs, buildGWAPICRDFromName(name))
 	}
 
@@ -722,8 +721,8 @@ func testGatewayAPIDNSListenerWithNoHostname(t *testing.T) {
 	t.Logf("Confirmed no DNSRecord created for gateway listener with no hostname.")
 }
 
-// testOperatorDegradedCondition verifies that unmanaged (e.g. experimental)
-// Gateway API CRDs affect the ingress cluster operator's Degraded status.
+// testOperatorDegradedCondition verifies that unmanaged Gateway API CRDs affect
+// the ingress cluster operator's Degraded status.
 func testOperatorDegradedCondition(t *testing.T) {
 	// Ensure that the ingress operator is not in a Degraded state
 	// to prevent conflicts with the unmanaged Gateway API CRDs logic.
@@ -738,9 +737,9 @@ func testOperatorDegradedCondition(t *testing.T) {
 		t.Fatalf("Operator should be Degraded=False: %v", err)
 	}
 
-	// Create experimental CRDs to check if the ingress cluster operator
+	// Create test CRDs to check if the ingress cluster operator
 	// transitions to the Degraded state.
-	bypassVAP(t, ensureExperimentalCRDs)
+	bypassVAP(t, ensureTestCRDs)
 	expectedDegraded = []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:   configv1.OperatorDegraded,
@@ -754,7 +753,7 @@ func testOperatorDegradedCondition(t *testing.T) {
 
 	// Remove the experimental CRDs to checks that the ingress cluster operator
 	// recovers from the Degraded state.
-	bypassVAP(t, deleteExperimentalCRDs)
+	bypassVAP(t, deleteTestCRDs)
 	expectedDegraded = []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:   configv1.OperatorDegraded,
@@ -791,29 +790,6 @@ func deleteCRDs(t *testing.T) {
 	}
 }
 
-// deleteExperimentalCRDs deletes experimental Gateway API custom resource definitions.
-func deleteExperimentalCRDs(t *testing.T) {
-	t.Helper()
-
-	for _, crdName := range xcrdNames {
-		err := deleteExistingCRD(t, crdName)
-		if err != nil {
-			t.Errorf("failed to delete crd %s: %v", crdName, err)
-		}
-	}
-}
-
-// ensureExperimentalCRDs creates experimental Gateway API custom resource definitions.
-func ensureExperimentalCRDs(t *testing.T) {
-	for _, crdName := range xcrdNames {
-		if _, err := createCRD(crdName); err != nil {
-			t.Fatalf("failed to create experimental crd %q: %v", crdName, err)
-		} else {
-			t.Logf("created experimental crd %q", crdName)
-		}
-	}
-}
-
 // ensureGatewayObjectCreation tests that gateway class, gateway, and http route objects can be created.
 func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 	var domain string
@@ -843,6 +819,29 @@ func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 	// The http route is cleaned up when the namespace is deleted.
 
 	return nil
+}
+
+// deleteTestCRDs deletes test Gateway API custom resource definitions.
+func deleteTestCRDs(t *testing.T) {
+	t.Helper()
+
+	for _, crdName := range testCRDNames {
+		err := deleteExistingCRD(t, crdName)
+		if err != nil {
+			t.Errorf("failed to delete crd %s: %v", crdName, err)
+		}
+	}
+}
+
+// ensureTestCRDs creates test Gateway API custom resource definitions.
+func ensureTestCRDs(t *testing.T) {
+	for _, crdName := range testCRDNames {
+		if _, err := createCRD(crdName); err != nil {
+			t.Fatalf("failed to create test crd %q: %v", crdName, err)
+		} else {
+			t.Logf("created test crd %q", crdName)
+		}
+	}
 }
 
 // ensureGatewayObjectSuccess tests that gateway class, gateway, and http route objects were accepted as valid,

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -406,9 +406,9 @@ func buildGWAPICRDFromName(name string) *apiextensionsv1.CustomResourceDefinitio
 	case "referencegrants":
 		kind = "ReferenceGrant"
 		versions = []map[string]bool{{"v1beta1": true}}
-	case "listenersets":
-		kind = "ListenerSet"
-		versions = []map[string]bool{{"v1alpha1": true}}
+	case "tests":
+		kind = "Test"
+		versions = []map[string]bool{{"v1": true}}
 	case "grpcroutes":
 		kind = "GRPCRoute"
 		versions = []map[string]bool{{"v1": true}}


### PR DESCRIPTION
Previously, cluster-ingress-operator would manage and block any updates to CRDs that were from group gateway.networking.x-k8s.io.

After some analysis we identified that OSSM/Istio does filter these resources in case it does not have a flag to enable alpha APIs, which means  it is safe to allow users to deploy these CRDs.

This way, this change removes any restriction on x-k8s.io group, and removes any further reconciliation from CIO on x-k8s.io group.

This is a manual cherry-pick of #1336.  