### PR TITLE
RFE-2195: expose ROUTER_METRICS_HAPROXY_SERVER_THRESHOLD value via IngressController API

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -149,6 +149,12 @@ const (
 	RouterBackendCheckInterval = "ROUTER_BACKEND_CHECK_INTERVAL"
 	RouterTLSCurves            = "ROUTER_CURVES"
 
+	// RouterMetricsHAProxyServerThreshold is the env var that controls the maximum
+	// number of servers (backends) per HAProxy process for which per-server Prometheus
+	// metrics are reported. Exceeding this threshold disables per-server metrics to
+	// limit metric cardinality. Maps to spec.tuningOptions.haproxyServerThreshold.
+	RouterMetricsHAProxyServerThreshold = "ROUTER_METRICS_HAPROXY_SERVER_THRESHOLD"
+
 	RouterServiceHTTPPort  = "ROUTER_SERVICE_HTTP_PORT"
 	RouterServiceHTTPSPort = "ROUTER_SERVICE_HTTPS_PORT"
 	StatsPort              = "STATS_PORT"
@@ -564,6 +570,12 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 	env = append(env, corev1.EnvVar{Name: "ROUTER_METRICS_TYPE", Value: "haproxy"})
 	env = append(env, corev1.EnvVar{Name: "ROUTER_METRICS_TLS_CERT_FILE", Value: filepath.Join(certsVolumeMountPath, "tls.crt")})
 	env = append(env, corev1.EnvVar{Name: "ROUTER_METRICS_TLS_KEY_FILE", Value: filepath.Join(certsVolumeMountPath, "tls.key")})
+	if ci.Spec.TuningOptions.HaproxyServerThreshold > 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  RouterMetricsHAProxyServerThreshold,
+			Value: strconv.Itoa(int(ci.Spec.TuningOptions.HaproxyServerThreshold)),
+		})
+	}
 
 	var unsupportedConfigOverrides struct {
 		LoadBalancingAlgorithm string `json:"loadBalancingAlgorithm"`

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -3066,3 +3066,62 @@ func Test_detectFIPS(t *testing.T) {
 		})
 	}
 }
+
+// Test_HaproxyServerThreshold validates that desiredRouterDeployment correctly
+// sets or omits the ROUTER_METRICS_HAPROXY_SERVER_THRESHOLD environment variable
+// based on the value of spec.tuningOptions.haproxyServerThreshold.
+//
+// When the field is zero (omitted/default), the env var must not be set so that
+// the router image applies its own built-in default. When the field is a positive
+// integer, the env var must be set to the corresponding string value.
+func Test_HaproxyServerThreshold(t *testing.T) {
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
+
+	for _, tc := range []struct {
+		name                string
+		threshold           int32
+		expectEnvVarPresent bool
+		expectedEnvVarValue string
+	}{{
+		name:                "threshold is zero (default) — env var must be absent",
+		threshold:           0,
+		expectEnvVarPresent: false,
+		expectedEnvVarValue: "",
+	}, {
+		name:                "threshold is 1 (minimum valid value)",
+		threshold:           1,
+		expectEnvVarPresent: true,
+		expectedEnvVarValue: "1",
+	}, {
+		name:                "threshold is 500 (common production value)",
+		threshold:           500,
+		expectEnvVarPresent: true,
+		expectedEnvVarValue: "500",
+	}, {
+		name:                "threshold is 10000 (large cluster value)",
+		threshold:           10000,
+		expectEnvVarPresent: true,
+		expectedEnvVarValue: "10000",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			ic.Spec.TuningOptions.HaproxyServerThreshold = tc.threshold
+
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
+			if err != nil {
+				t.Fatalf("failed to generate desired router Deployment: %v", err)
+			}
+
+			expectedEnv := []envData{{
+				name:          RouterMetricsHAProxyServerThreshold,
+				expectPresent: tc.expectEnvVarPresent,
+				expectedValue: tc.expectedEnvVarValue,
+			}}
+
+			if err := checkDeploymentEnvironment(t, deployment, expectedEnv); err != nil {
+				t.Errorf("environment variable check failed: %v", err)
+			}
+
+			checkDeploymentHasEnvSorted(t, deployment)
+		})
+	}
+}

--- a/vendor/github.com/openshift/api/operator/v1/types_ingress.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_ingress.go
@@ -2037,6 +2037,27 @@ type IngressControllerTuningOptions struct {
 	// +optional
 	MaxConnections int32 `json:"maxConnections,omitempty"`
 
+	// haproxyServerThreshold defines the maximum number of servers (backends) per HAProxy
+	// process for which HAProxy will report per-server metrics. When the number of servers
+	// exceeds this threshold, per-server metrics collection is disabled to prevent high
+	// Prometheus metric cardinality, which can cause significant memory and CPU overhead
+	// in large clusters.
+	//
+	// This value applies globally across all HAProxy processes on each ingress controller
+	// pod. Setting the threshold too high in clusters with many backends may cause
+	// excessive memory consumption in the monitoring stack.
+	//
+	// If this field is empty or 0, the IngressController will use the default value
+	// built into the router image. The current default is 500, but this is subject to
+	// change in future releases.
+	//
+	// The minimum allowed value is 1. There is no enforced upper bound, but values
+	// significantly above the number of active backends provide no benefit.
+	//
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	HaproxyServerThreshold int32 `json:"haproxyServerThreshold,omitempty"`
+
 	// reloadInterval defines the minimum interval at which the router is allowed to reload
 	// to accept new changes. Increasing this value can prevent the accumulation of
 	// HAProxy processes, depending on the scenario. Increasing this interval can


### PR DESCRIPTION
## Summary

`ROUTER_METRICS_HAPROXY_SERVER_THRESHOLD` controls the maximum number of HAProxy backends (servers) per shard for which per-server Prometheus metrics  are collected. When the number of active backends exceeds this threshold,
per-server metrics are suppressed to prevent high-cardinality metric explosions in the monitoring stack.

Previously this variable was hardcoded to a default of 500 inside the router image with no way to tune it via the IngressController API. This PR exposes it as `spec.tuningOptions.haproxyServerThreshold` so cluster administrators can adjust the value — for example, raising it to 1000 to match the typical number of routes per shard and improve metrics coverage in large clusters.