### PR TITLE
OCPBUGS-85690: Add referencegrants and backendtlspolicies to Gateway API RBAC

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -165,6 +165,8 @@ rules:
   - gateways
   - httproutes
   - grpcroutes
+  - referencegrants
+  - backendtlspolicies
   verbs:
   - '*'
 

--- a/pkg/manifests/assets/gateway-api/aggregated-cluster-roles/admin-cluster-role.yaml
+++ b/pkg/manifests/assets/gateway-api/aggregated-cluster-roles/admin-cluster-role.yaml
@@ -19,6 +19,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - referencegrants
+      - backendtlspolicies
     verbs:
       - get
       - list

--- a/pkg/manifests/assets/gateway-api/aggregated-cluster-roles/view-cluster-role.yaml
+++ b/pkg/manifests/assets/gateway-api/aggregated-cluster-roles/view-cluster-role.yaml
@@ -18,6 +18,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - referencegrants
+      - backendtlspolicies
     verbs:
       - get
       - list


### PR DESCRIPTION
## Summary
- Add `referencegrants` and `backendtlspolicies` to the aggregated admin/edit and view ClusterRoles so users with those roles can access all installed Gateway API resources
- Add the same resources to the operator's own ClusterRole in `manifests/00-cluster-role.yaml`

