### PR TITLE
OCPBUGS-85676: Harden CRD permission RBAC in operator ClusterRole

### DIFF
--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -173,7 +173,11 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - update
+  - watch
 
 - apiGroups:
   - operators.coreos.com

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -343,13 +343,17 @@ func testGatewayAPIResourcesProtection(t *testing.T) {
 	t.Cleanup(func() {
 		bypassVAP(t, deleteTestCRDs)
 	})
-	// Get kube client which impersonates ingress operator's service account.
+	// Get kube client which impersonates the ingress operator's service
+	// account with cluster-admin RBAC.  The "system:masters" group
+	// ensures RBAC never blocks the request so the VAP is the only
+	// enforcement layer under test.
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
 		t.Fatalf("failed to get kube config: %v", err)
 	}
 	kubeConfig.Impersonate = rest.ImpersonationConfig{
 		UserName: "system:serviceaccount:openshift-ingress-operator:ingress-operator",
+		Groups:   []string{"system:masters"},
 	}
 	kubeClient, err := operatorclient.NewClient(kubeConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Replace wildcard `'*'` verbs on `customresourcedefinitions` with the explicit verbs the operator actually uses: `create`, `get`, `list`, `update`, `watch`
- Removes implicit access to `delete`, `patch`, and `deletecollection` which the operator never performs on CRDs