### PR TITLE
OCPBUGS-36723: Add missing include annotations to IBM Cloud and PowerVS ingress CredentialsRequests

### DIFF
--- a/manifests/00-ingress-credentials-request.yaml
+++ b/manifests/00-ingress-credentials-request.yaml
@@ -90,10 +90,15 @@ spec:
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: openshift-ingress-ibmcloud
   namespace: openshift-cloud-credential-operator
   annotations:
     capability.openshift.io/name: CloudCredential+Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
@@ -120,10 +125,15 @@ spec:
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: openshift-ingress-powervs
   namespace: openshift-cloud-credential-operator
   annotations:
     capability.openshift.io/name: CloudCredential+Ingress
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1


### PR DESCRIPTION
## Summary

- Add `include.release.openshift.io` annotations and `controller-tools.k8s.io` label to IBM Cloud and PowerVS CredentialsRequest documents in `manifests/00-ingress-credentials-request.yaml`
- Matches the annotations already present on the AWS, Azure, and GCP documents in the same file

## Why this approach

The ingress credentials request file contains 5 YAML documents (one per cloud provider). The AWS, Azure, and GCP documents have:

```yaml
labels:
  controller-tools.k8s.io: "1.0"
annotations:
  capability.openshift.io/name: CloudCredential+Ingress
  include.release.openshift.io/ibm-cloud-managed: "true"
  include.release.openshift.io/self-managed-high-availability: "true"
  include.release.openshift.io/single-node-developer: "true"
```

The IBM Cloud and PowerVS documents only have the `capability.openshift.io/name` annotation.

When `oc adm release extract --credentials-requests --included` runs, it checks each document's `include.release.openshift.io/self-managed-high-availability` annotation. Documents without it are excluded with:

```
Excluding CredentialsRequest "openshift-ingress-ibmcloud": include.release.openshift.io/self-managed-high-availability unset
```

This means every IBM Cloud and PowerVS IPI installation using Manual credentials mode is missing the ingress credential and must work around it by extracting without `--included` and manually copying the file.

## Verification

Confirmed the filtering behavior using `oc adm release extract -v=4`:
- With this fix, IBM Cloud and PowerVS ingress CRs pass the `--included` filter
- Without this fix, they are excluded, producing only 4 of the required 5 credential secrets

Bug: https://issues.redhat.com/browse/OCPBUGS-36723