### PR TITLE
OCPBUGS-85680: Re-fetch infraConfig on every periodic loop iteration

### DIFF
--- a/pkg/operator/controller/ingress/replicas_test.go
+++ b/pkg/operator/controller/ingress/replicas_test.go
@@ -1,0 +1,69 @@
+package ingress
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestDetermineReplicas(t *testing.T) {
+	tests := []struct {
+		name             string
+		infraTopology    configv1.TopologyMode
+		cpTopology       configv1.TopologyMode
+		defaultPlacement configv1.DefaultPlacement
+		expect           int32
+	}{
+		{
+			name:          "HighlyAvailable infrastructure topology returns 2",
+			infraTopology: configv1.HighlyAvailableTopologyMode,
+			cpTopology:    configv1.HighlyAvailableTopologyMode,
+			expect:        2,
+		},
+		{
+			name:          "SingleReplica infrastructure topology returns 1",
+			infraTopology: configv1.SingleReplicaTopologyMode,
+			cpTopology:    configv1.HighlyAvailableTopologyMode,
+			expect:        1,
+		},
+		{
+			name:             "ControlPlane placement uses ControlPlaneTopology",
+			infraTopology:    configv1.HighlyAvailableTopologyMode,
+			cpTopology:       configv1.SingleReplicaTopologyMode,
+			defaultPlacement: configv1.DefaultPlacementControlPlane,
+			expect:           1,
+		},
+		{
+			name:             "ControlPlane placement with HighlyAvailable CP returns 2",
+			infraTopology:    configv1.SingleReplicaTopologyMode,
+			cpTopology:       configv1.HighlyAvailableTopologyMode,
+			defaultPlacement: configv1.DefaultPlacementControlPlane,
+			expect:           2,
+		},
+		{
+			name:          "empty topology defaults to 2",
+			infraTopology: "",
+			cpTopology:    "",
+			expect:        2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			infraConfig := &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureTopology: tc.infraTopology,
+					ControlPlaneTopology:   tc.cpTopology,
+				},
+			}
+			ingressConfig := &configv1.Ingress{
+				Status: configv1.IngressStatus{
+					DefaultPlacement: tc.defaultPlacement,
+				},
+			}
+			got := DetermineReplicas(ingressConfig, infraConfig)
+			if got != tc.expect {
+				t.Errorf("expected %d replicas, got %d", tc.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -384,33 +384,32 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 // TODO: Move the default IngressController logic elsewhere.
 func (o *Operator) Start(ctx context.Context) error {
 
-	infraConfig := &configv1.Infrastructure{}
-	if err := o.client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
-		return fmt.Errorf("failed fetching infrastructure config: %w", err)
-	}
-
-	if infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
-		log.Info("skipping default ingress controller creation")
-	} else {
-		// Periodicaly ensure the default controller exists.
-		go wait.Until(func() {
-			if !o.manager.GetCache().WaitForCacheSync(ctx) {
-				log.Error(nil, "failed to sync cache before ensuring default ingresscontroller")
-				return
-			}
-			ingressConfigName := operatorcontroller.IngressClusterConfigName()
-			ingressConfig := &configv1.Ingress{}
-			if err := o.client.Get(context.TODO(), ingressConfigName, ingressConfig); err != nil {
-				log.Error(err, "failed to fetch ingress config")
-				return
-			}
-			err := o.ensureDefaultIngressController(infraConfig, ingressConfig)
-			if err != nil {
-				log.Error(err, "failed to ensure default ingresscontroller")
-			}
-		}, 1*time.Minute, ctx.Done())
-
-	}
+	// Periodically ensure the default controller exists.
+	go wait.Until(func() {
+		if !o.manager.GetCache().WaitForCacheSync(ctx) {
+			log.Info("failed to sync cache before ensuring default ingresscontroller")
+			return
+		}
+		infraConfig := &configv1.Infrastructure{}
+		if err := o.client.Get(context.TODO(), operatorcontroller.InfrastructureClusterConfigName(), infraConfig); err != nil {
+			log.Error(err, "failed to fetch infrastructure config")
+			return
+		}
+		if infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			log.V(4).Info("skipping default ingress controller creation for external topology")
+			return
+		}
+		ingressConfigName := operatorcontroller.IngressClusterConfigName()
+		ingressConfig := &configv1.Ingress{}
+		if err := o.client.Get(context.TODO(), ingressConfigName, ingressConfig); err != nil {
+			log.Error(err, "failed to fetch ingress config")
+			return
+		}
+		err := o.ensureDefaultIngressController(infraConfig, ingressConfig)
+		if err != nil {
+			log.Error(err, "failed to ensure default ingresscontroller")
+		}
+	}, 1*time.Minute, ctx.Done())
 
 	if err := o.handleSingleNode4Dot11Upgrade(); err != nil {
 		log.Error(err, "failed to handle single node 4.11 upgrade logic")


### PR DESCRIPTION
## Problem

The `Infrastructure` config (which includes `ControlPlaneTopology`) is fetched once during `Operator.Start()` and reused on every 1 minute reconciliation tick. If the topology changes at runtime, the operator never detects it and continues using stale configuration until it is restarted.

This was identified as problematic

We follow the pattern of the `Ingress` config where it is already re-fetched inside the periodic loop.

## Solution

- Move the `Infrastructure` config fetch inside the periodic `wait.Until` loop, matching the pattern already used for the `Ingress` config
- The `ExternalTopologyMode` check is now evaluated each tick, allowing the operator to respond to topology transitions without a restart
- Add unit tests for `DetermineReplicas()` which had no prior test coverage