### PR TITLE
[release-4.21] OCPBUGS-88295, OCPBUGS-88297, OCPBUGS-82146, OCPBUGS-78330, OCPBUGS-85550: Remove feature-set annotations from Sail Library RBAC Manifests

### DIFF
--- a/manifests/00-cluster-role-sail-library.yaml
+++ b/manifests/00-cluster-role-sail-library.yaml
@@ -31,7 +31,6 @@ metadata:
   name: openshift-ingress-operator-sail-library
   annotations:
     capability.openshift.io/name: Ingress
-    release.openshift.io/feature-set: DevPreviewNoUpgrade,TechPreviewNoUpgrade # Remove when GA
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/01-cluster-role-binding-sail-library.yaml
+++ b/manifests/01-cluster-role-binding-sail-library.yaml
@@ -7,7 +7,6 @@ metadata:
   name: openshift-ingress-operator-sail-library
   annotations:
     capability.openshift.io/name: Ingress
-    release.openshift.io/feature-set: DevPreviewNoUpgrade,TechPreviewNoUpgrade # Remove when GA
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
## Summary

Remove the `release.openshift.io/feature-set: DevPreviewNoUpgrade,TechPreviewNoUpgrade` annotation from the Sail Library ClusterRole and ClusterRoleBinding manifests. This annotation restricts CVO from deploying these RBAC resources on clusters running the Default feature set. Removing it is required before promoting the `GatewayAPIWithoutOLM` feature gate to GA.

Depends on #1442. Blocks [openshift/api#2865](https://github.com/openshift/api/pull/2865) (FG promotion to Default/GA).

### Why this annotation needs to be removed in 4.21

On 4.22, https://github.com/openshift/cluster-ingress-operator/pull/1393 switched the Sail Library RBAC manifests from the `release.openshift.io/feature-set` annotation to the `release.openshift.io/feature-gate` annotation, which allows CVO to gate manifest deployment on individual feature gates rather than entire feature sets. However, CVO on 4.21 does not support the `release.openshift.io/feature-gate` annotation https://github.com/openshift/cluster-version-operator/pull/1273 was not backported.

As a result, the 4.21 backport https://github.com/openshift/cluster-ingress-operator/pull/1442 uses the `release.openshift.io/feature-set` annotation instead, which gates the RBAC manifests behind TechPreviewNoUpgrade. This PR removes that annotation so the RBAC is deployed on Default clusters, which is required before promoting the feature gate to GA.