### PR TITLE
OCPBUGS-86841: Add BackendTLSPolicy and ReferenceGrant e2e test coverage helpers

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -158,9 +158,7 @@ func testGatewayAPIResources(t *testing.T) {
 	ensureCRDs(t)
 
 	// Verify that all Gateway API CRDs on the cluster are in our test list.
-	if err := assertAllGatewayAPICRDsCovered(t, crdNames); err != nil {
-		t.Errorf("CRD coverage gap: %v", err)
-	}
+	assertAllGatewayAPICRDsCovered(t, crdNames)
 
 	// Deleting CRDs to ensure they gets recreated again
 	bypassVAP(t, deleteCRDs)
@@ -1653,31 +1651,11 @@ func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 	}
 	// The http route is cleaned up when the namespace is deleted.
 
-	// Create BackendTLSPolicy and ReferenceGrant if their CRDs are available.
-	// These CRDs are installed by the operator but not reconciled, so this
-	// validates the CRD schemas are functional and objects can be persisted.
-	// The CRD existence check allows safe backporting to older branches.
-	btlsCRD := &apiextensionsv1.CustomResourceDefinition{}
-	if err := kclient.Get(t.Context(), types.NamespacedName{Name: "backendtlspolicies.gateway.networking.k8s.io"}, btlsCRD); kerrors.IsNotFound(err) {
-		t.Log("BackendTLSPolicy CRD not found, skipping creation test")
-	} else if err != nil {
-		return fmt.Errorf("failed to check for BackendTLSPolicy CRD: %w", err)
-	} else {
-		if err := createBackendTLSPolicy(t, ns); err != nil {
-			return fmt.Errorf("BackendTLSPolicy object could not be created: %w", err)
-		}
-	}
-
-	refGrantCRD := &apiextensionsv1.CustomResourceDefinition{}
-	if err := kclient.Get(t.Context(), types.NamespacedName{Name: "referencegrants.gateway.networking.k8s.io"}, refGrantCRD); kerrors.IsNotFound(err) {
-		t.Log("ReferenceGrant CRD not found, skipping creation test")
-	} else if err != nil {
-		return fmt.Errorf("failed to check for ReferenceGrant CRD: %w", err)
-	} else {
-		if err := createReferenceGrant(t, ns); err != nil {
-			return fmt.Errorf("ReferenceGrant object could not be created: %w", err)
-		}
-	}
+	// Create BackendTLSPolicy and ReferenceGrant CR instances. The operator
+	// installs these CRDs but does not reconcile them, so this validates
+	// the CRD schemas are functional and objects can be persisted.
+	createBackendTLSPolicy(t, ns)
+	createReferenceGrant(t, ns)
 
 	return nil
 }

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -157,6 +157,9 @@ func testGatewayAPIResources(t *testing.T) {
 	// Make sure all the *.gateway.networking.k8s.io CRDs are available since the FeatureGate is enabled.
 	ensureCRDs(t)
 
+	// Verify that all Gateway API CRDs on the cluster are in our test list.
+	assertAllGatewayAPICRDsCovered(t, crdNames)
+
 	// Deleting CRDs to ensure they gets recreated again
 	bypassVAP(t, deleteCRDs)
 
@@ -557,6 +560,9 @@ func testGatewayAPIRBAC(t *testing.T) {
 	}
 
 	for srcClusterRoleName, destClusterRoleNames := range aggregationMapping {
+		t.Logf("verifying that ClusterRole %s covers all namespaced Gateway API CRDs", srcClusterRoleName)
+		assertClusterRoleCoversGatewayAPICRDs(t, srcClusterRoleName)
+
 		for _, destClusterRoleName := range destClusterRoleNames {
 			t.Logf("verifying that ClusterRole %s aggregates all PolicyRules from %s", destClusterRoleName, srcClusterRoleName)
 
@@ -1644,6 +1650,12 @@ func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 		return fmt.Errorf("feature gate was enabled, but http route object could not be created: %v", err)
 	}
 	// The http route is cleaned up when the namespace is deleted.
+
+	// Create BackendTLSPolicy and ReferenceGrant CR instances. The operator
+	// installs these CRDs but does not reconcile them, so this validates
+	// the CRD schemas are functional and objects can be persisted.
+	createBackendTLSPolicy(t, ns)
+	createReferenceGrant(t, ns)
 
 	return nil
 }

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -125,6 +125,7 @@ func TestGatewayAPI(t *testing.T) {
 	})
 
 	t.Run("testGatewayAPIResources", testGatewayAPIResources)
+	t.Run("testGatewayAPICRDValidation", testGatewayAPICRDValidation)
 	t.Run("testGatewayAPIObjects", testGatewayAPIObjects)
 	t.Run("testGatewayAPIManualDeployment", testGatewayAPIManualDeployment)
 	if gatewayAPIWithoutOLMEnabled {
@@ -284,6 +285,21 @@ func testGatewayAPIIstioUninstallSailLibrary(t *testing.T) {
 	if err := assertIstioCRDs(t); err != nil {
 		t.Fatalf("Istio CRDs should persist after uninstall: %v", err)
 	}
+}
+
+// testGatewayAPICRDValidation tests that BackendTLSPolicy and ReferenceGrant
+// custom resources can be created and are accepted by the API server. These
+// CRDs are installed by the operator but not reconciled, so this validates
+// the CRD schemas are functional.
+func testGatewayAPICRDValidation(t *testing.T) {
+	ns := createNamespace(t, names.SimpleNameGenerator.GenerateName("test-e2e-gwapi-crd-"))
+
+	t.Run("BackendTLSPolicy", func(t *testing.T) {
+		testBackendTLSPolicyCreation(t, ns)
+	})
+	t.Run("ReferenceGrant", func(t *testing.T) {
+		testReferenceGrantCreation(t, ns)
+	})
 }
 
 // testGatewayAPIObjects tests that Gateway API objects can be created successfully.

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -157,6 +157,9 @@ func testGatewayAPIResources(t *testing.T) {
 	// Make sure all the *.gateway.networking.k8s.io CRDs are available since the FeatureGate is enabled.
 	ensureCRDs(t)
 
+	// Verify that all Gateway API CRDs on the cluster are in our test list.
+	assertAllGatewayAPICRDsCovered(t, crdNames)
+
 	// Deleting CRDs to ensure they gets recreated again
 	bypassVAP(t, deleteCRDs)
 
@@ -557,6 +560,9 @@ func testGatewayAPIRBAC(t *testing.T) {
 	}
 
 	for srcClusterRoleName, destClusterRoleNames := range aggregationMapping {
+		t.Logf("verifying that ClusterRole %s covers all namespaced Gateway API CRDs", srcClusterRoleName)
+		assertClusterRoleCoversGatewayAPICRDs(t, srcClusterRoleName)
+
 		for _, destClusterRoleName := range destClusterRoleNames {
 			t.Logf("verifying that ClusterRole %s aggregates all PolicyRules from %s", destClusterRoleName, srcClusterRoleName)
 

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -125,7 +125,6 @@ func TestGatewayAPI(t *testing.T) {
 	})
 
 	t.Run("testGatewayAPIResources", testGatewayAPIResources)
-	t.Run("testGatewayAPICRDValidation", testGatewayAPICRDValidation)
 	t.Run("testGatewayAPIObjects", testGatewayAPIObjects)
 	t.Run("testGatewayAPIManualDeployment", testGatewayAPIManualDeployment)
 	if gatewayAPIWithoutOLMEnabled {
@@ -159,7 +158,9 @@ func testGatewayAPIResources(t *testing.T) {
 	ensureCRDs(t)
 
 	// Verify that all Gateway API CRDs on the cluster are in our test list.
-	assertAllGatewayAPICRDsCovered(t, crdNames)
+	if err := assertAllGatewayAPICRDsCovered(t, crdNames); err != nil {
+		t.Errorf("CRD coverage gap: %v", err)
+	}
 
 	// Deleting CRDs to ensure they gets recreated again
 	bypassVAP(t, deleteCRDs)
@@ -285,21 +286,6 @@ func testGatewayAPIIstioUninstallSailLibrary(t *testing.T) {
 	if err := assertIstioCRDs(t); err != nil {
 		t.Fatalf("Istio CRDs should persist after uninstall: %v", err)
 	}
-}
-
-// testGatewayAPICRDValidation tests that BackendTLSPolicy and ReferenceGrant
-// custom resources can be created and are accepted by the API server. These
-// CRDs are installed by the operator but not reconciled, so this validates
-// the CRD schemas are functional.
-func testGatewayAPICRDValidation(t *testing.T) {
-	ns := createNamespace(t, names.SimpleNameGenerator.GenerateName("test-e2e-gwapi-crd-"))
-
-	t.Run("BackendTLSPolicy", func(t *testing.T) {
-		testBackendTLSPolicyCreation(t, ns)
-	})
-	t.Run("ReferenceGrant", func(t *testing.T) {
-		testReferenceGrantCreation(t, ns)
-	})
 }
 
 // testGatewayAPIObjects tests that Gateway API objects can be created successfully.
@@ -1666,6 +1652,32 @@ func ensureGatewayObjectCreation(t *testing.T, ns *corev1.Namespace) error {
 		return fmt.Errorf("feature gate was enabled, but http route object could not be created: %v", err)
 	}
 	// The http route is cleaned up when the namespace is deleted.
+
+	// Create BackendTLSPolicy and ReferenceGrant if their CRDs are available.
+	// These CRDs are installed by the operator but not reconciled, so this
+	// validates the CRD schemas are functional and objects can be persisted.
+	// The CRD existence check allows safe backporting to older branches.
+	btlsCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := kclient.Get(t.Context(), types.NamespacedName{Name: "backendtlspolicies.gateway.networking.k8s.io"}, btlsCRD); kerrors.IsNotFound(err) {
+		t.Log("BackendTLSPolicy CRD not found, skipping creation test")
+	} else if err != nil {
+		return fmt.Errorf("failed to check for BackendTLSPolicy CRD: %w", err)
+	} else {
+		if err := createBackendTLSPolicy(t, ns); err != nil {
+			return fmt.Errorf("BackendTLSPolicy object could not be created: %w", err)
+		}
+	}
+
+	refGrantCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := kclient.Get(t.Context(), types.NamespacedName{Name: "referencegrants.gateway.networking.k8s.io"}, refGrantCRD); kerrors.IsNotFound(err) {
+		t.Log("ReferenceGrant CRD not found, skipping creation test")
+	} else if err != nil {
+		return fmt.Errorf("failed to check for ReferenceGrant CRD: %w", err)
+	} else {
+		if err := createReferenceGrant(t, ns); err != nil {
+			return fmt.Errorf("ReferenceGrant object could not be created: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -33,6 +33,9 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -1591,12 +1594,10 @@ func eventuallyClusterRoleContainsAggregatedPolicies(t *testing.T, destClusterRo
 	})
 }
 
-func assertAllGatewayAPICRDsCovered(t *testing.T, wantCRDs []string) error {
+func assertAllGatewayAPICRDsCovered(t *testing.T, wantCRDs []string) {
 	t.Helper()
 	haveCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := kclient.List(t.Context(), haveCRDs); err != nil {
-		t.Fatalf("failed to list CRDs: %v", err)
-	}
+	require.NoError(t, kclient.List(t.Context(), haveCRDs), "failed to list CRDs")
 	var extraCRDs []string
 	for _, crd := range haveCRDs.Items {
 		if crd.Spec.Group == "gateway.networking.k8s.io" {
@@ -1605,33 +1606,27 @@ func assertAllGatewayAPICRDsCovered(t *testing.T, wantCRDs []string) error {
 			}
 		}
 	}
-	if len(extraCRDs) > 0 {
-		return fmt.Errorf("Gateway API CRDs installed but not tested: %q", extraCRDs)
-	}
-	return nil
+	assert.Len(t, extraCRDs, 0, "Gateway API CRDs installed but not tested: %q", extraCRDs)
 }
 
 func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string) {
 	t.Helper()
 
 	var clusterRole rbacv1.ClusterRole
-	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		if err := kclient.Get(ctx, types.NamespacedName{Name: clusterRoleName}, &clusterRole); err != nil {
 			t.Logf("failed to get ClusterRole %s: %v; retrying...", clusterRoleName, err)
 			return false, nil
 		}
 		return true, nil
-	}); err != nil {
-		t.Fatalf("failed to get ClusterRole %s: %v", clusterRoleName, err)
-	}
+	})
+	require.NoError(t, err, "failed to get ClusterRole %s", clusterRoleName)
 
 	var roleResources []string
 	for _, rule := range clusterRole.Rules {
 		if slices.Contains(rule.APIGroups, "gateway.networking.k8s.io") {
 			for _, res := range rule.Resources {
-				if res == "*" {
-					t.Fatalf("ClusterRole %s uses wildcard resource for gateway.networking.k8s.io; expected explicit resource names", clusterRoleName)
-				}
+				require.NotEqual(t, "*", res, "ClusterRole %s uses wildcard resource for gateway.networking.k8s.io; expected explicit resource names", clusterRoleName)
 				// Skip subresources (e.g. gatewayclasses/status) since
 				// we are only checking top-level resource coverage.
 				if !strings.Contains(res, "/") {
@@ -1642,21 +1637,13 @@ func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string)
 	}
 
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := kclient.List(t.Context(), crdList); err != nil {
-		t.Fatalf("failed to list CRDs: %v", err)
-	}
+	require.NoError(t, kclient.List(t.Context(), crdList), "failed to list CRDs")
 	for _, crd := range crdList.Items {
-		if crd.Spec.Group != "gateway.networking.k8s.io" {
-			continue
-		}
 		// Cluster-scoped CRDs (e.g. GatewayClass) use separate RBAC and
 		// are not expected in namespace-scoped aggregated ClusterRoles.
-		if crd.Spec.Scope == apiextensionsv1.ClusterScoped {
-			continue
-		}
-		plural := crd.Spec.Names.Plural
-		if !slices.Contains(roleResources, plural) {
-			t.Errorf("ClusterRole %s missing rule for Gateway API resource %q (CRD %s)", clusterRoleName, plural, crd.Name)
+		if crd.Spec.Group == "gateway.networking.k8s.io" && crd.Spec.Scope == apiextensionsv1.NamespaceScoped {
+			assert.Contains(t, roleResources, crd.Spec.Names.Plural,
+				"ClusterRole %s missing rule for Gateway API resource %q (CRD %s)", clusterRoleName, crd.Spec.Names.Plural, crd.Name)
 		}
 	}
 }
@@ -1722,7 +1709,7 @@ func buildBackendTLSPolicy(name, namespace, targetServiceName, configMapName, ho
 
 // createBackendTLSPolicy creates the prerequisite Service and ConfigMap, then
 // creates a BackendTLSPolicy and verifies it can be retrieved from the API server.
-func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) error {
+func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -1740,9 +1727,7 @@ func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) error {
 			Selector: map[string]string{"app": "btlspolicy-target"},
 		},
 	}
-	if err := createWithRetryOnError(t, ctx, svc, DefaultRetryTimeout); err != nil {
-		return fmt.Errorf("failed to create target service: %w", err)
-	}
+	require.NoError(t, createWithRetryOnError(t, ctx, svc, DefaultRetryTimeout), "failed to create target service")
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1753,27 +1738,20 @@ func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) error {
 			"ca.crt": "placeholder-ca-cert-data",
 		},
 	}
-	if err := createWithRetryOnError(t, ctx, cm, DefaultRetryTimeout); err != nil {
-		return fmt.Errorf("failed to create CA cert configmap: %w", err)
-	}
+	require.NoError(t, createWithRetryOnError(t, ctx, cm, DefaultRetryTimeout), "failed to create CA cert configmap")
 
 	btlsPolicy := buildBackendTLSPolicy("test-btlspolicy", ns.Name, svc.Name, cm.Name, "backend.example.com")
-	if err := createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout); err != nil {
-		return fmt.Errorf("failed to create BackendTLSPolicy: %w", err)
-	}
+	require.NoError(t, createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout), "failed to create BackendTLSPolicy")
 
 	retrieved := &gatewayapiv1.BackendTLSPolicy{}
-	if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved); err != nil {
-		return fmt.Errorf("failed to get created BackendTLSPolicy: %w", err)
-	}
+	require.NoError(t, kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved), "failed to get created BackendTLSPolicy")
 	t.Logf("successfully created and retrieved BackendTLSPolicy %s/%s", retrieved.Namespace, retrieved.Name)
-	return nil
 }
 
-func buildReferenceGrantUnstructured(name, namespace string) *unstructured.Unstructured {
-	refGrant := &unstructured.Unstructured{
+func buildReferenceGrantUnstructured(name, namespace, version string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "gateway.networking.k8s.io/v1beta1",
+			"apiVersion": "gateway.networking.k8s.io/" + version,
 			"kind":       "ReferenceGrant",
 			"metadata": map[string]interface{}{
 				"name":      name,
@@ -1796,29 +1774,43 @@ func buildReferenceGrantUnstructured(name, namespace string) *unstructured.Unstr
 			},
 		},
 	}
-	return refGrant
+}
+
+// referenceGrantStorageVersion returns the storage version of the ReferenceGrant
+// CRD so we can build unstructured objects with the correct apiVersion rather
+// than hardcoding v1beta1, which may change as the API graduates.
+func referenceGrantStorageVersion(t *testing.T) string {
+	t.Helper()
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	require.NoError(t, kclient.Get(t.Context(),
+		types.NamespacedName{Name: "referencegrants.gateway.networking.k8s.io"}, crd),
+		"failed to get ReferenceGrant CRD")
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			return v.Name
+		}
+	}
+	return "v1beta1"
 }
 
 // createReferenceGrant creates a ReferenceGrant using unstructured objects (since
-// v1beta1 is not vendored) and verifies it can be retrieved from the API server.
-func createReferenceGrant(t *testing.T, ns *corev1.Namespace) error {
+// the Go type lives in v1beta1 which is not vendored) and verifies it can be
+// retrieved from the API server. The version is determined dynamically from the
+// CRD to avoid hardcoding v1beta1 across a Gateway API upgrade.
+func createReferenceGrant(t *testing.T, ns *corev1.Namespace) {
 	t.Helper()
 	ctx := t.Context()
 
-	refGrant := buildReferenceGrantUnstructured("test-referencegrant", ns.Name)
-	if err := createWithRetryOnError(t, ctx, refGrant, DefaultRetryTimeout); err != nil {
-		return fmt.Errorf("failed to create ReferenceGrant: %w", err)
-	}
+	version := referenceGrantStorageVersion(t)
+	refGrant := buildReferenceGrantUnstructured("test-referencegrant", ns.Name, version)
+	require.NoError(t, createWithRetryOnError(t, ctx, refGrant, DefaultRetryTimeout), "failed to create ReferenceGrant")
 
 	retrieved := &unstructured.Unstructured{}
 	retrieved.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "gateway.networking.k8s.io",
-		Version: "v1beta1",
+		Version: version,
 		Kind:    "ReferenceGrant",
 	})
-	if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-referencegrant"}, retrieved); err != nil {
-		return fmt.Errorf("failed to get created ReferenceGrant: %w", err)
-	}
+	require.NoError(t, kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-referencegrant"}, retrieved), "failed to get created ReferenceGrant")
 	t.Logf("successfully created and retrieved ReferenceGrant %s/%s", retrieved.GetNamespace(), retrieved.GetName())
-	return nil
 }

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -1589,6 +1589,60 @@ func eventuallyClusterRoleContainsAggregatedPolicies(t *testing.T, destClusterRo
 	})
 }
 
+func assertAllGatewayAPICRDsCovered(t *testing.T, crdNames []string) {
+	t.Helper()
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := kclient.List(context.Background(), crdList); err != nil {
+		t.Fatalf("failed to list CRDs: %v", err)
+	}
+	for _, crd := range crdList.Items {
+		if crd.Spec.Group == "gateway.networking.k8s.io" {
+			if !slices.Contains(crdNames, crd.Name) {
+				t.Errorf("Gateway API CRD %q exists on cluster but is not in crdNames; add it to ensure test coverage", crd.Name)
+			}
+		}
+	}
+}
+
+func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string) {
+	t.Helper()
+
+	var clusterRole rbacv1.ClusterRole
+	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, types.NamespacedName{Name: clusterRoleName}, &clusterRole); err != nil {
+			t.Logf("failed to get ClusterRole %s: %v; retrying...", clusterRoleName, err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to get ClusterRole %s: %v", clusterRoleName, err)
+	}
+
+	var roleResources []string
+	for _, rule := range clusterRole.Rules {
+		if slices.Contains(rule.APIGroups, "gateway.networking.k8s.io") {
+			roleResources = append(roleResources, rule.Resources...)
+		}
+	}
+
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := kclient.List(context.Background(), crdList); err != nil {
+		t.Fatalf("failed to list CRDs: %v", err)
+	}
+	for _, crd := range crdList.Items {
+		if crd.Spec.Group != "gateway.networking.k8s.io" {
+			continue
+		}
+		if crd.Spec.Scope == apiextensionsv1.ClusterScoped {
+			continue
+		}
+		plural := crd.Spec.Names.Plural
+		if !slices.Contains(roleResources, plural) {
+			t.Errorf("ClusterRole %s missing rule for Gateway API resource %q (CRD %s)", clusterRoleName, plural, crd.Name)
+		}
+	}
+}
+
 func containsPolicyRules(destRules, srcRules []rbacv1.PolicyRule) bool {
 	for _, srcRule := range srcRules {
 		if !slices.ContainsFunc(destRules, func(destRule rbacv1.PolicyRule) bool {

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -33,6 +33,8 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -1674,4 +1676,141 @@ func updateGatewaySpecWithRetry(t *testing.T, name types.NamespacedName, timeout
 		}
 		return true, nil
 	})
+}
+
+func buildBackendTLSPolicy(name, namespace, targetServiceName, configMapName, hostname string) *gatewayapiv1.BackendTLSPolicy {
+	return &gatewayapiv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayapiv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayapiv1.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayapiv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayapiv1.ObjectName(targetServiceName),
+				},
+			}},
+			Validation: gatewayapiv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayapiv1.LocalObjectReference{{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  gatewayapiv1.ObjectName(configMapName),
+				}},
+				Hostname: gatewayapiv1.PreciseHostname(hostname),
+			},
+		},
+	}
+}
+
+func testBackendTLSPolicyCreation(t *testing.T, ns *corev1.Namespace) {
+	t.Helper()
+	ctx := context.Background()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "btlspolicy-target-svc",
+			Namespace: ns.Name,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name:     "https",
+				Port:     443,
+				Protocol: corev1.ProtocolTCP,
+			}},
+			Selector: map[string]string{"app": "btlspolicy-target"},
+		},
+	}
+	if err := createWithRetryOnError(t, ctx, svc, DefaultRetryTimeout); err != nil {
+		t.Fatalf("failed to create target service: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "btlspolicy-ca-cert",
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			"ca.crt": "placeholder-ca-cert-data",
+		},
+	}
+	if err := createWithRetryOnError(t, ctx, cm, DefaultRetryTimeout); err != nil {
+		t.Fatalf("failed to create CA cert configmap: %v", err)
+	}
+
+	t.Run("validCreation", func(t *testing.T) {
+		btlsPolicy := buildBackendTLSPolicy("test-btlspolicy", ns.Name, svc.Name, cm.Name, "backend.example.com")
+		if err := createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout); err != nil {
+			t.Fatalf("failed to create BackendTLSPolicy: %v", err)
+		}
+
+		retrieved := &gatewayapiv1.BackendTLSPolicy{}
+		if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved); err != nil {
+			t.Fatalf("failed to get created BackendTLSPolicy: %v", err)
+		}
+		t.Logf("successfully created and retrieved BackendTLSPolicy %s/%s", retrieved.Namespace, retrieved.Name)
+	})
+
+	t.Run("celValidationRejectsBothCACertAndWellKnown", func(t *testing.T) {
+		invalidPolicy := buildBackendTLSPolicy("test-btlspolicy-invalid", ns.Name, svc.Name, cm.Name, "backend.example.com")
+		wellKnown := gatewayapiv1.WellKnownCACertificatesSystem
+		invalidPolicy.Spec.Validation.WellKnownCACertificates = &wellKnown
+
+		err := kclient.Create(ctx, invalidPolicy)
+		if err == nil {
+			t.Fatal("expected CEL validation to reject BackendTLSPolicy with both CACertificateRefs and WellKnownCACertificates, but creation succeeded")
+		}
+		t.Logf("CEL validation correctly rejected invalid BackendTLSPolicy: %v", err)
+	})
+}
+
+func buildReferenceGrantUnstructured(name, namespace string) *unstructured.Unstructured {
+	refGrant := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1beta1",
+			"kind":       "ReferenceGrant",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"from": []interface{}{
+					map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "HTTPRoute",
+						"namespace": namespace,
+					},
+				},
+				"to": []interface{}{
+					map[string]interface{}{
+						"group": "",
+						"kind":  "Service",
+					},
+				},
+			},
+		},
+	}
+	return refGrant
+}
+
+func testReferenceGrantCreation(t *testing.T, ns *corev1.Namespace) {
+	t.Helper()
+	ctx := context.Background()
+
+	refGrant := buildReferenceGrantUnstructured("test-referencegrant", ns.Name)
+	if err := createWithRetryOnError(t, ctx, refGrant, DefaultRetryTimeout); err != nil {
+		t.Fatalf("failed to create ReferenceGrant: %v", err)
+	}
+
+	retrieved := &unstructured.Unstructured{}
+	retrieved.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "gateway.networking.k8s.io",
+		Version: "v1beta1",
+		Kind:    "ReferenceGrant",
+	})
+	if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-referencegrant"}, retrieved); err != nil {
+		t.Fatalf("failed to get created ReferenceGrant: %v", err)
+	}
+	t.Logf("successfully created and retrieved ReferenceGrant %s/%s", retrieved.GetNamespace(), retrieved.GetName())
 }

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -1591,19 +1591,24 @@ func eventuallyClusterRoleContainsAggregatedPolicies(t *testing.T, destClusterRo
 	})
 }
 
-func assertAllGatewayAPICRDsCovered(t *testing.T, crdNames []string) {
+func assertAllGatewayAPICRDsCovered(t *testing.T, wantCRDs []string) error {
 	t.Helper()
-	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := kclient.List(context.Background(), crdList); err != nil {
+	haveCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := kclient.List(t.Context(), haveCRDs); err != nil {
 		t.Fatalf("failed to list CRDs: %v", err)
 	}
-	for _, crd := range crdList.Items {
+	var extraCRDs []string
+	for _, crd := range haveCRDs.Items {
 		if crd.Spec.Group == "gateway.networking.k8s.io" {
-			if !slices.Contains(crdNames, crd.Name) {
-				t.Errorf("Gateway API CRD %q exists on cluster but is not in crdNames; add it to ensure test coverage", crd.Name)
+			if !slices.Contains(wantCRDs, crd.Name) {
+				extraCRDs = append(extraCRDs, crd.Name)
 			}
 		}
 	}
+	if len(extraCRDs) > 0 {
+		return fmt.Errorf("Gateway API CRDs installed but not tested: %q", extraCRDs)
+	}
+	return nil
 }
 
 func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string) {
@@ -1623,18 +1628,29 @@ func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string)
 	var roleResources []string
 	for _, rule := range clusterRole.Rules {
 		if slices.Contains(rule.APIGroups, "gateway.networking.k8s.io") {
-			roleResources = append(roleResources, rule.Resources...)
+			for _, res := range rule.Resources {
+				if res == "*" {
+					t.Fatalf("ClusterRole %s uses wildcard resource for gateway.networking.k8s.io; expected explicit resource names", clusterRoleName)
+				}
+				// Skip subresources (e.g. gatewayclasses/status) since
+				// we are only checking top-level resource coverage.
+				if !strings.Contains(res, "/") {
+					roleResources = append(roleResources, res)
+				}
+			}
 		}
 	}
 
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := kclient.List(context.Background(), crdList); err != nil {
+	if err := kclient.List(t.Context(), crdList); err != nil {
 		t.Fatalf("failed to list CRDs: %v", err)
 	}
 	for _, crd := range crdList.Items {
 		if crd.Spec.Group != "gateway.networking.k8s.io" {
 			continue
 		}
+		// Cluster-scoped CRDs (e.g. GatewayClass) use separate RBAC and
+		// are not expected in namespace-scoped aggregated ClusterRoles.
 		if crd.Spec.Scope == apiextensionsv1.ClusterScoped {
 			continue
 		}
@@ -1704,9 +1720,11 @@ func buildBackendTLSPolicy(name, namespace, targetServiceName, configMapName, ho
 	}
 }
 
-func testBackendTLSPolicyCreation(t *testing.T, ns *corev1.Namespace) {
+// createBackendTLSPolicy creates the prerequisite Service and ConfigMap, then
+// creates a BackendTLSPolicy and verifies it can be retrieved from the API server.
+func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) error {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1723,7 +1741,7 @@ func testBackendTLSPolicyCreation(t *testing.T, ns *corev1.Namespace) {
 		},
 	}
 	if err := createWithRetryOnError(t, ctx, svc, DefaultRetryTimeout); err != nil {
-		t.Fatalf("failed to create target service: %v", err)
+		return fmt.Errorf("failed to create target service: %w", err)
 	}
 
 	cm := &corev1.ConfigMap{
@@ -1736,33 +1754,20 @@ func testBackendTLSPolicyCreation(t *testing.T, ns *corev1.Namespace) {
 		},
 	}
 	if err := createWithRetryOnError(t, ctx, cm, DefaultRetryTimeout); err != nil {
-		t.Fatalf("failed to create CA cert configmap: %v", err)
+		return fmt.Errorf("failed to create CA cert configmap: %w", err)
 	}
 
-	t.Run("validCreation", func(t *testing.T) {
-		btlsPolicy := buildBackendTLSPolicy("test-btlspolicy", ns.Name, svc.Name, cm.Name, "backend.example.com")
-		if err := createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout); err != nil {
-			t.Fatalf("failed to create BackendTLSPolicy: %v", err)
-		}
+	btlsPolicy := buildBackendTLSPolicy("test-btlspolicy", ns.Name, svc.Name, cm.Name, "backend.example.com")
+	if err := createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout); err != nil {
+		return fmt.Errorf("failed to create BackendTLSPolicy: %w", err)
+	}
 
-		retrieved := &gatewayapiv1.BackendTLSPolicy{}
-		if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved); err != nil {
-			t.Fatalf("failed to get created BackendTLSPolicy: %v", err)
-		}
-		t.Logf("successfully created and retrieved BackendTLSPolicy %s/%s", retrieved.Namespace, retrieved.Name)
-	})
-
-	t.Run("celValidationRejectsBothCACertAndWellKnown", func(t *testing.T) {
-		invalidPolicy := buildBackendTLSPolicy("test-btlspolicy-invalid", ns.Name, svc.Name, cm.Name, "backend.example.com")
-		wellKnown := gatewayapiv1.WellKnownCACertificatesSystem
-		invalidPolicy.Spec.Validation.WellKnownCACertificates = &wellKnown
-
-		err := kclient.Create(ctx, invalidPolicy)
-		if err == nil {
-			t.Fatal("expected CEL validation to reject BackendTLSPolicy with both CACertificateRefs and WellKnownCACertificates, but creation succeeded")
-		}
-		t.Logf("CEL validation correctly rejected invalid BackendTLSPolicy: %v", err)
-	})
+	retrieved := &gatewayapiv1.BackendTLSPolicy{}
+	if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved); err != nil {
+		return fmt.Errorf("failed to get created BackendTLSPolicy: %w", err)
+	}
+	t.Logf("successfully created and retrieved BackendTLSPolicy %s/%s", retrieved.Namespace, retrieved.Name)
+	return nil
 }
 
 func buildReferenceGrantUnstructured(name, namespace string) *unstructured.Unstructured {
@@ -1794,13 +1799,15 @@ func buildReferenceGrantUnstructured(name, namespace string) *unstructured.Unstr
 	return refGrant
 }
 
-func testReferenceGrantCreation(t *testing.T, ns *corev1.Namespace) {
+// createReferenceGrant creates a ReferenceGrant using unstructured objects (since
+// v1beta1 is not vendored) and verifies it can be retrieved from the API server.
+func createReferenceGrant(t *testing.T, ns *corev1.Namespace) error {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	refGrant := buildReferenceGrantUnstructured("test-referencegrant", ns.Name)
 	if err := createWithRetryOnError(t, ctx, refGrant, DefaultRetryTimeout); err != nil {
-		t.Fatalf("failed to create ReferenceGrant: %v", err)
+		return fmt.Errorf("failed to create ReferenceGrant: %w", err)
 	}
 
 	retrieved := &unstructured.Unstructured{}
@@ -1810,7 +1817,8 @@ func testReferenceGrantCreation(t *testing.T, ns *corev1.Namespace) {
 		Kind:    "ReferenceGrant",
 	})
 	if err := kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-referencegrant"}, retrieved); err != nil {
-		t.Fatalf("failed to get created ReferenceGrant: %v", err)
+		return fmt.Errorf("failed to get created ReferenceGrant: %w", err)
 	}
 	t.Logf("successfully created and retrieved ReferenceGrant %s/%s", retrieved.GetNamespace(), retrieved.GetName())
+	return nil
 }

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -33,6 +33,11 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -1589,6 +1594,60 @@ func eventuallyClusterRoleContainsAggregatedPolicies(t *testing.T, destClusterRo
 	})
 }
 
+func assertAllGatewayAPICRDsCovered(t *testing.T, wantCRDs []string) {
+	t.Helper()
+	haveCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
+	require.NoError(t, kclient.List(t.Context(), haveCRDs), "failed to list CRDs")
+	var extraCRDs []string
+	for _, crd := range haveCRDs.Items {
+		if crd.Spec.Group == "gateway.networking.k8s.io" {
+			if !slices.Contains(wantCRDs, crd.Name) {
+				extraCRDs = append(extraCRDs, crd.Name)
+			}
+		}
+	}
+	assert.Len(t, extraCRDs, 0, "Gateway API CRDs installed but not tested: %q", extraCRDs)
+}
+
+func assertClusterRoleCoversGatewayAPICRDs(t *testing.T, clusterRoleName string) {
+	t.Helper()
+
+	var clusterRole rbacv1.ClusterRole
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := kclient.Get(ctx, types.NamespacedName{Name: clusterRoleName}, &clusterRole); err != nil {
+			t.Logf("failed to get ClusterRole %s: %v; retrying...", clusterRoleName, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "failed to get ClusterRole %s", clusterRoleName)
+
+	var roleResources []string
+	for _, rule := range clusterRole.Rules {
+		if slices.Contains(rule.APIGroups, "gateway.networking.k8s.io") {
+			for _, res := range rule.Resources {
+				require.NotEqual(t, "*", res, "ClusterRole %s uses wildcard resource for gateway.networking.k8s.io; expected explicit resource names", clusterRoleName)
+				// Skip subresources (e.g. gatewayclasses/status) since
+				// we are only checking top-level resource coverage.
+				if !strings.Contains(res, "/") {
+					roleResources = append(roleResources, res)
+				}
+			}
+		}
+	}
+
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	require.NoError(t, kclient.List(t.Context(), crdList), "failed to list CRDs")
+	for _, crd := range crdList.Items {
+		// Cluster-scoped CRDs (e.g. GatewayClass) use separate RBAC and
+		// are not expected in namespace-scoped aggregated ClusterRoles.
+		if crd.Spec.Group == "gateway.networking.k8s.io" && crd.Spec.Scope == apiextensionsv1.NamespaceScoped {
+			assert.Contains(t, roleResources, crd.Spec.Names.Plural,
+				"ClusterRole %s missing rule for Gateway API resource %q (CRD %s)", clusterRoleName, crd.Spec.Names.Plural, crd.Name)
+		}
+	}
+}
+
 func containsPolicyRules(destRules, srcRules []rbacv1.PolicyRule) bool {
 	for _, srcRule := range srcRules {
 		if !slices.ContainsFunc(destRules, func(destRule rbacv1.PolicyRule) bool {
@@ -1620,4 +1679,138 @@ func updateGatewaySpecWithRetry(t *testing.T, name types.NamespacedName, timeout
 		}
 		return true, nil
 	})
+}
+
+func buildBackendTLSPolicy(name, namespace, targetServiceName, configMapName, hostname string) *gatewayapiv1.BackendTLSPolicy {
+	return &gatewayapiv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayapiv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayapiv1.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayapiv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  gatewayapiv1.ObjectName(targetServiceName),
+				},
+			}},
+			Validation: gatewayapiv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayapiv1.LocalObjectReference{{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  gatewayapiv1.ObjectName(configMapName),
+				}},
+				Hostname: gatewayapiv1.PreciseHostname(hostname),
+			},
+		},
+	}
+}
+
+// createBackendTLSPolicy creates the prerequisite Service and ConfigMap, then
+// creates a BackendTLSPolicy and verifies it can be retrieved from the API server.
+func createBackendTLSPolicy(t *testing.T, ns *corev1.Namespace) {
+	t.Helper()
+	ctx := t.Context()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "btlspolicy-target-svc",
+			Namespace: ns.Name,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name:     "https",
+				Port:     443,
+				Protocol: corev1.ProtocolTCP,
+			}},
+			Selector: map[string]string{"app": "btlspolicy-target"},
+		},
+	}
+	require.NoError(t, createWithRetryOnError(t, ctx, svc, DefaultRetryTimeout), "failed to create target service")
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "btlspolicy-ca-cert",
+			Namespace: ns.Name,
+		},
+		Data: map[string]string{
+			"ca.crt": "placeholder-ca-cert-data",
+		},
+	}
+	require.NoError(t, createWithRetryOnError(t, ctx, cm, DefaultRetryTimeout), "failed to create CA cert configmap")
+
+	btlsPolicy := buildBackendTLSPolicy("test-btlspolicy", ns.Name, svc.Name, cm.Name, "backend.example.com")
+	require.NoError(t, createWithRetryOnError(t, ctx, btlsPolicy, DefaultRetryTimeout), "failed to create BackendTLSPolicy")
+
+	retrieved := &gatewayapiv1.BackendTLSPolicy{}
+	require.NoError(t, kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-btlspolicy"}, retrieved), "failed to get created BackendTLSPolicy")
+	t.Logf("successfully created and retrieved BackendTLSPolicy %s/%s", retrieved.Namespace, retrieved.Name)
+}
+
+func buildReferenceGrantUnstructured(name, namespace, version string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/" + version,
+			"kind":       "ReferenceGrant",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"from": []interface{}{
+					map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "HTTPRoute",
+						"namespace": namespace,
+					},
+				},
+				"to": []interface{}{
+					map[string]interface{}{
+						"group": "",
+						"kind":  "Service",
+					},
+				},
+			},
+		},
+	}
+}
+
+// referenceGrantStorageVersion returns the storage version of the ReferenceGrant
+// CRD so we can build unstructured objects with the correct apiVersion rather
+// than hardcoding v1beta1, which may change as the API graduates.
+func referenceGrantStorageVersion(t *testing.T) string {
+	t.Helper()
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	require.NoError(t, kclient.Get(t.Context(),
+		types.NamespacedName{Name: "referencegrants.gateway.networking.k8s.io"}, crd),
+		"failed to get ReferenceGrant CRD")
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			return v.Name
+		}
+	}
+	return "v1beta1"
+}
+
+// createReferenceGrant creates a ReferenceGrant using unstructured objects (since
+// the Go type lives in v1beta1 which is not vendored) and verifies it can be
+// retrieved from the API server. The version is determined dynamically from the
+// CRD to avoid hardcoding v1beta1 across a Gateway API upgrade.
+func createReferenceGrant(t *testing.T, ns *corev1.Namespace) {
+	t.Helper()
+	ctx := t.Context()
+
+	version := referenceGrantStorageVersion(t)
+	refGrant := buildReferenceGrantUnstructured("test-referencegrant", ns.Name, version)
+	require.NoError(t, createWithRetryOnError(t, ctx, refGrant, DefaultRetryTimeout), "failed to create ReferenceGrant")
+
+	retrieved := &unstructured.Unstructured{}
+	retrieved.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "gateway.networking.k8s.io",
+		Version: version,
+		Kind:    "ReferenceGrant",
+	})
+	require.NoError(t, kclient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: "test-referencegrant"}, retrieved), "failed to get created ReferenceGrant")
+	t.Logf("successfully created and retrieved ReferenceGrant %s/%s", retrieved.GetNamespace(), retrieved.GetName())
 }


### PR DESCRIPTION
## Summary

- Add `assertAllGatewayAPICRDsCovered` — lists all Gateway API CRDs on the
  cluster and verifies each is in the e2e `crdNames` list, catching cases where
  a new CRD is added to the operator but not to the test suite
- Add `assertClusterRoleCoversGatewayAPICRDs` — verifies the aggregated
  ClusterRoles have resource entries for all namespace-scoped Gateway API CRDs,
  catching RBAC gaps like OCPBUGS-85690
- Add `createBackendTLSPolicy` — creates a BackendTLSPolicy CR instance and
  verifies the API server accepts and persists it
- Add `createReferenceGrant` — creates a ReferenceGrant CR instance using
  unstructured objects (v1beta1 not vendored), with dynamic version lookup via
  `referenceGrantStorageVersion()` to handle API graduation

## Context

PR #1523 (merged) added `backendtlspolicies` to `crdNames` so the CRD is
exercised by the existing lifecycle and VAP protection tests. This PR extends
coverage by:

1. **Reverse coverage guardrail** — `assertAllGatewayAPICRDsCovered` prevents
   future CRDs from silently missing test coverage
2. **RBAC guardrail** — `assertClusterRoleCoversGatewayAPICRDs` prevents future
   RBAC gaps (catches the class of bug fixed in OCPBUGS-85690)
3. **CR creation validation** — `createBackendTLSPolicy` and `createReferenceGrant`
   are called from `ensureGatewayObjectCreation` to verify the CRD schemas are
   functional and objects can be persisted end-to-end

A full operational BackendTLSPolicy traffic test (TLS backend + actual traffic
through the gateway) is tracked as a follow-up in OCPBUGS-99912.