### PR TITLE
[release-4.21] OCPBUGS-86718: Add configuration override for X-SSL strip

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -96,9 +96,10 @@ const (
 
 	WorkloadPartitioningManagement = "target.workload.openshift.io/management"
 
-	RouterClientAuthPolicy = "ROUTER_MUTUAL_TLS_AUTH"
-	RouterClientAuthCA     = "ROUTER_MUTUAL_TLS_AUTH_CA"
-	RouterClientAuthFilter = "ROUTER_MUTUAL_TLS_AUTH_FILTER"
+	RouterClientAuthPolicy      = "ROUTER_MUTUAL_TLS_AUTH"
+	RouterClientAuthCA          = "ROUTER_MUTUAL_TLS_AUTH_CA"
+	RouterClientAuthFilter      = "ROUTER_MUTUAL_TLS_AUTH_FILTER"
+	RouterMutualTLSHeaderFilter = "ROUTER_MUTUAL_TLS_HEADER_FILTER"
 
 	RouterEnableCompression    = "ROUTER_ENABLE_COMPRESSION"
 	RouterCompressionMIMETypes = "ROUTER_COMPRESSION_MIME"
@@ -536,7 +537,8 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		// Note, however, that dynamic servers consume memory even when not enabled.
 		// Use this analysis of the memory usage to assess the impact of different numbers of servers:
 		// https://gist.github.com/frobware/2b527ce3f040797909eff482a4776e0b
-		MaxDynamicServers string `json:"maxDynamicServers"`
+		MaxDynamicServers     string `json:"maxDynamicServers"`
+		MutualTLSHeaderFilter string `json:"mutualTLSHeaderFilter"`
 	}
 	if len(ci.Spec.UnsupportedConfigOverrides.Raw) > 0 {
 		if err := json.Unmarshal(ci.Spec.UnsupportedConfigOverrides.Raw, &unsupportedConfigOverrides); err != nil {
@@ -616,6 +618,13 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		env = append(env, corev1.EnvVar{
 			Name:  RouterHAProxyContstats,
 			Value: "true",
+		})
+	}
+
+	if v, err := strconv.ParseBool(unsupportedConfigOverrides.MutualTLSHeaderFilter); err == nil && !v {
+		env = append(env, corev1.EnvVar{
+			Name:  RouterMutualTLSHeaderFilter,
+			Value: "false",
 		})
 	}
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1237,6 +1237,66 @@ func TestDesiredRouterDeploymentDynamicConfigManager(t *testing.T) {
 	}
 }
 
+func TestDesiredRouterDeploymentMutualTLSHeaderFilter(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		unsupportedConfigOverrides string
+		expectedEnv                []envData
+	}{
+		{
+			name:                       "not-set",
+			unsupportedConfigOverrides: `{}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+		{
+			name:                       "set-to-false",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"false"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", true, "false"},
+			},
+		},
+		{
+			name:                       "set-to-true",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"true"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+		{
+			name:                       "set-to-invalid-value",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"banana"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ic := &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: operatorv1.IngressControllerSpec{
+					UnsupportedConfigOverrides: runtime.RawExtension{
+						Raw: []byte(tc.unsupportedConfigOverrides),
+					},
+				},
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.PrivateStrategyType,
+					},
+				},
+			}
+
+			deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, false, false, nil, &configv1.Proxy{})
+			assert.NoError(t, err)
+			assert.NoError(t, checkDeploymentEnvironment(t, deployment, tc.expectedEnv))
+		})
+	}
+}
+
 func checkContainerPort(t *testing.T, d *appsv1.Deployment, portName string, port int32) {
 	t.Helper()
 	for _, p := range d.Spec.Template.Spec.Containers[0].Ports {


### PR DESCRIPTION
Router strips X-SSL headers from HTTP listeners. In some cases a Load Balancer may be doing TLS termination and sending traffic to rotuer with these headers. While this topology is not supported, there is a need for a knob to allow these users to rollback this validation assuming the risks of allowing the router to accept the X-SSL headers on the HTTP listener

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingress controller now supports configurable mutual-TLS header filtering. Users can enable or disable this feature through configuration overrides to customize header filtering behavior.

* **Tests**
  * Added comprehensive test coverage validating mutual-TLS header filter configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->