### PR TITLE
OCPBUGS-86833: Detect orphaned OSSM subscription after noOLM migration

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -158,6 +158,10 @@ func start(opts *StartOptions) error {
 	if err := routemetricscontroller.RegisterMetrics(); err != nil {
 		log.Error(err, "unable to register metrics for route_metrics_controller")
 	}
+	log.Info("registering Prometheus metrics for status_controller")
+	if err := statuscontroller.RegisterMetrics(); err != nil {
+		log.Error(err, "unable to register metrics for status_controller")
+	}
 
 	// Set up and start the file watcher.
 	watcher, err := fsnotify.NewWatcher()

--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -60,9 +60,9 @@ spec:
         labels:
           severity: info
         annotations:
-          summary: Orphaned OSSM subscription detected after Gateway API migration
-          description: "This alert fires when the servicemeshoperator3 OLM subscription with the 'ingress.operator.openshift.io/owned' annotation persists after migration to Sail Library (noOLM). The subscription is no longer managed by the Cluster Ingress Operator. To take ownership, remove the annotation: `oc annotate subscription servicemeshoperator3 -n openshift-operators ingress.operator.openshift.io/owned-`. To delete it: `oc delete subscription servicemeshoperator3 -n openshift-operators`."
-          message: "The servicemeshoperator3 subscription is orphaned after migration to Sail Library and is no longer managed by the Cluster Ingress Operator."
+          summary: Orphaned OpenShift Service Mesh operator subscription detected after Gateway API migration
+          description: "This alert fires when the servicemeshoperator3 OLM subscription with the 'ingress.operator.openshift.io/owned' annotation persists after the Cluster Ingress Operator migrated Gateway API from OLM-managed to direct installation. The subscription is no longer managed by the Cluster Ingress Operator. To take ownership, remove the annotation: `oc annotate subscription servicemeshoperator3 -n openshift-operators ingress.operator.openshift.io/owned-`. To uninstall the operator entirely, follow the procedure in the OpenShift documentation for deleting operators from a cluster."
+          message: "An OpenShift Service Mesh operator subscription is orphaned after Gateway API migration and is no longer managed by the Cluster Ingress Operator."
       # Recording rules related to route metrics for sending via telemetry
       - expr: min(route_metrics_controller_routes_per_shard)
         record: cluster:route_metrics_controller_routes_per_shard:min

--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -54,6 +54,15 @@ spec:
           message: |
             The {{ $labels.namespace }}/{{ $labels.name }} ingresscontroller is
             unavailable: {{ $labels.reason }}.
+      - alert: OrphanedOSSMSubscription
+        expr: ingress_operator_orphaned_ossm_subscription == 1
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: Orphaned OSSM subscription detected after Gateway API migration
+          description: "This alert fires when the servicemeshoperator3 OLM subscription with the 'ingress.operator.openshift.io/owned' annotation persists after migration to Sail Library (noOLM). The subscription is no longer managed by the Cluster Ingress Operator. To take ownership, remove the annotation: `oc annotate subscription servicemeshoperator3 -n openshift-operators ingress.operator.openshift.io/owned-`. To delete it: `oc delete subscription servicemeshoperator3 -n openshift-operators`."
+          message: "The servicemeshoperator3 subscription is orphaned after migration to Sail Library and is no longer managed by the Cluster Ingress Operator."
       # Recording rules related to route metrics for sending via telemetry
       - expr: min(route_metrics_controller_routes_per_shard)
         record: cluster:route_metrics_controller_routes_per_shard:min

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -69,7 +69,7 @@ const (
 
 var orphanedOSSMSubscriptionMetric = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "ingress_operator_orphaned_ossm_subscription",
-	Help: "Set to 1 when a CIO-owned OSSM subscription persists after migration to Sail Library (noOLM).",
+	Help: "Set to 1 when an orphaned OpenShift Service Mesh operator OLM subscription is detected that is no longer managed by the Cluster Ingress Operator.",
 })
 
 func RegisterMetrics() error {
@@ -151,10 +151,8 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	// status when the OSSM subscription is created or updated.  Note that
 	// the subscriptions resource only exists if the
 	// "OperatorLifecycleManager" capability is enabled, so we cannot watch
-	// it if the capability is not enabled.  Additionally, the default
-	// catalog only exists if the "marketplace" capability is enabled, so we
-	// cannot install OSSM without that capability.
-	if config.MarketplaceEnabled && config.OperatorLifecycleManagerEnabled {
+	// it if the capability is not enabled.
+	if config.OperatorLifecycleManagerEnabled {
 		if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.Subscription{}, handler.EnqueueRequestsFromMapFunc(toDefaultIngressController), predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
 				return e.Object.GetNamespace() == operatorcontroller.OpenshiftOperatorNamespace
@@ -469,77 +467,73 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 	// Check for Gateway API resources.
 	// OLM related objects are kept to handle failed migration scenarios, even though
 	// Sail Library doesn't use OLM. Can be removed after all clusters migrate
-	useOLM := r.config.MarketplaceEnabled && r.config.OperatorLifecycleManagerEnabled
+	olmCapabilityEnabled := r.config.OperatorLifecycleManagerEnabled
 	useSailLibrary := r.config.GatewayAPIWithoutOLMEnabled
 	state.useSailLibrary = useSailLibrary
-	if useOLM || useSailLibrary {
-		var (
-			crd                                  apiextensionsv1.CustomResourceDefinition
-			gatewaysResourceNamespacedName       = types.NamespacedName{Name: gatewaysResourceName}
-			gatewayclassesResourceNamespacedName = types.NamespacedName{Name: gatewayclassesResourceName}
-			istiosResourceNamespacedName         = types.NamespacedName{Name: istiosResourceName}
-		)
+	var (
+		crd                                  apiextensionsv1.CustomResourceDefinition
+		gatewaysResourceNamespacedName       = types.NamespacedName{Name: gatewaysResourceName}
+		gatewayclassesResourceNamespacedName = types.NamespacedName{Name: gatewayclassesResourceName}
+		istiosResourceNamespacedName         = types.NamespacedName{Name: istiosResourceName}
+	)
 
-		if err := r.cache.Get(ctx, gatewaysResourceNamespacedName, &crd); err != nil {
-			if !errors.IsNotFound(err) {
-				return state, fmt.Errorf("failed to get CRD %q: %v", gatewaysResourceName, err)
-			}
-		} else {
-			state.haveGatewaysResource = true
+	if err := r.cache.Get(ctx, gatewaysResourceNamespacedName, &crd); err != nil {
+		if !errors.IsNotFound(err) {
+			return state, fmt.Errorf("failed to get CRD %q: %v", gatewaysResourceName, err)
 		}
-		if err := r.cache.Get(ctx, gatewayclassesResourceNamespacedName, &crd); err != nil {
-			if !errors.IsNotFound(err) {
-				return state, fmt.Errorf("failed to get CRD %q: %v", gatewayclassesResourceName, err)
-			}
-		} else {
-			state.haveGatewayclassesResource = true
-		}
-		if err := r.cache.Get(ctx, istiosResourceNamespacedName, &crd); err != nil {
-			if !errors.IsNotFound(err) {
-				return state, fmt.Errorf("failed to get CRD %q: %v", istiosResourceName, err)
-			}
-		} else {
-			state.haveIstiosResource = true
-		}
-
-		state.expectedGatewayAPIOperatorVersion = r.config.GatewayAPIOperatorVersion
-
-		// List OSSM subscriptions.
-		// In OLM mode, check for subscription conflicts.
-		// In Sail Library mode, detect orphaned CIO-owned subscriptions.
-		if useOLM || useSailLibrary {
-			subscriptionList := operatorsv1alpha1.SubscriptionList{}
-			// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
-			if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
-				Namespace: "",
-			}); err != nil {
-				return state, fmt.Errorf("failed to get subscriptions: %w", err)
-			}
-			for _, subscription := range subscriptionList.Items {
-				if subscription.Spec == nil {
-					continue
-				}
-				if useOLM && ossmSubscriptions.Has(subscription.Spec.Package) {
-					state.ossmSubscriptions = append(state.ossmSubscriptions, subscription)
-				}
-				if useSailLibrary && subscription.Spec.Package == operatorcontroller.ServiceMeshOperatorSubscriptionPackage {
-					if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; ok {
-						state.orphanedOSSMSubscriptions = append(state.orphanedOSSMSubscriptions, subscription)
-					}
-				}
-			}
-		}
-
-		gatewayClassList := gatewayapiv1.GatewayClassList{}
-		if err := r.cache.List(ctx, &gatewayClassList, client.MatchingFields{
-			operatorcontroller.GatewayClassIndexFieldName: operatorcontroller.OpenShiftGatewayClassControllerName,
-		}); err != nil {
-			return state, fmt.Errorf("failed to list gateway classes: %w", err)
-		}
-		// If one or more gateway classes have ControllerName=operatorcontroller.OpenShiftGatewayClassControllerName,
-		// the ingress operator should try to install OSSM.
-		state.shouldInstallOSSM = (len(gatewayClassList.Items) > 0)
+	} else {
+		state.haveGatewaysResource = true
 	}
+	if err := r.cache.Get(ctx, gatewayclassesResourceNamespacedName, &crd); err != nil {
+		if !errors.IsNotFound(err) {
+			return state, fmt.Errorf("failed to get CRD %q: %v", gatewayclassesResourceName, err)
+		}
+	} else {
+		state.haveGatewayclassesResource = true
+	}
+	if err := r.cache.Get(ctx, istiosResourceNamespacedName, &crd); err != nil {
+		if !errors.IsNotFound(err) {
+			return state, fmt.Errorf("failed to get CRD %q: %v", istiosResourceName, err)
+		}
+	} else {
+		state.haveIstiosResource = true
+	}
+
+	state.expectedGatewayAPIOperatorVersion = r.config.GatewayAPIOperatorVersion
+
+	// List subscriptions when OLM capability is available.
+	if olmCapabilityEnabled {
+		subscriptionList := operatorsv1alpha1.SubscriptionList{}
+		// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
+		if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
+			Namespace: "",
+		}); err != nil {
+			return state, fmt.Errorf("failed to get subscriptions: %w", err)
+		}
+		for _, subscription := range subscriptionList.Items {
+			if subscription.Spec == nil {
+				continue
+			}
+			if !useSailLibrary && ossmSubscriptions.Has(subscription.Spec.Package) {
+				state.ossmSubscriptions = append(state.ossmSubscriptions, subscription)
+			}
+			if useSailLibrary && subscription.Spec.Package == operatorcontroller.ServiceMeshOperatorSubscriptionPackage {
+				if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; ok {
+					state.orphanedOSSMSubscriptions = append(state.orphanedOSSMSubscriptions, subscription)
+				}
+			}
+		}
+	}
+
+	gatewayClassList := gatewayapiv1.GatewayClassList{}
+	if err := r.cache.List(ctx, &gatewayClassList, client.MatchingFields{
+		operatorcontroller.GatewayClassIndexFieldName: operatorcontroller.OpenShiftGatewayClassControllerName,
+	}); err != nil {
+		return state, fmt.Errorf("failed to list gateway classes: %w", err)
+	}
+	// If one or more gateway classes have ControllerName=operatorcontroller.OpenShiftGatewayClassControllerName,
+	// the ingress operator should try to install OSSM.
+	state.shouldInstallOSSM = (len(gatewayClassList.Items) > 0)
 
 	return state, nil
 }
@@ -739,7 +733,10 @@ func computeOrphanedSubscriptionCondition(state operatorState) configv1.ClusterO
 	degradedCondition.Status = configv1.ConditionFalse
 	degradedCondition.Reason = "OrphanedOSSMSubscription"
 	degradedCondition.Message = fmt.Sprintf(
-		"Orphaned OSSM subscription(s) found after migration to Sail Library: %s.",
+		"Orphaned OSSM subscription(s) found after the Cluster Ingress Operator migrated Gateway API from OLM-managed to direct installation: %s. "+
+			"The subscription(s) are no longer managed by the Cluster Ingress Operator. "+
+			"To take ownership, remove the 'ingress.operator.openshift.io/owned' annotation. "+
+			"To uninstall the operator entirely, follow the procedure in the OpenShift documentation for deleting operators from a cluster.",
 		strings.Join(names, ", "),
 	)
 	return degradedCondition

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -35,6 +35,8 @@ import (
 
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -64,6 +66,15 @@ const (
 
 	controllerName = "status_controller"
 )
+
+var orphanedOSSMSubscriptionMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ingress_operator_orphaned_ossm_subscription",
+	Help: "Set to 1 when a CIO-owned OSSM subscription persists after migration to Sail Library (noOLM).",
+})
+
+func RegisterMetrics() error {
+	return prometheus.Register(orphanedOSSMSubscriptionMetric)
+}
 
 var (
 	log = logf.Logger.WithName(controllerName)
@@ -252,6 +263,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to get operator state: %v", err)
 	}
 
+	if len(state.orphanedOSSMSubscriptions) > 0 {
+		orphanedOSSMSubscriptionMetric.Set(1)
+	} else {
+		orphanedOSSMSubscriptionMetric.Set(0)
+	}
+
 	related := []configv1.ObjectReference{
 		{
 			Resource: "namespaces",
@@ -401,6 +418,8 @@ type operatorState struct {
 	haveGatewayclassesResource bool
 	// ossmSubscriptions contains all subscriptions that may conflict with the operator-created ossm subscription.
 	ossmSubscriptions []operatorsv1alpha1.Subscription
+	// orphanedOSSMSubscriptions contains CIO-owned OSSM subscriptions that persist after migration to Sail Library.
+	orphanedOSSMSubscriptions []operatorsv1alpha1.Subscription
 	// expectedGatewayAPIOperatorVersion reflects the expected OSSM 3 version. It is used in determining if a
 	// user-supplied OSSM 3 subscription would cause the operator's installation of OSSM 3 to fail.
 	expectedGatewayAPIOperatorVersion string
@@ -485,9 +504,10 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 
 		state.expectedGatewayAPIOperatorVersion = r.config.GatewayAPIOperatorVersion
 
-		// List OSSM subscriptions (OLM-specific only).
-		// In Sail Library mode, we don't check for subscription conflicts, so no need to list them.
-		if useOLM {
+		// List OSSM subscriptions.
+		// In OLM mode, check for subscription conflicts.
+		// In Sail Library mode, detect orphaned CIO-owned subscriptions.
+		if useOLM || useSailLibrary {
 			subscriptionList := operatorsv1alpha1.SubscriptionList{}
 			// r.client is being used here so we can scan all namespaces without relying/requiring them to be on the cache
 			if err := r.client.List(ctx, &subscriptionList, &client.ListOptions{
@@ -496,8 +516,16 @@ func (r *reconciler) getOperatorState(ctx context.Context, ingressNamespace, can
 				return state, fmt.Errorf("failed to get subscriptions: %w", err)
 			}
 			for _, subscription := range subscriptionList.Items {
-				if subscription.Spec != nil && ossmSubscriptions.Has(subscription.Spec.Package) {
+				if subscription.Spec == nil {
+					continue
+				}
+				if useOLM && ossmSubscriptions.Has(subscription.Spec.Package) {
 					state.ossmSubscriptions = append(state.ossmSubscriptions, subscription)
+				}
+				if useSailLibrary && subscription.Spec.Package == operatorcontroller.ServiceMeshOperatorSubscriptionPackage {
+					if _, ok := subscription.Annotations[operatorcontroller.IngressOperatorOwnedAnnotation]; ok {
+						state.orphanedOSSMSubscriptions = append(state.orphanedOSSMSubscriptions, subscription)
+					}
 				}
 			}
 		}
@@ -568,6 +596,7 @@ func computeOperatorDegradedCondition(state operatorState) configv1.ClusterOpera
 		computeIngressControllerDegradedCondition,
 		computeGatewayAPICRDsDegradedCondition,
 		computeGatewayAPIInstallDegradedCondition,
+		computeOrphanedSubscriptionCondition,
 	} {
 		degradedCondition = joinConditions(degradedCondition, fn(state))
 	}
@@ -695,6 +724,24 @@ func computeGatewayAPIInstallDegradedCondition(state operatorState) configv1.Clu
 		degradedCondition.Message = strings.Join(warnings, "\n")
 	}
 
+	return degradedCondition
+}
+
+func computeOrphanedSubscriptionCondition(state operatorState) configv1.ClusterOperatorStatusCondition {
+	degradedCondition := configv1.ClusterOperatorStatusCondition{}
+	if !state.useSailLibrary || len(state.orphanedOSSMSubscriptions) == 0 {
+		return degradedCondition
+	}
+	names := make([]string, 0, len(state.orphanedOSSMSubscriptions))
+	for _, sub := range state.orphanedOSSMSubscriptions {
+		names = append(names, fmt.Sprintf("%s/%s", sub.Namespace, sub.Name))
+	}
+	degradedCondition.Status = configv1.ConditionFalse
+	degradedCondition.Reason = "OrphanedOSSMSubscription"
+	degradedCondition.Message = fmt.Sprintf(
+		"Orphaned OSSM subscription(s) found after migration to Sail Library: %s.",
+		strings.Join(names, ", "),
+	)
 	return degradedCondition
 }
 

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -977,7 +977,10 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 				Status: configv1.ConditionFalse,
 				Reason: "IngressNotDegradedAndOrphanedOSSMSubscription",
 				Message: `The "default" ingress controller reports Degraded=False.` + "\n" +
-					"Orphaned OSSM subscription(s) found after migration to Sail Library: foo/servicemeshoperator3.",
+					"Orphaned OSSM subscription(s) found after the Cluster Ingress Operator migrated Gateway API from OLM-managed to direct installation: foo/servicemeshoperator3. " +
+					"The subscription(s) are no longer managed by the Cluster Ingress Operator. " +
+					"To take ownership, remove the 'ingress.operator.openshift.io/owned' annotation. " +
+					"To uninstall the operator entirely, follow the procedure in the OpenShift documentation for deleting operators from a cluster.",
 			},
 		},
 		{

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -962,6 +962,40 @@ func Test_computeOperatorDegradedCondition(t *testing.T) {
 			},
 		},
 		{
+			description: "orphaned CIO-owned subscription detected after migration",
+			modes:       sailLibraryMode,
+			state: operatorState{
+				IngressControllers: []operatorv1.IngressController{
+					icWithStatus("default", false),
+				},
+				orphanedOSSMSubscriptions: []operatorsv1alpha1.Subscription{
+					sub("servicemeshoperator3", "servicemeshoperator3", "servicemeshoperator3.v3.1.0", true),
+				},
+			},
+			expectCondition: configv1.ClusterOperatorStatusCondition{
+				Type:   configv1.OperatorDegraded,
+				Status: configv1.ConditionFalse,
+				Reason: "IngressNotDegradedAndOrphanedOSSMSubscription",
+				Message: `The "default" ingress controller reports Degraded=False.` + "\n" +
+					"Orphaned OSSM subscription(s) found after migration to Sail Library: foo/servicemeshoperator3.",
+			},
+		},
+		{
+			description: "no orphaned subscription warning when no CIO-owned subscriptions exist",
+			modes:       sailLibraryMode,
+			state: operatorState{
+				IngressControllers: []operatorv1.IngressController{
+					icWithStatus("default", false),
+				},
+			},
+			expectCondition: configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorDegraded,
+				Status:  configv1.ConditionFalse,
+				Reason:  "IngressNotDegraded",
+				Message: `The "default" ingress controller reports Degraded=False.`,
+			},
+		},
+		{
 			description: "OSSM conflicts ignored but unmanaged CRDs still degrade",
 			modes:       sailLibraryMode,
 			state: operatorState{


### PR DESCRIPTION
When migrating from OLM-based Gateway API to the Sail Library path, CIO stops managing the OLM subscription but does not clean it up or notify the cluster-admin. The subscription remains with the ingress.operator.openshift.io/owned annotation, consuming resources and potentially confusing the cluster-admin who may not know the migration happened.

Add a Prometheus gauge metric (ingress_operator_orphaned_ossm_subscription), a ClusterOperator status condition (OrphanedOSSMSubscription), and a PrometheusRule alert to inform the cluster-admin to either remove the annotation and take ownership of the subscription, or delete it entirely.