### PR TITLE
NE-2737: Add support for TLS curves in router deployment configuration

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -92,6 +92,16 @@ var (
 		"TLS_AES_128_GCM_SHA256",
 		"TLS_AES_256_GCM_SHA384",
 	)
+
+	// nonFIPSGroups is the set of TLS groups that are NOT approved for use
+	// under FIPS 140-3 / NIST SP 800-56Ar3. X25519 and X25519MLKEM768 rely
+	// on Curve25519 arithmetic which is excluded from the FIPS-approved list
+	// (see TRT-2597 and NIST SP 800-56Ar3 Appendix D). These are stripped from
+	// any group list — explicit or default — when isFIPSEnabled is true.
+	nonFIPSGroups = sets.NewString(
+		string(configv1.TLSGroupX25519),
+		string(configv1.TLSGroupX25519MLKEM768),
+	)
 )
 
 // New creates the ingress controller from configuration. This is the controller

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1090,20 +1091,52 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		})
 	}
 
-	// The default TLS supportedGroups (curves) include X25519MLKEM768,
-	// x25519, P-256, P-384, and P-521.
-	tlsCurves := "X25519MLKEM768:X25519:P-256:P-384:P-521"
-	// If FIPS is enabled on this cluster, we cannot use
-	// ML-KEM or X25519 in the TLS supportedGroups (aka curves).
-	// ML-KEM and X25519 are not supported by OpenSSL FIPS 140-3.
+	// Determine the candidate group list: use the explicitly configured groups
+	// when set (via a Custom TLS profile), otherwise use the defaults from the
+	// named TLS profiles. Component implementors do not need to check the
+	// TLSCurvePreferences feature gate; an absent field means the gate is
+	// disabled and components fall back to defaults automatically.
+	var tlsGroupList []string
+	if len(tlsProfileSpec.Groups) != 0 {
+		// When an explicit groups list is configured, pass it to the router
+		// as-is. FIPS filtering is applied below after the else clause.
+		for _, g := range tlsProfileSpec.Groups {
+			tlsGroupList = append(tlsGroupList, string(g))
+		}
+	} else {
+		// The default TLS supportedGroups (curves) include X25519MLKEM768,
+		// X25519, secp256r1 (P-256), secp384r1 (P-384), and secp521r1 (P-521).
+		// These use IANA names that HAProxy/OpenSSL accept directly.
+		tlsGroupList = []string{
+			string(configv1.TLSGroupX25519MLKEM768),
+			string(configv1.TLSGroupX25519),
+			string(configv1.TLSGroupSecP256r1),
+			string(configv1.TLSGroupSecP384r1),
+			string(configv1.TLSGroupSecP521r1),
+		}
+	}
+
+	// If FIPS is enabled on this cluster, we cannot use ML-KEM or X25519 in
+	// the TLS supportedGroups (aka curves). ML-KEM and X25519 are not
+	// supported by OpenSSL FIPS 140-3.
 	// See https://redhat.atlassian.net/browse/TRT-2597 and Appendix D of
 	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
+	// If filtering empties the list, fall back to the FIPS-compliant defaults
+	// (secp256r1:secp384r1:secp521r1) so the router always has at least one
+	// usable group.
 	if isFIPSEnabled {
-		tlsCurves = "P-256:P-384:P-521"
+		tlsGroupList = slices.DeleteFunc(tlsGroupList, nonFIPSGroups.Has)
+		if len(tlsGroupList) == 0 {
+			tlsGroupList = []string{
+				string(configv1.TLSGroupSecP256r1),
+				string(configv1.TLSGroupSecP384r1),
+				string(configv1.TLSGroupSecP521r1),
+			}
+		}
 	}
 	env = append(env, corev1.EnvVar{
 		Name:  RouterTLSCurves,
-		Value: tlsCurves,
+		Value: strings.Join(tlsGroupList, ":"),
 	})
 
 	var minTLSVersion string
@@ -1518,6 +1551,7 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 		ciphersString       string
 		cipherSuitesString  string
 		minTLSVersionString string
+		groupsString        string
 	)
 	for _, v := range env {
 		switch v.Name {
@@ -1527,6 +1561,8 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 			cipherSuitesString = v.Value
 		case "SSL_MIN_VERSION":
 			minTLSVersionString = v.Value
+		case RouterTLSCurves:
+			groupsString = v.Value
 		}
 	}
 
@@ -1550,9 +1586,17 @@ func inferTLSProfileSpecFromDeployment(deployment *appsv1.Deployment) *configv1.
 		minTLSVersion = configv1.VersionTLS12
 	}
 
+	var groups []configv1.TLSGroup
+	if len(groupsString) != 0 {
+		for _, s := range strings.Split(groupsString, ":") {
+			groups = append(groups, configv1.TLSGroup(s))
+		}
+	}
+
 	profile := &configv1.TLSProfileSpec{
 		Ciphers:       ciphers,
 		MinTLSVersion: minTLSVersion,
+		Groups:        groups,
 	}
 
 	return profile

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1156,7 +1156,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		{RouterHTTPIgnoreProbes, true, "true"},
 		{"ROUTER_CIPHERS", true, "quux"},
 		{"ROUTER_CIPHERSUITES", true, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"},
-		{"ROUTER_CURVES", true, "X25519:secp256r1:secp384r1"},
+		{"ROUTER_CURVES", true, "X25519:secp256r1:secp521r1:secp384r1"},
 		{"SSL_MIN_VERSION", true, "TLSv1.2"},
 		{"ROUTER_IP_V4_V6_MODE", true, "v4v6"},
 		{RouterEnableCompression, true, "true"},

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1051,6 +1051,12 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 					"TLS_AES_256_GCM_SHA384",
 					"TLS_CHACHA20_POLY1305_SHA256",
 				},
+				Groups: []configv1.TLSGroup{
+					configv1.TLSGroupX25519,
+					configv1.TLSGroupSecP256r1,
+					configv1.TLSGroupSecP521r1,
+					configv1.TLSGroupSecP384r1,
+				},
 				MinTLSVersion: configv1.VersionTLS12,
 			},
 		},
@@ -1150,6 +1156,7 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		{RouterHTTPIgnoreProbes, true, "true"},
 		{"ROUTER_CIPHERS", true, "quux"},
 		{"ROUTER_CIPHERSUITES", true, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"},
+		{"ROUTER_CURVES", true, "X25519:secp256r1:secp384r1"},
 		{"SSL_MIN_VERSION", true, "TLSv1.2"},
 		{"ROUTER_IP_V4_V6_MODE", true, "v4v6"},
 		{RouterEnableCompression, true, "true"},
@@ -1915,6 +1922,10 @@ func Test_inferTLSProfileSpecFromDeployment(t *testing.T) {
 							Name:  "SSL_MIN_VERSION",
 							Value: "TLSv1.3",
 						},
+						{
+							Name:  "ROUTER_CURVES",
+							Value: "foo:bar",
+						},
 					},
 				},
 				{
@@ -1924,6 +1935,7 @@ func Test_inferTLSProfileSpecFromDeployment(t *testing.T) {
 			expected: &configv1.TLSProfileSpec{
 				Ciphers:       []string{"foo", "bar", "baz"},
 				MinTLSVersion: configv1.VersionTLS13,
+				Groups:        []configv1.TLSGroup{"foo", "bar"},
 			},
 		},
 	}
@@ -3312,25 +3324,99 @@ func Test_ClosedClientConnectionPolicy(t *testing.T) {
 	}
 }
 
-// TestDesiredRouterDeploymentTLSCurves verifies that desiredRouterDeployment
-// sets ROUTER_CURVES as expected with and without FIPS enabled.
-func TestDesiredRouterDeploymentTLSCurves(t *testing.T) {
+// TestDesiredRouterDeploymentTLSGroups verifies that desiredRouterDeployment
+// sets ROUTER_CURVES correctly for both default and explicit group
+// configurations, including proper FIPS filtering in both cases.
+func TestDesiredRouterDeploymentTLSGroups(t *testing.T) {
 	testCases := []struct {
-		name        string
-		fipsEnabled bool
-		expectedEnv []envData
+		name           string
+		fipsEnabled    bool
+		explicitGroups []configv1.TLSGroup // nil means no Custom profile; non-nil (even empty) sets a Custom profile
+		expectedEnv    []envData
 	}{
+		// ── Pre-defined profile type (Old, Intermediate, Modern) ────────────
+		// Modern, Intermediate, and Old profiles all have the same pre-defined
+		// groups:
+		//	TLSGroupX25519MLKEM768,
+		//	TLSGroupX25519,
+		//	TLSGroupSecP256r1,
+		//	TLSGroupSecP384r1,
+		// The else-branch fallback (which also includes secp521r1) is only
+		// reached when the TLSCurvePreferences feature gate is disabled and
+		// Groups is absent entirely.
 		{
-			name:        "Include ML-KEM and X25519 when FIPS is not enabled",
+			name:        "Pre-defined: Groups passed through when FIPS is not enabled",
 			fipsEnabled: false,
 			expectedEnv: []envData{
-				{"ROUTER_CURVES", true, "X25519MLKEM768:X25519:P-256:P-384:P-521"},
+				{"ROUTER_CURVES", true, "X25519MLKEM768:X25519:secp256r1:secp384r1"},
 			},
-		}, {
-			name:        "Exclude ML-KEM and X25519 when FIPS is enabled",
+		},
+		{
+			name:        "Pre-defined: groups are filtered when FIPS is enabled",
 			fipsEnabled: true,
 			expectedEnv: []envData{
-				{"ROUTER_CURVES", true, "P-256:P-384:P-521"},
+				// X25519MLKEM768 and X25519 are filtered;
+				{"ROUTER_CURVES", true, "secp256r1:secp384r1"},
+			},
+		},
+		// ── Custom groups (Custom TLS profile) ────────────────────────────
+		{
+			name:        "Custom groups: groups passed through unchanged when FIPS is not enabled",
+			fipsEnabled: false,
+			explicitGroups: []configv1.TLSGroup{
+				configv1.TLSGroupX25519MLKEM768,
+				configv1.TLSGroupX25519,
+				configv1.TLSGroupSecP256r1,
+			},
+			expectedEnv: []envData{
+				{"ROUTER_CURVES", true, "X25519MLKEM768:X25519:secp256r1"},
+			},
+		},
+		{
+			name:        "Custom Groups: non-FIPS groups filtered out when FIPS is enabled",
+			fipsEnabled: true,
+			explicitGroups: []configv1.TLSGroup{
+				configv1.TLSGroupX25519MLKEM768,
+				configv1.TLSGroupX25519,
+				configv1.TLSGroupSecP256r1,
+				configv1.TLSGroupSecP384r1,
+			},
+			expectedEnv: []envData{
+				// X25519MLKEM768 and X25519 are non-FIPS; only secp256r1 and secp384r1 remain.
+				{"ROUTER_CURVES", true, "secp256r1:secp384r1"},
+			},
+		},
+		{
+			name:        "Custom Groups: fall back to FIPS defaults when all explicit groups are non-FIPS",
+			fipsEnabled: true,
+			explicitGroups: []configv1.TLSGroup{
+				configv1.TLSGroupX25519MLKEM768,
+				configv1.TLSGroupX25519,
+			},
+			expectedEnv: []envData{
+				// Entire list is non-FIPS; must fall back to secp256r1:secp384r1:secp521r1.
+				{"ROUTER_CURVES", true, "secp256r1:secp384r1:secp521r1"},
+			},
+		},
+		// ── Feature-gate disabled (Groups field absent) ──────────────────────
+		{
+			// When TLSCurvePreferences is disabled, Groups is absent from the
+			// profile spec and the operator falls back to its own built-in
+			// defaults, which include secp521r1 (P-521).
+			name:           "Gate-disabled: operator built-in defaults include P-521 when FIPS is not enabled",
+			fipsEnabled:    false,
+			explicitGroups: []configv1.TLSGroup{}, // non-nil but empty → Custom profile with no groups
+			expectedEnv: []envData{
+				{"ROUTER_CURVES", true, "X25519MLKEM768:X25519:secp256r1:secp384r1:secp521r1"},
+			},
+		},
+		{
+			name:           "Gate-disabled: FIPS filters non-approved groups from built-in defaults",
+			fipsEnabled:    true,
+			explicitGroups: []configv1.TLSGroup{}, // non-nil but empty → Custom profile with no groups
+			expectedEnv: []envData{
+				// X25519MLKEM768 and X25519 filtered; secp521r1 (P-521) survives.
+				{"ROUTER_CURVES", true, "secp256r1:secp384r1:secp521r1"},
 			},
 		},
 	}
@@ -3342,6 +3428,17 @@ func TestDesiredRouterDeploymentTLSCurves(t *testing.T) {
 						Type: operatorv1.PrivateStrategyType,
 					},
 				},
+			}
+			if tc.explicitGroups != nil {
+				ic.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Groups:        tc.explicitGroups,
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				}
 			}
 
 			wasFIPSEnabled := isFIPSEnabled

--- a/pkg/operator/controller/tls.go
+++ b/pkg/operator/controller/tls.go
@@ -12,6 +12,7 @@ func copyTLSSpec(in *configv1.TLSProfileSpec) *configv1.TLSProfileSpec {
 	}
 	out := *in
 	out.Ciphers = append([]string(nil), in.Ciphers...)
+	out.Groups = append([]configv1.TLSGroup(nil), in.Groups...)
 	return &out
 }
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -23,9 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -41,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1954,19 +1954,28 @@ func TestTLSSecurityProfile(t *testing.T) {
 	}
 	intermediateProfileSpec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 
-	actualCiphers := ic.Status.TLSProfile.Ciphers
-	expectedCiphers := intermediateProfileSpec.Ciphers
+	tlsGroupsEnabled, err := isFeatureGateEnabled(features.FeatureGateTLSGroupPreferences)
+	if err != nil {
+		t.Fatalf("failed to check TLSGroupPreferences feature gate: %v", err)
+	}
+
+	actualCiphers := append([]string{}, ic.Status.TLSProfile.Ciphers...)
+	expectedCiphers := append([]string{}, intermediateProfileSpec.Ciphers...)
 	sort.Strings(actualCiphers)
 	sort.Strings(expectedCiphers)
 
-	if !reflect.DeepEqual(actualCiphers, expectedCiphers) || !reflect.DeepEqual(intermediateProfileSpec.MinTLSVersion, ic.Status.TLSProfile.MinTLSVersion) {
-		expected, _ := yaml.Marshal(intermediateProfileSpec)
-		actual, _ := yaml.Marshal(*ic.Status.TLSProfile)
-		t.Fatalf("ingresscontroller status has unexpected security profile spec.\nexpected:\n%s\ngot:\n%s", expected, actual)
+	if diff := cmp.Diff(expectedCiphers, actualCiphers); diff != "" || intermediateProfileSpec.MinTLSVersion != ic.Status.TLSProfile.MinTLSVersion {
+		t.Fatalf("ingresscontroller status has unexpected security profile spec (-want +got):\n%s", cmp.Diff(*intermediateProfileSpec, *ic.Status.TLSProfile))
+	}
+	if tlsGroupsEnabled {
+		assert.Equal(t, intermediateProfileSpec.Groups, ic.Status.TLSProfile.Groups,
+			"ingresscontroller status has unexpected TLS groups: expected %v, got %v",
+			intermediateProfileSpec.Groups, ic.Status.TLSProfile.Groups)
 	}
 
 	customProfileSpec := configv1.TLSProfileSpec{
 		Ciphers:       []string{"ECDHE-ECDSA-AES256-GCM-SHA384"},
+		Groups:        []configv1.TLSGroup{configv1.TLSGroupSecP256r1, configv1.TLSGroupSecP384r1},
 		MinTLSVersion: configv1.VersionTLS12,
 	}
 	ic.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
@@ -1978,20 +1987,24 @@ func TestTLSSecurityProfile(t *testing.T) {
 	if err := kclient.Update(context.TODO(), ic); err != nil {
 		t.Errorf("failed to update ingresscontroller %s: %v", name, err)
 	}
-	err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
 		if err := kclient.Get(context.TODO(), name, ic); err != nil {
 			t.Logf("failed to get ingresscontroller %s: %v", name.Name, err)
 			return false, nil
 		}
-		if !reflect.DeepEqual(*ic.Status.TLSProfile, customProfileSpec) {
+		if !cmp.Equal(ic.Status.TLSProfile.Ciphers, customProfileSpec.Ciphers) {
+			return false, nil
+		}
+		if ic.Status.TLSProfile.MinTLSVersion != customProfileSpec.MinTLSVersion {
+			return false, nil
+		}
+		if tlsGroupsEnabled && !cmp.Equal(ic.Status.TLSProfile.Groups, customProfileSpec.Groups) {
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
-		expected, _ := yaml.Marshal(customProfileSpec)
-		actual, _ := yaml.Marshal(*ic.Status.TLSProfile)
-		t.Fatalf("ingresscontroller status has unexpected security profile spec.\nexpected:\n%s\ngot:\n%s", expected, actual)
+		t.Fatalf("ingresscontroller status has unexpected security profile spec (-want +got):\n%s", cmp.Diff(customProfileSpec, *ic.Status.TLSProfile))
 	}
 }
 


### PR DESCRIPTION
To support new PQC curves, let's add a config for explicitly setting the supported groups. 

ROUTER_CURVES is piped through OpenShift/router to HAProxy where it will be used by `ssl-default-bind-curves`

For more context see: https://github.com/openshift/router/pull/678