### PR TITLE
OCPBUGS-90505: Guard OLM watches with capability check in gatewayclass controller

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -202,20 +202,21 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 		isIstioCRD := predicate.NewPredicateFuncs(func(o client.Object) bool {
 			return strings.Contains(o.GetName(), "istio.io")
 		})
-		isServiceMeshSubscription := predicate.NewPredicateFuncs(func(o client.Object) bool {
-			sub, ok := o.(*operatorsv1alpha1.Subscription)
-			if !ok {
-				return false
-			}
-			// Check if package name starts with "servicemeshoperator"
-			return sub.Spec != nil && strings.HasPrefix(sub.Spec.Package, "servicemeshoperator")
-		})
+		if config.OperatorLifecycleManagerEnabled {
+			isServiceMeshSubscription := predicate.NewPredicateFuncs(func(o client.Object) bool {
+				sub, ok := o.(*operatorsv1alpha1.Subscription)
+				if !ok {
+					return false
+				}
+				return sub.Spec != nil && strings.HasPrefix(sub.Spec.Package, "servicemeshoperator")
+			})
 
-		if err = c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.Subscription{}, reconciler.enqueueRequestForCRDOwnershipChange(), isServiceMeshSubscription)); err != nil {
-			return nil, err
-		}
-		if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.InstallPlan{}, reconciler.enqueueRequestForCRDOwnershipChange(), isOurInstallPlan)); err != nil {
-			return nil, err
+			if err = c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.Subscription{}, reconciler.enqueueRequestForCRDOwnershipChange(), isServiceMeshSubscription)); err != nil {
+				return nil, err
+			}
+			if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorsv1alpha1.InstallPlan{}, reconciler.enqueueRequestForCRDOwnershipChange(), isOurInstallPlan)); err != nil {
+				return nil, err
+			}
 		}
 		if err := c.Watch(source.Kind[client.Object](operatorCache, &apiextensionsv1.CustomResourceDefinition{}, reconciler.enqueueRequestForCRDOwnershipChange(), isIstioCRD)); err != nil {
 			return nil, err
@@ -258,6 +259,8 @@ type Config struct {
 	GatewayAPIOperatorVersion string
 	// GatewayAPIWithoutOLMEnabled indicates whether the GatewayAPIWithoutOLM feature gate is enabled.
 	GatewayAPIWithoutOLMEnabled bool
+	// OperatorLifecycleManagerEnabled indicates whether the OperatorLifecycleManager capability is enabled.
+	OperatorLifecycleManagerEnabled bool
 	// IstioVersion is the version of Istio to install.
 	IstioVersion string
 	// Context is the context for controller lifecycle.

--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -98,10 +98,12 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	// tracking OLM subscriptions across all namespaces.
 	var subscriptionCache cache.Cache
 	var err error
-	if subscriptionCache, err = cache.New(mgr.GetConfig(), cache.Options{}); err != nil {
-		return nil, err
+	if config.OperatorLifecycleManagerEnabled {
+		if subscriptionCache, err = cache.New(mgr.GetConfig(), cache.Options{}); err != nil {
+			return nil, err
+		}
+		mgr.Add(subscriptionCache)
 	}
-	mgr.Add(subscriptionCache)
 	reconciler := &reconciler{
 		config:            config,
 		client:            mgr.GetClient(),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -312,14 +312,15 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	// the manager; the gatewayapi controller starts it after it creates the
 	// Gateway API CRDs.
 	gatewayclassControllerConfig := gatewayclasscontroller.Config{
-		OperatorNamespace:           config.Namespace,
-		OperandNamespace:            operatorcontroller.DefaultOperandNamespace,
-		GatewayAPIOperatorCatalog:   config.GatewayAPIOperatorCatalog,
-		GatewayAPIOperatorChannel:   config.GatewayAPIOperatorChannel,
-		GatewayAPIOperatorVersion:   config.GatewayAPIOperatorVersion,
-		GatewayAPIWithoutOLMEnabled: gatewayAPIWithoutOLMEnabled,
-		IstioVersion:                config.IstioVersion,
-		Context:                     ctx,
+		OperatorNamespace:               config.Namespace,
+		OperandNamespace:                operatorcontroller.DefaultOperandNamespace,
+		GatewayAPIOperatorCatalog:       config.GatewayAPIOperatorCatalog,
+		GatewayAPIOperatorChannel:       config.GatewayAPIOperatorChannel,
+		GatewayAPIOperatorVersion:       config.GatewayAPIOperatorVersion,
+		GatewayAPIWithoutOLMEnabled:     gatewayAPIWithoutOLMEnabled,
+		OperatorLifecycleManagerEnabled: olmEnabled,
+		IstioVersion:                    config.IstioVersion,
+		Context:                         ctx,
 	}
 
 	gatewayClassController, err := gatewayclasscontroller.NewUnmanaged(mgr, gatewayclassControllerConfig)


### PR DESCRIPTION
## Summary

- The gatewayclass controller's Sail Library branch sets up `source.Kind` watches on `Subscription` and `InstallPlan` without checking whether the OLM capability is enabled
- On clusters without the `OperatorLifecycleManager` capability, these CRDs don't exist, causing `WaitForSync` to block indefinitely — the controller's reconcile workers never start and Gateway API is completely non-functional
- Guard the watches with `config.OperatorLifecycleManagerEnabled` so they are only registered when OLM is present
- Also guard the status controller's `subscriptionCache` creation with the same check to avoid creating an unused cache on non-OLM clusters

Bug: [OCPBUGS-90505](https://redhat.atlassian.net/browse/OCPBUGS-90505)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/operator/controller/gatewayclass/...` passes (86 tests)
- [ ] `go test ./pkg/operator/controller/status/...` passes (75 tests)
- [ ] On a cluster without OLM: verify the gatewayclass controller logs `Starting Controller` and `Starting workers` (instead of blocking on informer errors)
- [ ] On a cluster with OLM: verify Subscription/InstallPlan watches still work for CRD ownership tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)