### PR TITLE
NE-2796: Respect OpenShift TLS Profiles during Istio/GatewayAPI installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,12 @@ test-e2e-list: generate
 gatewayapi-conformance:
 	hack/gatewayapi-conformance.sh
 
+# Provision a leave-behind HTTPS Gateway for the CI TLS scanner.
+# GATEWAY_NAME defaults to tls-scanner-gatewayapi (must match COMPONENT_FILTER).
+.PHONY: gatewayapi-tls-scanner-setup
+gatewayapi-tls-scanner-setup:
+	GATEWAYAPI_TLS_SCANNER_SETUP=1 $(GO) test -timeout 30m -count 1 -v -tags e2e -run '^TestGatewayAPITLSScannerSetup$$' ./test/e2e
+
 .PHONY: test-pre-release-ossm
 test-pre-release-ossm:
 	hack/test-pre-release-ossm-images.sh

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/istio-ecosystem/sail-operator v0.0.0-20250513111011-30be83268d6b
 	github.com/openshift/api v0.0.0-20260721171203-ef67063fadc9
 	github.com/openshift/client-go v0.0.0-20260721124015-35d8f3c0e847
+	github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e
 	github.com/openshift/library-go v0.0.0-20260722141911-d8f45c2a4f64
 	github.com/operator-framework/api v0.30.0
 	github.com/pkg/errors v0.9.1
@@ -180,7 +181,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/operator/controller/gatewayclass/controller.go
+++ b/pkg/operator/controller/gatewayclass/controller.go
@@ -93,8 +93,9 @@ const (
 )
 
 type extraIstioConfig struct {
-	proxyConfig *configv1.Proxy
-	infraConfig *configv1.Infrastructure
+	proxyConfig     *configv1.Proxy
+	infraConfig     *configv1.Infrastructure
+	apiserverConfig *configv1.APIServer
 }
 
 var log = logf.Logger.WithName(controllerName)
@@ -240,6 +241,15 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, er
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.Infrastructure{}, reconciler.enqueueRequestForSomeGatewayClass())); err != nil {
 		return nil, err
 	}
+
+	// Watch the cluster TLSProfile config for changes
+	isClusterAPIServerConfig := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == "cluster"
+	})
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &configv1.APIServer{}, reconciler.enqueueRequestForSomeGatewayClass(), isClusterAPIServerConfig)); err != nil {
+		return nil, err
+	}
+
 	// Watch the istiod network policy.
 	isIstiodNetworkPolicy := predicate.NewPredicateFuncs(func(o client.Object) bool {
 		istiodNetworkPolicyName := operatorcontroller.IstiodNetworkPolicyName()

--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -102,6 +103,16 @@ func Test_Reconcile(t *testing.T) {
 				HTTPProxy:  http,
 				HTTPSProxy: https,
 				NoProxy:    noproxy,
+			},
+		}
+	}
+
+	apiserverConfig := func(profile *configv1.TLSSecurityProfile, adherencePolicy configv1.TLSAdherencePolicy) *configv1.APIServer {
+		return &configv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: configv1.APIServerSpec{
+				TLSSecurityProfile: profile,
+				TLSAdherence:       adherencePolicy,
 			},
 		}
 	}
@@ -252,7 +263,7 @@ func Test_Reconcile(t *testing.T) {
 		}
 	}
 
-	expectedSailLibraryOptions := func(version string, gieEnabled bool, proxyConfig map[string]string, gatewayclassesConfig json.RawMessage) *install.Options {
+	expectedSailLibraryOptions := func(version string, gieEnabled bool, proxyConfig map[string]string, gatewayclassesConfig json.RawMessage, openshiftTLS *config.OpenShiftTLS) *install.Options {
 		// Start with sail-operator's Gateway API defaults aka trust upstream defaults
 		values := install.GatewayAPIDefaults("openshift-ingress")
 
@@ -321,6 +332,7 @@ func Test_Reconcile(t *testing.T) {
 			Values:         values,
 			ManageCRDs:     true,
 			IncludeAllCRDs: true,
+			OpenShiftTLS:   openshiftTLS,
 		}
 	}
 
@@ -646,7 +658,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: installs Istio (single replica)",
@@ -662,7 +674,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: installs Istio (highly available)",
@@ -678,7 +690,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: installs Istio with system proxy configuration",
@@ -695,7 +707,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: installs Istio for multiple gatewayclasses in single-topology mode with system proxy configuration",
@@ -722,7 +734,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default", "openshift-internal", "openshift-custom")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, expectedProxyConfiguration, gatewayclassesConfig(gatewayclassConfig(1), "openshift-default", "openshift-internal", "openshift-custom"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: experimental InferencePool CRD",
@@ -743,7 +755,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: stable InferencePool CRD",
@@ -764,7 +776,7 @@ func Test_Reconcile(t *testing.T) {
 			expectedStatusPatched: []client.Object{
 				gatewayClass("openshift-default", true, nil, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", true, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: Istio version override",
@@ -784,7 +796,7 @@ func Test_Reconcile(t *testing.T) {
 					"unsupported.do-not-use.openshift.io/istio-version": "v1.24-latest",
 				}, installedConditions(), false),
 			},
-			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default")),
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24-latest", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
 		},
 		{
 			name:              "Sail Library: full removal of last GatewayClass",
@@ -828,6 +840,65 @@ func Test_Reconcile(t *testing.T) {
 			expectError:                      "failed to uninstall Istio: failed to cleanup resources",
 			expectedSailLibraryOptions:       &install.Options{},
 			expectSailLibraryUninstallCalled: true,
+		},
+		{
+			name:              "Sail Library: installs Istio with null TLSProfile and no TLS adherence",
+			fakeSailInstaller: &fakeSailInstaller{},
+			request:           req("openshift-default"),
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, nil, nil, false),
+				apiserverConfig(nil, ""),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, nil, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions("v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"), &config.OpenShiftTLS{}),
+		},
+		{
+			name:              "Sail Library: installs Istio with intermediate TLSProfile and strict adherence",
+			fakeSailInstaller: &fakeSailInstaller{},
+			request:           req("openshift-default"),
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, nil, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileIntermediateType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, nil, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileIntermediateType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
+		{
+			name:              "Sail Library: installs Istio with Modern TLSProfile and strict adherence",
+			fakeSailInstaller: &fakeSailInstaller{},
+			request:           req("openshift-default"),
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, nil, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, nil, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
 		},
 	}
 
@@ -924,6 +995,7 @@ func Test_Reconcile(t *testing.T) {
 						tc.expectedSailLibraryOptions,
 						&fakeInstaller.internalOpts,
 						cmpopts.IgnoreFields(install.Options{}, "OverwriteOLMManagedCRD"),
+						cmpopts.IgnoreFields(config.OpenShiftTLS{}, "TLSConfigFunc"),
 					)
 					if optsDiff != "" {
 						t.Fatalf("found diff between Sail Library options:\n%s", optsDiff)

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
+	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 	v1 "k8s.io/api/core/v1"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -134,10 +136,16 @@ func (r *reconciler) ensureIstio(ctx context.Context, istioVersion string, gatew
 		return fmt.Errorf("error verifying cluster proxy configuration: %w", err)
 	}
 
+	var apiserverConfig configv1.APIServer
+	if err := r.cache.Get(ctx, types.NamespacedName{Name: "cluster"}, &apiserverConfig); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error verifying apiserver configuration: %w", err)
+	}
+
 	// Build options from current state
 	opts, err := r.buildInstallerOptions(enableInferenceExtension, istioVersion, gatewayclasses, &extraIstioConfig{
-		proxyConfig: &proxyConfig,
-		infraConfig: infraConfig,
+		proxyConfig:     &proxyConfig,
+		infraConfig:     infraConfig,
+		apiserverConfig: &apiserverConfig,
 	})
 	if err != nil {
 		return err
@@ -171,6 +179,14 @@ func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioV
 		return install.Options{}, fmt.Errorf("failed to merge Istio values: %w", err)
 	}
 
+	tlsOptions := &config.OpenShiftTLS{}
+	if extraConfig.apiserverConfig != nil {
+		tlsOptions, err = getTLSOptions(extraConfig.apiserverConfig.Spec.TLSSecurityProfile, extraConfig.apiserverConfig.Spec.TLSAdherence)
+		if err != nil {
+			return install.Options{}, fmt.Errorf("failed to get TLS Profile spec: %w", err)
+		}
+	}
+
 	return install.Options{
 		Namespace:      r.config.OperandNamespace,
 		Revision:       controller.IstioName("").Name,
@@ -178,7 +194,29 @@ func (r *reconciler) buildInstallerOptions(enableInferenceExtension bool, istioV
 		Version:        istioVersion,
 		ManageCRDs:     true,
 		IncludeAllCRDs: true,
+		OpenShiftTLS:   tlsOptions,
 	}, nil
+}
+
+func getTLSOptions(profile *configv1.TLSSecurityProfile, adherence configv1.TLSAdherencePolicy) (*config.OpenShiftTLS, error) {
+	tlsOptions := &config.OpenShiftTLS{}
+	if profile == nil {
+		return tlsOptions, nil
+	}
+
+	tlsspec, err := openshifttls.GetTLSProfileSpec(profile)
+	if err != nil {
+		return tlsOptions, fmt.Errorf("failed to get TLS Profile spec: %w", err)
+	}
+
+	tlsconfig, _ := openshifttls.NewTLSConfigFromProfile(tlsspec)
+
+	tlsOptions.TLSAdherencePolicy = adherence
+	tlsOptions.TLSProfileSpec = tlsspec
+	tlsOptions.TLSConfigFunc = tlsconfig
+
+	return tlsOptions, nil
+
 }
 
 // openshiftValues returns the OpenShift-specific value overrides for Istio.

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer_test.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer_test.go
@@ -6,14 +6,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/istio-ecosystem/sail-operator/pkg/config"
 	"github.com/istio-ecosystem/sail-operator/pkg/install"
+	"github.com/istio-ecosystem/sail-operator/pkg/istiovalues"
 
+	configv1 "github.com/openshift/api/config/v1"
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -598,4 +602,57 @@ func TestSailLibraryImageDigestsAreDownstream(t *testing.T) {
 				"ProxyImage %q is not from registry.redhat.io", images.ProxyImage)
 		})
 	}
+}
+
+// TestSailLibraryCipherForTLS verifies that the sail library is properly parsing the TLS
+// options, removing any cipher suite from "modern" profiles and adding properly ECDH curves.
+// Because Envoy does not support passing a CipherSuite when TLS is v1.3, we need to
+// guarantee that the ApplyTLSConfig is properly patched.
+// This is implemented on the commit https://github.com/openshift-service-mesh/sail-operator/commit/3666a74d8bfae662bcb32a948b6c02a6dd53461b
+// and we have added it to the vendored library while it is not bumped to v3.4.1 or up
+func TestSailLibraryCipherForTLS(t *testing.T) {
+	istioVersion := "1.29.0"
+	t.Run("intermediate profile must return ciphersuite and TLS 1.2", func(t *testing.T) {
+		tlsconfig := expectedTLSConfig(t, configv1.TLSProfileIntermediateType, configv1.TLSAdherencePolicyStrictAllComponents)
+		istioTLS := config.NewTLSConfigForOpenShift(
+			tlsconfig.TLSProfileSpec,
+			tlsconfig.TLSAdherencePolicy,
+			logr.Discard(),
+		)
+		values := &sailv1.Values{}
+		istiovalues.ApplyTLSConfig(istioTLS, istioVersion, values)
+		require.NotNil(t, values.MeshConfig)
+		require.NotNil(t, values.MeshConfig.TlsDefaults)
+		assert.Equal(t, sailv1.MeshConfigTLSConfigTLSProtocolTlsv12, values.MeshConfig.TlsDefaults.MinProtocolVersion)
+		assert.Greater(t, len(values.MeshConfig.TlsDefaults.CipherSuites), 0)
+	})
+
+	t.Run("modern profile must return a null ciphersuite and TLS 1.3", func(t *testing.T) {
+		tlsconfig := expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)
+		istioTLS := config.NewTLSConfigForOpenShift(
+			tlsconfig.TLSProfileSpec,
+			tlsconfig.TLSAdherencePolicy,
+			logr.Discard(),
+		)
+		values := &sailv1.Values{}
+		istiovalues.ApplyTLSConfig(istioTLS, istioVersion, values)
+		require.NotNil(t, values.MeshConfig)
+		require.NotNil(t, values.MeshConfig.TlsDefaults)
+		assert.Equal(t, sailv1.MeshConfigTLSConfigTLSProtocolTlsv13, values.MeshConfig.TlsDefaults.MinProtocolVersion)
+		assert.Greater(t, len(values.MeshConfig.TlsDefaults.EcdhCurves), 0)
+		assert.Nil(t, values.MeshConfig.TlsDefaults.CipherSuites)
+	})
+
+}
+
+func expectedTLSConfig(t *testing.T, profile configv1.TLSProfileType, adherence configv1.TLSAdherencePolicy) *config.OpenShiftTLS {
+	t.Helper()
+	if profile == "" {
+		return &config.OpenShiftTLS{}
+	}
+	config, err := getTLSOptions(&configv1.TLSSecurityProfile{
+		Type: profile,
+	}, adherence)
+	require.NoError(t, err, "getting the TLSOptions should never return error on unit tests")
+	return config
 }

--- a/test/e2e/all_test.go
+++ b/test/e2e/all_test.go
@@ -151,6 +151,10 @@ func TestAll(t *testing.T) {
 		// the ClusterOperator/ingress resource reports only "default" ingress and the ingress
 		// resource being tested.
 		t.Run("TestMultiHAProxyUpgradeableCondition", TestMultiHAProxyUpgradeableCondition)
+		// TestGatewayAPITLSScannerSetup skips unless GATEWAYAPI_TLS_SCANNER_SETUP=1
+		// (make gatewayapi-tls-scanner-setup). It intentionally leaves Gateway
+		// resources for the CI TLS scanner and must not run during normal e2e.
+		t.Run("TestGatewayAPITLSScannerSetup", TestGatewayAPITLSScannerSetup)
 		t.Run("TestIngressControllerConditionsMetricAfterRestart", TestIngressControllerConditionsMetricAfterRestart)
 		// TestIngressControllerCustomEndpoints must run last because
 		// modifying Infrastructure.spec.platformSpec.aws.serviceEndpoints

--- a/test/e2e/gateway_api_tls_scanner_setup_test.go
+++ b/test/e2e/gateway_api_tls_scanner_setup_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -89,6 +88,11 @@ func TestGatewayAPITLSScannerSetup(t *testing.T) {
 	_, err = assertGatewaySuccessful(t, gateway.Namespace, gateway.Name)
 	require.NoError(t, err, "Gateway was not accepted/programmed")
 
+	err = assertGatewayInfrastructureLabelsPropagated(t, gateway.Namespace, gateway.Name, string(gateway.Spec.GatewayClassName), map[string]string{
+		"app": gateway.Name,
+	})
+	require.NoError(t, err, "Gateway infrastructure labels were not propagated to Envoy pods")
+
 	err = assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
 		{dnsName: hostname + ".", gatewayName: gateway.Name}: true,
 	})
@@ -120,15 +124,14 @@ func ensureGatewayTLSSecret(t *testing.T, namespace, name, dnsName string) (*cor
 			"tls.key": []byte(keyPEM),
 		},
 	}
-	if err := createOrGetWithRetry(t, context.Background(), secret, DefaultRetryTimeout); err != nil {
+	if err := createOrGetWithRetry(t, t.Context(), secret, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create TLS secret %s/%s: %w", namespace, name, err)
 	}
 	return secret, nil
 }
 
-// ensureHTTPSGateway creates a Gateway with an HTTPS listener and an
-// infrastructure "app" label matching the Gateway name so tls-scanner's
-// COMPONENT_FILTER can select the generated Envoy pods.
+// ensureHTTPSGateway creates a Gateway with an HTTPS listener and the given
+// TLS secret, including an infrastructure "app" label matching the Gateway name.
 func ensureHTTPSGateway(t *testing.T, gatewayClassName, name, namespace, hostname, secretName string) (*gatewayapiv1.Gateway, error) {
 	t.Helper()
 
@@ -145,7 +148,6 @@ func ensureHTTPSGateway(t *testing.T, gatewayClassName, name, namespace, hostnam
 			GatewayClassName: gatewayapiv1.ObjectName(gatewayClassName),
 			Infrastructure: &gatewayapiv1.GatewayInfrastructure{
 				Labels: map[gatewayapiv1.LabelKey]gatewayapiv1.LabelValue{
-					// COMPONENT_FILTER matches app / component / app.kubernetes.io/name.
 					"app": gatewayapiv1.LabelValue(name),
 				},
 			},
@@ -167,7 +169,7 @@ func ensureHTTPSGateway(t *testing.T, gatewayClassName, name, namespace, hostnam
 		},
 	}
 
-	if err := createOrGetWithRetry(t, context.Background(), gateway, DefaultRetryTimeout); err != nil {
+	if err := createOrGetWithRetry(t, t.Context(), gateway, DefaultRetryTimeout); err != nil {
 		return nil, fmt.Errorf("failed to create gateway %s/%s: %w", namespace, name, err)
 	}
 	return gateway, nil

--- a/test/e2e/gateway_api_tls_scanner_setup_test.go
+++ b/test/e2e/gateway_api_tls_scanner_setup_test.go
@@ -1,0 +1,225 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	// gatewayAPITLSScannerSetupEnv enables TestGatewayAPITLSScannerSetup.
+	// The Makefile gatewayapi-tls-scanner-setup target sets this so the test
+	// can provision leave-behind Gateway resources for the TLS scanner.
+	gatewayAPITLSScannerSetupEnv = "GATEWAYAPI_TLS_SCANNER_SETUP"
+
+	// defaultTLSScannerGatewayName matches the COMPONENT_FILTER / GATEWAY_NAME
+	// used by the openshift/release tls-scanner-gatewayapi job.
+	defaultTLSScannerGatewayName = "tls-scanner-gatewayapi"
+)
+
+// TestGatewayAPITLSScannerSetup provisions a Gateway with an HTTPS listener
+// and TLS certificate in openshift-ingress for the CI TLS scanner.
+//
+// Unlike other Gateway API e2e tests, this intentionally does not clean up
+// created resources: the subsequent tls-scanner-run step discovers the Envoy
+// pods by COMPONENT_FILTER matching the Gateway infrastructure "app" label.
+//
+// Run via: make gatewayapi-tls-scanner-setup
+// Optional: GATEWAY_NAME=<name> (defaults to tls-scanner-gatewayapi)
+func TestGatewayAPITLSScannerSetup(t *testing.T) {
+	if os.Getenv(gatewayAPITLSScannerSetupEnv) != "1" {
+		t.Skipf("skipping: set %s=1 to provision leave-behind Gateway resources for the TLS scanner", gatewayAPITLSScannerSetupEnv)
+	}
+
+	// DNS publishing and AWS ELB provisioning are required for Gateway readiness
+	// checks used below; skip on non-AWS platforms.
+	if infraConfig.Status.PlatformStatus == nil {
+		t.Skip("Skipping test: platform status is nil")
+	}
+	if infraConfig.Status.PlatformStatus.Type != configv1.AWSPlatformType {
+		t.Skipf("Skipping test on platform %q: test requires AWS for load balancer and DNS publishing", infraConfig.Status.PlatformStatus.Type)
+	}
+
+	// Gateway API is GA; verify CRDs are present before provisioning.
+	ensureCRDs(t)
+
+	gatewayName := os.Getenv("GATEWAY_NAME")
+	if gatewayName == "" {
+		gatewayName = defaultTLSScannerGatewayName
+	}
+	secretName := gatewayName + "-cert"
+	domain := gatewayName + ".gws." + dnsConfig.Spec.BaseDomain
+	hostname := "*." + domain
+
+	t.Logf("Provisioning TLS scanner Gateway %q in namespace %q (hostname %q)", gatewayName, operatorcontroller.DefaultOperandNamespace, hostname)
+
+	gatewayClass, err := createGatewayClass(t, operatorcontroller.OpenShiftDefaultGatewayClassName, operatorcontroller.OpenShiftGatewayClassControllerName)
+	require.NoError(t, err, "failed to create GatewayClass")
+	_, err = assertGatewayClassSuccessful(t, gatewayClass.Name)
+	require.NoError(t, err, "GatewayClass was not accepted")
+
+	_, err = ensureGatewayTLSSecret(t, operatorcontroller.DefaultOperandNamespace, secretName, hostname)
+	require.NoError(t, err, "failed to create TLS secret")
+
+	gateway, err := ensureHTTPSGateway(t, gatewayClass.Name, gatewayName, operatorcontroller.DefaultOperandNamespace, hostname, secretName)
+	require.NoError(t, err, "failed to create Gateway")
+
+	_, err = assertGatewaySuccessful(t, gateway.Namespace, gateway.Name)
+	require.NoError(t, err, "Gateway was not accepted/programmed")
+
+	err = assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
+		{dnsName: hostname + ".", gatewayName: gateway.Name}: true,
+	})
+	require.NoError(t, err, "DNSRecord never got ready")
+
+	assertProxyDeployCustomConfigurations(t, gateway.Namespace, gateway.Name, string(gateway.Spec.GatewayClassName))
+
+	t.Logf("Gateway %s/%s is ready for TLS scanning (resources intentionally left in place)", gateway.Namespace, gateway.Name)
+}
+
+// ensureGatewayTLSSecret creates a self-signed TLS secret for the Gateway
+// HTTPS listener if it does not already exist.
+func ensureGatewayTLSSecret(t *testing.T, namespace, name, dnsName string) (*corev1.Secret, error) {
+	t.Helper()
+
+	certPEM, keyPEM, err := generateServerTLSKeyPair(dnsName)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": []byte(certPEM),
+			"tls.key": []byte(keyPEM),
+		},
+	}
+	if err := createOrGetWithRetry(t, context.Background(), secret, DefaultRetryTimeout); err != nil {
+		return nil, fmt.Errorf("failed to create TLS secret %s/%s: %w", namespace, name, err)
+	}
+	return secret, nil
+}
+
+// ensureHTTPSGateway creates a Gateway with an HTTPS listener and an
+// infrastructure "app" label matching the Gateway name so tls-scanner's
+// COMPONENT_FILTER can select the generated Envoy pods.
+func ensureHTTPSGateway(t *testing.T, gatewayClassName, name, namespace, hostname, secretName string) (*gatewayapiv1.Gateway, error) {
+	t.Helper()
+
+	host := gatewayapiv1.Hostname(hostname)
+	fromNamespace := gatewayapiv1.FromNamespaces(allNamespaces)
+	mode := gatewayapiv1.TLSModeTerminate
+
+	gateway := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: gatewayapiv1.ObjectName(gatewayClassName),
+			Infrastructure: &gatewayapiv1.GatewayInfrastructure{
+				Labels: map[gatewayapiv1.LabelKey]gatewayapiv1.LabelValue{
+					// COMPONENT_FILTER matches app / component / app.kubernetes.io/name.
+					"app": gatewayapiv1.LabelValue(name),
+				},
+			},
+			Listeners: []gatewayapiv1.Listener{{
+				Name:     "https",
+				Hostname: &host,
+				Port:     443,
+				Protocol: gatewayapiv1.HTTPSProtocolType,
+				TLS: &gatewayapiv1.ListenerTLSConfig{
+					Mode: &mode,
+					CertificateRefs: []gatewayapiv1.SecretObjectReference{{
+						Name: gatewayapiv1.ObjectName(secretName),
+					}},
+				},
+				AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+					Namespaces: &gatewayapiv1.RouteNamespaces{From: &fromNamespace},
+				},
+			}},
+		},
+	}
+
+	if err := createOrGetWithRetry(t, context.Background(), gateway, DefaultRetryTimeout); err != nil {
+		return nil, fmt.Errorf("failed to create gateway %s/%s: %w", namespace, name, err)
+	}
+	return gateway, nil
+}
+
+// generateServerTLSKeyPair returns PEM-encoded certificate and key material
+// suitable for a Gateway HTTPS listener Secret.
+func generateServerTLSKeyPair(dnsName string) (certPEM, keyPEM string, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate serial: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			Organization: []string{"OpenShift E2E Testing"},
+			CommonName:   dnsName,
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{dnsName, "localhost"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create certificate: %w", err)
+	}
+	certs, err := x509.ParseCertificates(der)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+	if len(certs) != 1 {
+		return "", "", fmt.Errorf("expected 1 certificate, got %d", len(certs))
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyDER,
+	}))
+
+	return encodeCert(certs[0]), keyPEM, nil
+}

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -833,6 +833,59 @@ func assertProxyDeployCustomConfigurations(t *testing.T, namespaceName, gatewayN
 	}
 }
 
+// assertGatewayInfrastructureLabelsPropagated verifies that labels from
+// Gateway.spec.infrastructure.labels are present on the generated proxy
+// Deployment pod template and on at least one Ready pod.
+func assertGatewayInfrastructureLabelsPropagated(t *testing.T, namespace, gatewayName, gatewayClassName string, infrastructureLabels map[string]string) error {
+	t.Helper()
+
+	deploymentName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("%s-%s", gatewayName, gatewayClassName),
+	}
+	expectedLabels := map[string]string{
+		operatorcontroller.GatewayNameLabelKey: gatewayName,
+	}
+	for key, value := range infrastructureLabels {
+		expectedLabels[key] = value
+	}
+
+	return wait.PollUntilContextTimeout(t.Context(), 5*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
+		var dep appsv1.Deployment
+		if err := kclient.Get(ctx, deploymentName, &dep); err != nil {
+			t.Logf("failed to get deployment %v: %v; retrying...", deploymentName, err)
+			return false, nil
+		}
+		for key, want := range expectedLabels {
+			if got := dep.Spec.Template.Labels[key]; got != want {
+				t.Logf("deployment %v pod template missing label %s=%q (got %q); retrying...", deploymentName, key, want, got)
+				return false, nil
+			}
+		}
+
+		var pods corev1.PodList
+		if err := kclient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels(expectedLabels)); err != nil {
+			t.Logf("failed to list pods with infrastructure labels: %v; retrying...", err)
+			return false, nil
+		}
+		ready := 0
+		for _, pod := range pods.Items {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					ready++
+					break
+				}
+			}
+		}
+		if ready == 0 {
+			t.Logf("no Ready pods matched labels %v yet (found %d pods); retrying...", expectedLabels, len(pods.Items))
+			return false, nil
+		}
+		t.Logf("observed %d Ready pod(s) with infrastructure labels %v", ready, expectedLabels)
+		return true, nil
+	})
+}
+
 func waitForGatewayListenerCondition(t *testing.T, gatewayName types.NamespacedName, listenerName string, conditions ...metav1.Condition) error {
 	t.Helper()
 


### PR DESCRIPTION
This change makes Istio installation for Gateway API receive and respect the OpenShift TLS configuration once fetched from apiserver configuration.

The change will add a new watcher on apiservers.config.openshift.io, and generate a proper TLS configuration to be passed to sail-library that will both make Istio/Pilot and the provisioned Gateways to respect the centralized configurations.

Additionally, the changes from the commit https://github.com/openshift-service-mesh/sail-operator/commit/73fe9266d9e0dd7b04db344bf8331d7025bd04aa that fix how sail-library configures the TLS options is versioned on this change while OSSM 3.4.1, that contains this fix is not available. 