### PR TITLE
OCPBUGS-90616: Add GRPCRoute to Gateway API e2e CRD test coverage

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -54,6 +54,7 @@ const (
 var crdNames = []string{
 	"gatewayclasses.gateway.networking.k8s.io",
 	"gateways.gateway.networking.k8s.io",
+	"grpcroutes.gateway.networking.k8s.io",
 	"httproutes.gateway.networking.k8s.io",
 	"referencegrants.gateway.networking.k8s.io",
 }


### PR DESCRIPTION
## Summary

- Add `grpcroutes.gateway.networking.k8s.io` to the `crdNames` list in `gateway_api_test.go` so that existing e2e tests (CRD existence, lifecycle, VAP protection) also cover GRPCRoute

The `buildGWAPICRDFromName` switch already has a `grpcroutes` case, so no other changes are needed.