### PR TITLE
NE-2664: deploy haproxy as sidecar

### DIFF
--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -1,5 +1,8 @@
 # Deployment with default values
 # Ingress Controller specific values are applied at runtime.
+#
+# Methods hashableDeployment() and deploymentConfigChanged()
+# must be updated when adding new fields to this manifest.
 kind: Deployment
 apiVersion: apps/v1
 # name and namespace are set at runtime.
@@ -10,17 +13,75 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      # manually configure the service account, so we can configure it only in the router container.
+      automountServiceAccountToken: false
       serviceAccountName: router
       # nodeSelector is set at runtime.
       priorityClassName: system-cluster-critical
+      shareProcessNamespace: true
+      initContainers:
+        - name: init-router
+          # image is set at runtime.
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+          command: ["/bin/bash", "-c", "cp -R -p /var/lib/haproxy/* /mnt/config/"]
+          volumeMounts:
+          - mountPath: /mnt/config
+            name: haproxy-config
+        - name: haproxy
+          # image is set at runtime.
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          securityContext:
+            # See https://bugzilla.redhat.com/2007246
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          command: ["/var/lib/haproxy/start-haproxy"]
+          # admin.sock should follow routerHAProxyAdminSocket const
+          args: ["-W", "-db", "-S", "/var/lib/haproxy/run/admin.sock,mode,600", "-f", "/var/lib/haproxy/conf/haproxy.config"]
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/haproxy.sock"]
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            terminationGracePeriodSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            exec:
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/haproxy.sock"]
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 120
+            exec:
+              # admin.sock should follow routerHAProxyAdminSocket const
+              command: ["/bin/sh", "-c", "echo show version | socat - /var/lib/haproxy/run/admin.sock"]
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /var/lib/haproxy
+            name: haproxy-config
+          - mountPath: /etc/pki/tls/private
+            name: default-certificate
+            readOnly: true
+          - mountPath: /var/run/configmaps/service-ca
+            name: service-ca-bundle
+            readOnly: true
       containers:
         - name: router
           # image is set at runtime.
           imagePullPolicy: IfNotPresent
           securityContext:
-            # See https://bugzilla.redhat.com/2007246
-            allowPrivilegeEscalation: true
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           # Merged at runtime.
           env:
@@ -60,14 +121,19 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 25m
+              memory: 64Mi
           volumeMounts:
+          - mountPath: /var/lib/haproxy
+            name: haproxy-config
           - mountPath: /etc/pki/tls/private
             name: default-certificate
             readOnly: true
           - mountPath: /var/run/configmaps/service-ca
             name: service-ca-bundle
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
             readOnly: true
       tolerations:
       # Ensure the pod isn't deleted during serial NoExecuteTaintManager tests.
@@ -82,6 +148,8 @@ spec:
         secret:
           defaultMode: 420
           # SecretName is set at run-time.
+      - name: haproxy-config
+        emptyDir: {}
       - name: service-ca-bundle
         configMap:
           defaultMode: 420
@@ -90,3 +158,20 @@ spec:
             path: service-ca.crt
           name: service-ca-bundle
           optional: false
+      - name: kube-api-access
+        projected:
+          defaultMode: 0400
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+          - downwardAPI:
+              items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -159,6 +159,12 @@ const (
 	StatsPortName = "metrics"
 
 	haproxyMaxTimeoutMilliseconds = 2147483647 * time.Millisecond
+
+	// routerHAProxyAdminSocket has the path to the unix socket of the master process CLI.
+	// This socket is used to issue reload, grab HAProxy version, list and manage active processes.
+	//
+	// NOTE: it is hardcoded in the deployment.yaml manifest, update there if updating here.
+	routerHAProxyAdminSocket = "/var/lib/haproxy/run/admin.sock"
 )
 
 // ensureRouterDeployment ensures the router deployment exists for a given
@@ -290,6 +296,9 @@ func headerValues(values []operatorv1.IngressControllerHTTPHeader) string {
 }
 
 // desiredRouterDeployment returns the desired router deployment.
+//
+// Methods hashableDeployment() and deploymentConfigChanged()
+// must be updated when adding new fields to this method.
 func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, ingressConfig *configv1.Ingress, infraConfig *configv1.Infrastructure, apiConfig *configv1.APIServer, networkConfig *configv1.Network, currentLBService *corev1.Service, proxyNeeded bool, haveClientCAConfigmap bool, clientCAConfigmap *corev1.ConfigMap, clusterProxyConfig *configv1.Proxy) (*appsv1.Deployment, error) {
 	deployment := manifests.RouterDeployment()
 	name := controller.RouterDeploymentName(ci)
@@ -321,6 +330,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 
 	volumes := deployment.Spec.Template.Spec.Volumes
 	routerVolumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	haproxyVolumeMounts := deployment.Spec.Template.Spec.InitContainers[1].VolumeMounts
 
 	desiredReplicas := determineDeploymentReplicas(ci, ingressConfig, infraConfig)
 	deployment.Spec.Replicas = &desiredReplicas
@@ -550,6 +560,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			MountPath: "/var/lib/haproxy/conf/error_code_pages",
 		}
 		routerVolumeMounts = append(routerVolumeMounts, httpErrorCodeVolumeMount)
+		haproxyVolumeMounts = append(haproxyVolumeMounts, httpErrorCodeVolumeMount)
 		if len(configmapName.Name) != 0 {
 			env = append(env, corev1.EnvVar{
 				Name:  "ROUTER_ERRORFILE_503",
@@ -813,7 +824,17 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		env = append(env, corev1.EnvVar{Name: "ROUTE_LABELS", Value: routeSelector.String()})
 	}
 
+	// init image: just needs bash, reusing router's image is fine since we already need to download it anyway.
+	deployment.Spec.Template.Spec.InitContainers[0].Image = config.IngressControllerImage
+
+	// router image.
 	deployment.Spec.Template.Spec.Containers[0].Image = config.IngressControllerImage
+
+	// haproxy image: using router's image for now, but it needs its own image.
+	// HAProxy images: https://redhat.atlassian.net/browse/NE-2218
+	// API field: https://redhat.atlassian.net/browse/NE-2217
+	deployment.Spec.Template.Spec.InitContainers[1].Image = config.IngressControllerImage
+
 	deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
 
 	var (
@@ -966,6 +987,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			)
 			volumes = append(volumes, rsyslogConfigVolume, rsyslogSocketVolume)
 			routerVolumeMounts = append(routerVolumeMounts, rsyslogSocketVolumeMount)
+			haproxyVolumeMounts = append(haproxyVolumeMounts, rsyslogSocketVolumeMount)
 			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, syslogContainer)
 
 		case accessLogging.Destination.Type == operatorv1.SyslogLoggingDestinationType:
@@ -1271,6 +1293,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 
 	deployment.Spec.Template.Spec.Volumes = volumes
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = routerVolumeMounts
+	deployment.Spec.Template.Spec.InitContainers[1].VolumeMounts = haproxyVolumeMounts
 
 	// If MIMETypes were supplied, expose the RouterEnableCompression and RouterCompressionMIMETypes
 	// environment variables.
@@ -1318,6 +1341,12 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 			Value: "true",
 		})
 	}
+
+	// ROUTER_HAPROXY_ADMIN_UNIX_SOCKET envvar defines where the router should find the HAProxy's admin socket.
+	env = append(env, corev1.EnvVar{
+		Name:  "ROUTER_HAPROXY_ADMIN_UNIX_SOCKET",
+		Value: routerHAProxyAdminSocket,
+	})
 
 	// TODO: The only connections from the router that may need the cluster-wide proxy are those for downloading CRLs,
 	// which, as of writing this, will always be http. If https becomes necessary, the router will need to mount the
@@ -1508,6 +1537,9 @@ func deploymentTemplateHash(deployment *appsv1.Deployment) string {
 // that have explicit values that are equal to their respective default values,
 // will be zeroed.  If onlyTemplate is true, fields that should not trigger a
 // rolling update are zeroed as well.
+//
+// Update this method when adding new fields to desiredRouterDeployment() or
+// pkg/manifests/assets/router/deployment.yaml.
 func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv1.Deployment {
 	var hashableDeployment appsv1.Deployment
 
@@ -1592,6 +1624,7 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 			LivenessProbe:   hashableProbe(container.LivenessProbe),
 			ReadinessProbe:  hashableProbe(container.ReadinessProbe),
 			StartupProbe:    hashableProbe(container.StartupProbe),
+			Resources:       container.Resources,
 			SecurityContext: container.SecurityContext,
 			Ports:           container.Ports,
 		}
@@ -1600,6 +1633,35 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 		return containers[i].Name < containers[j].Name
 	})
 	hashableDeployment.Spec.Template.Spec.Containers = containers
+	initContainers := make([]corev1.Container, len(deployment.Spec.Template.Spec.InitContainers))
+	for i, initContainer := range deployment.Spec.Template.Spec.InitContainers {
+		env := initContainer.Env
+		sort.Slice(env, func(i, j int) bool {
+			return env[i].Name < env[j].Name
+		})
+		initContainers[i] = corev1.Container{
+			Args:            initContainer.Args,
+			Command:         initContainer.Command,
+			Env:             env,
+			Image:           initContainer.Image,
+			ImagePullPolicy: initContainer.ImagePullPolicy,
+			Name:            initContainer.Name,
+			LivenessProbe:   hashableProbe(initContainer.LivenessProbe),
+			ReadinessProbe:  hashableProbe(initContainer.ReadinessProbe),
+			StartupProbe:    hashableProbe(initContainer.StartupProbe),
+			SecurityContext: initContainer.SecurityContext,
+			Ports:           initContainer.Ports,
+			Resources:       initContainer.Resources,
+			RestartPolicy:   initContainer.RestartPolicy,
+			VolumeMounts:    initContainer.VolumeMounts,
+		}
+	}
+	sort.Slice(initContainers, func(i, j int) bool {
+		return initContainers[i].Name < initContainers[j].Name
+	})
+	hashableDeployment.Spec.Template.Spec.InitContainers = initContainers
+	hashableDeployment.Spec.Template.Spec.AutomountServiceAccountToken = deployment.Spec.Template.Spec.AutomountServiceAccountToken
+	hashableDeployment.Spec.Template.Spec.ShareProcessNamespace = deployment.Spec.Template.Spec.ShareProcessNamespace
 	hashableDeployment.Spec.Template.Spec.DNSPolicy = deployment.Spec.Template.Spec.DNSPolicy
 	hashableDeployment.Spec.Template.Spec.HostNetwork = deployment.Spec.Template.Spec.HostNetwork
 	volumes := make([]corev1.Volume, len(deployment.Spec.Template.Spec.Volumes))
@@ -1768,6 +1830,9 @@ func deepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 
 // deploymentConfigChanged checks if current config matches the expected config
 // for the ingress controller deployment and if it does not, returns the updated config.
+//
+// Update this method when adding new fields to desiredRouterDeployment() or
+// pkg/manifests/assets/router/deployment.yaml.
 func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv1.Deployment) {
 	if deploymentHash(current) == deploymentHash(expected) {
 		return false, nil
@@ -1782,6 +1847,9 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 		containers[i+1] = *container.DeepCopy()
 	}
 	updated.Spec.Template.Spec.Containers = containers
+	updated.Spec.Template.Spec.InitContainers = expected.Spec.Template.Spec.InitContainers
+	updated.Spec.Template.Spec.AutomountServiceAccountToken = expected.Spec.Template.Spec.AutomountServiceAccountToken
+	updated.Spec.Template.Spec.ShareProcessNamespace = expected.Spec.Template.Spec.ShareProcessNamespace
 	updated.Spec.Template.Spec.DNSPolicy = expected.Spec.Template.Spec.DNSPolicy
 	updated.Spec.Template.Labels = expected.Spec.Template.Labels
 
@@ -1813,6 +1881,7 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	copyProbe(expected.Spec.Template.Spec.Containers[0].ReadinessProbe, updated.Spec.Template.Spec.Containers[0].ReadinessProbe, true)
 	copyProbe(expected.Spec.Template.Spec.Containers[0].StartupProbe, updated.Spec.Template.Spec.Containers[0].StartupProbe, true)
 	updated.Spec.Template.Spec.Containers[0].VolumeMounts = expected.Spec.Template.Spec.Containers[0].VolumeMounts
+	updated.Spec.Template.Spec.Containers[0].Resources = expected.Spec.Template.Spec.Containers[0].Resources
 	updated.Spec.Template.Spec.Containers[0].Ports = expected.Spec.Template.Spec.Containers[0].Ports
 	updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
 	updated.Spec.Template.Spec.TopologySpreadConstraints = expected.Spec.Template.Spec.TopologySpreadConstraints

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -22,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -31,6 +34,11 @@ import (
 const (
 	ingressControllerImage = "quay.io/openshift/router:latest"
 	routerContainerName    = "router"
+
+	routerInitContainerName        = "init-router"
+	routerHAProxyContainerName     = "haproxy"
+	routerHAProxyConfigVolume      = "haproxy-config"
+	routerServiceAccountVolumeName = "kube-api-access"
 )
 
 var toleration = corev1.Toleration{
@@ -59,10 +67,10 @@ func checkDeploymentHasEnvSorted(t *testing.T, deployment *appsv1.Deployment) {
 	}
 }
 
-func checkDeploymentHasContainer(t *testing.T, deployment *appsv1.Deployment, name string, expect bool) {
+func checkDeploymentHasContainer(t *testing.T, containers []corev1.Container, name string, expect bool) {
 	t.Helper()
 
-	for _, container := range deployment.Spec.Template.Spec.Containers {
+	for _, container := range containers {
 		if container.Name == name {
 			if expect {
 				return
@@ -75,20 +83,42 @@ func checkDeploymentHasContainer(t *testing.T, deployment *appsv1.Deployment, na
 	}
 }
 
-func checkRouterContainerSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
+func getHAProxyContainer(t *testing.T, deployment *appsv1.Deployment) *corev1.Container {
 	t.Helper()
-	checkDeploymentHasContainer(t, deployment, routerContainerName, true)
 
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == routerContainerName {
-			if allowPrivEsc := container.SecurityContext.AllowPrivilegeEscalation; allowPrivEsc == nil || !*allowPrivEsc {
-				t.Errorf("%s container does not have securityContext.allowPrivilegeEscalation: true", routerContainerName)
-			}
-			if readOnlyFS := container.SecurityContext.ReadOnlyRootFilesystem; readOnlyFS == nil || *readOnlyFS {
-				t.Errorf("%s container does not have securityContext.readOnlyRootFilesystem: false", routerContainerName)
-			}
+	for i := range deployment.Spec.Template.Spec.InitContainers {
+		container := &deployment.Spec.Template.Spec.InitContainers[i]
+		if container.Name == routerHAProxyContainerName {
+			return container
 		}
 	}
+
+	require.FailNow(t, "haproxy container not found")
+	return nil
+}
+
+func checkHAProxyContainerSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	container := getHAProxyContainer(t, deployment)
+	require.NotNil(t, container.SecurityContext, "containers[haproxy].securityContext")
+
+	if allowPrivEsc := container.SecurityContext.AllowPrivilegeEscalation; allowPrivEsc == nil || !*allowPrivEsc {
+		t.Errorf("%s container does not have securityContext.allowPrivilegeEscalation: true", routerHAProxyContainerName)
+	}
+	if readOnlyFS := container.SecurityContext.ReadOnlyRootFilesystem; readOnlyFS == nil || !*readOnlyFS {
+		t.Errorf("%s container does not have securityContext.readOnlyRootFilesystem: true", routerHAProxyContainerName)
+	}
+}
+
+func checkHAProxyContainerSocketRef(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	container := getHAProxyContainer(t, deployment)
+
+	require.Equal(t, container.Args, []string{"-W", "-db", "-S", routerHAProxyAdminSocket + ",mode,600", "-f", "/var/lib/haproxy/conf/haproxy.config"}, "containers[haproxy].Args")
+
+	require.NotNil(t, container.StartupProbe, "containers[haproxy].startupProbe")
+	require.NotNil(t, container.StartupProbe.Exec, "containers[haproxy].startupProbe.exec")
+	require.Equal(t, container.StartupProbe.Exec.Command, []string{"/bin/sh", "-c", "echo show version | socat - " + routerHAProxyAdminSocket}, "containers[haproxy].startupProbe.exec.command")
 }
 
 func checkDeploymentHash(t *testing.T, deployment *appsv1.Deployment) {
@@ -540,7 +570,8 @@ func Test_desiredRouterDeployment(t *testing.T) {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
 
-	checkRouterContainerSecurityContext(t, deployment)
+	checkHAProxyContainerSecurityContext(t, deployment)
+	checkHAProxyContainerSocketRef(t, deployment)
 	checkDeploymentHash(t, deployment)
 
 	if deployment.Spec.Replicas == nil {
@@ -648,6 +679,43 @@ func assertVolumeHasDefaultMode(t *testing.T, expected int32, actual *int32, vol
 	}
 }
 
+func assertVolumeHasServiceAccount(t *testing.T, volume corev1.Volume) {
+	t.Helper()
+
+	if !assert.NotNil(t, volume.Projected) {
+		return
+	}
+
+	assertVolumeHasDefaultMode(t, int32(0400), volume.Projected.DefaultMode, volume.Name)
+
+	require.Len(t, volume.Projected.Sources, 3, "expected 3 projected sources")
+
+	var hasToken, hasConfigMap, hasDownwardAPI bool
+	for _, source := range volume.Projected.Sources {
+		switch {
+		case source.ServiceAccountToken != nil:
+			assert.Equal(t, ptr.To(int64(3600)), source.ServiceAccountToken.ExpirationSeconds)
+			assert.Equal(t, "token", source.ServiceAccountToken.Path)
+			hasToken = true
+		case source.ConfigMap != nil:
+			assert.Equal(t, "kube-root-ca.crt", source.ConfigMap.Name)
+			assert.Equal(t, []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}}, source.ConfigMap.Items)
+			hasConfigMap = true
+		case source.DownwardAPI != nil:
+			volumeFile := []corev1.DownwardAPIVolumeFile{{
+				Path: "namespace",
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace"},
+			}}
+			assert.Equal(t, volumeFile, source.DownwardAPI.Items)
+			hasDownwardAPI = true
+		}
+	}
+	assert.True(t, hasToken, "missing ServiceAccountToken source")
+	assert.True(t, hasConfigMap, "missing ConfigMap source")
+	assert.True(t, hasDownwardAPI, "missing DownwardAPI source")
+}
+
 // checkProbes asserts that the given container specifies liveness, readiness,
 // and startup probes, and that these probes have the expected parameters.  If
 // useLocalhost is true, checkProbes asserts that the probe's HTTP action
@@ -657,13 +725,22 @@ func checkProbes(t *testing.T, container *corev1.Container, useLocalhost bool) {
 	t.Helper()
 
 	checkHandler := func(probe *corev1.Probe) {
-		if assert.NotNil(t, probe.HTTPGet) {
+		switch {
+		case probe.Exec != nil:
+			if assert.Len(t, probe.Exec.Command, 3) {
+				assert.Equal(t, "/bin/sh", probe.Exec.Command[0])
+				assert.Equal(t, "-c", probe.Exec.Command[1])
+				assert.Contains(t, probe.Exec.Command[2], "echo show version | socat - /var/lib/haproxy/run/")
+			}
+		case probe.HTTPGet != nil:
 			assert.Equal(t, corev1.URIScheme("HTTP"), probe.HTTPGet.Scheme)
 			if useLocalhost {
 				assert.Equal(t, "localhost", probe.HTTPGet.Host)
 			} else {
 				assert.Empty(t, probe.HTTPGet.Host)
 			}
+		default:
+			require.Fail(t, "container probe missing", "container %q does not configure neither exec nor httpGet probe", container.Name)
 		}
 	}
 
@@ -695,18 +772,72 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		t.Fatalf("invalid router Deployment: %v", err)
 	}
 
-	expectedVolumeSecretPairs := map[string]string{
-		"default-certificate": fmt.Sprintf("router-certs-%s", ic.Name),
-		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
-		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
-	}
 	expectedVolumes := []string{
 		"default-certificate",
 		"metrics-certs",
 		"stats-auth",
 		"service-ca-bundle",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
+	hasDesiredRouterDeploymentSpecTemplate(t, ic, deployment, expectedVolumes)
+}
+
+func TestDesiredRouterDeploymentSpecTemplateSidecar(t *testing.T) {
+	ic, ingressConfig, infraConfig, apiConfig, networkConfig, proxyNeeded, clusterProxyConfig := getRouterDeploymentComponents(t)
+	deployment, err := desiredRouterDeployment(ic, &Config{IngressControllerImage: ingressControllerImage}, ingressConfig, infraConfig, apiConfig, networkConfig, nil, proxyNeeded, false, nil, clusterProxyConfig)
+	if err != nil {
+		t.Fatalf("invalid router Deployment: %v", err)
+	}
+
+	require.Len(t, deployment.Spec.Template.Spec.InitContainers, 2, "len(initContainers)")
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1, "len(containers)")
+
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.InitContainers, routerHAProxyContainerName, true)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.InitContainers, routerInitContainerName, true)
+
+	envvars := []envData{
+		{name: "ROUTER_HAPROXY_ADMIN_UNIX_SOCKET", expectPresent: true, expectedValue: routerHAProxyAdminSocket},
+	}
+	if err := checkDeploymentEnvironment(t, deployment, envvars); err != nil {
+		t.Error(err)
+	}
+
+	expectedVolumes := []string{
+		"default-certificate",
+		"metrics-certs",
+		"stats-auth",
+		"service-ca-bundle",
+		routerServiceAccountVolumeName, // available in the pod but not mounted in the container
+		routerHAProxyConfigVolume,
+	}
+	hasDesiredRouterDeploymentSpecTemplate(t, ic, deployment, expectedVolumes)
+
+	haproxyContainer := getHAProxyContainer(t, deployment)
+
+	// restartPolicy == Always configures an init container as a sidecar
+	require.Equal(t, haproxyContainer.RestartPolicy, ptr.To(corev1.ContainerRestartPolicyAlways))
+
+	kubeAPIAccessMounted := slices.ContainsFunc(haproxyContainer.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.Name == routerServiceAccountVolumeName
+	})
+	require.Falsef(t, kubeAPIAccessMounted, "haproxy sidecar is unexpectedly mounting volume %q", routerServiceAccountVolumeName)
+
+	haproxyConfigMounted := slices.ContainsFunc(haproxyContainer.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.Name == routerHAProxyConfigVolume
+	})
+	require.Truef(t, haproxyConfigMounted, "haproxy sidecar is missing volume %q", routerHAProxyConfigVolume)
+}
+
+// hasDesiredRouterDeploymentSpecTemplate has common configuration for router deployments, with and without an HAProxy sidecar
+func hasDesiredRouterDeploymentSpecTemplate(t *testing.T, ic *operatorv1.IngressController, deployment *appsv1.Deployment, expectedVolumes []string) {
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
+
+	expectedVolumeSecretPairs := map[string]string{
+		"default-certificate": fmt.Sprintf("router-certs-%s", ic.Name),
+		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
+		"stats-auth":          fmt.Sprintf("router-stats-%s", ic.Name),
+	}
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
 		if secretName, ok := expectedVolumeSecretPairs[volume.Name]; ok {
 			if volume.Secret.SecretName != secretName {
@@ -718,6 +849,9 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 		switch volume.Name {
 		case "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
@@ -757,7 +891,10 @@ func TestDesiredRouterDeploymentSpecTemplate(t *testing.T) {
 
 	checkProbes(t, &deployment.Spec.Template.Spec.Containers[0], false)
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, false)
+	haproxyContainer := getHAProxyContainer(t, deployment)
+	checkProbes(t, haproxyContainer, false)
+
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, false)
 
 	checkDeploymentHasEnvSorted(t, deployment)
 }
@@ -848,6 +985,9 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 
 	checkProbes(t, &deployment.Spec.Template.Spec.Containers[0], false)
 
+	haproxyContainer := getHAProxyContainer(t, deployment)
+	checkProbes(t, haproxyContainer, false)
+
 	expectedVolumes := []string{
 		"default-certificate",
 		"metrics-certs",
@@ -856,6 +996,8 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 		"error-pages",
 		"rsyslog-config",
 		"rsyslog-socket",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -864,13 +1006,16 @@ func TestDesiredRouterDeploymentSpecAndNetwork(t *testing.T) {
 			assertVolumeHasDefaultMode(t, int32(0644), volume.Secret.DefaultMode, volume.Name)
 		case "error-pages", "rsyslog-config", "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		case "rsyslog-socket":
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, true)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, true)
 	tests := []envData{
 		{"ROUTER_HAPROXY_CONFIG_MANAGER", false, ""},
 		{"ROUTER_LOAD_BALANCE_ALGORITHM", true, "leastconn"},
@@ -1074,6 +1219,9 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 
 	checkProbes(t, &deployment.Spec.Template.Spec.Containers[0], true)
 
+	haproxyContainer := getHAProxyContainer(t, deployment)
+	checkProbes(t, haproxyContainer, false)
+
 	expectedVolumeSecretPairs := map[string]string{
 		"default-certificate": secretName,
 		"metrics-certs":       fmt.Sprintf("router-metrics-certs-%s", ic.Name),
@@ -1084,6 +1232,8 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		"metrics-certs",
 		"stats-auth",
 		"service-ca-bundle",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -1097,12 +1247,15 @@ func TestDesiredRouterDeploymentVariety(t *testing.T) {
 		switch volume.Name {
 		case "service-ca-bundle":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
 	}
 
-	checkDeploymentHasContainer(t, deployment, operatorv1.ContainerLoggingSidecarContainerName, false)
+	checkDeploymentHasContainer(t, deployment.Spec.Template.Spec.Containers, operatorv1.ContainerLoggingSidecarContainerName, false)
 	tests := []envData{
 		{"ROUTER_LOG_FACILITY", true, "local2"},
 		{"ROUTER_LOG_MAX_LENGTH", true, "4096"},
@@ -1300,6 +1453,8 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 		"stats-auth",
 		"service-ca-bundle",
 		"client-ca",
+		routerServiceAccountVolumeName,
+		routerHAProxyConfigVolume,
 	}
 	assertHasVolumes(t, deployment.Spec.Template.Spec.Volumes, expectedVolumes)
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
@@ -1311,6 +1466,9 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 		case "client-ca":
 			assertVolumeHasDefaultMode(t, int32(0644), volume.ConfigMap.DefaultMode, volume.Name)
 			assert.Equal(t, "router-client-ca-default", volume.VolumeSource.ConfigMap.LocalObjectReference.Name)
+		case routerServiceAccountVolumeName:
+			assertVolumeHasServiceAccount(t, volume)
+		case routerHAProxyConfigVolume:
 		default:
 			t.Errorf("router deployment has unexpected volume %s", volume.Name)
 		}
@@ -1973,9 +2131,40 @@ func Test_deploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if the container resources is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				}
+			},
+			expect: true,
+		},
+		{
 			description: "if the container image is changed",
 			mutate: func(deployment *appsv1.Deployment) {
 				deployment.Spec.Template.Spec.Containers[0].Image = "openshift/origin-cluster-ingress-operator:latest"
+			},
+			expect: true,
+		},
+		{
+			description: "if the init container resources is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				}
+			},
+			expect: true,
+		},
+		{
+			description: "if the sidecar container image is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Image = "openshift/haproxy-v28:latest"
 			},
 			expect: true,
 		},
@@ -2125,6 +2314,20 @@ func Test_deploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if automountServiceAccountToken is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)
+			},
+			expect: true,
+		},
+		{
+			description: "if shareProcessNamespace is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.ShareProcessNamespace = ptr.To(true)
+			},
+			expect: true,
+		},
+		{
 			description: "if dnsPolicy is changed",
 			mutate: func(deployment *appsv1.Deployment) {
 				deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
@@ -2257,7 +2460,9 @@ func Test_deploymentConfigChanged(t *testing.T) {
 							},
 						},
 						Spec: corev1.PodSpec{
-							DNSPolicy: corev1.DNSClusterFirst,
+							AutomountServiceAccountToken: ptr.To(false),
+							ShareProcessNamespace:        ptr.To(false),
+							DNSPolicy:                    corev1.DNSClusterFirst,
 							Volumes: []corev1.Volume{
 								{
 									Name: "default-certificate",
@@ -2344,6 +2549,12 @@ func Test_deploymentConfigChanged(t *testing.T) {
 											},
 										},
 									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("25m"),
+											corev1.ResourceMemory: resource.MustParse("64Mi"),
+										},
+									},
 									Ports: []corev1.ContainerPort{
 										{
 											Name:          "http",
@@ -2362,8 +2573,19 @@ func Test_deploymentConfigChanged(t *testing.T) {
 										},
 									},
 									SecurityContext: &corev1.SecurityContext{
-										AllowPrivilegeEscalation: ptr.To[bool](true),
-										ReadOnlyRootFilesystem:   ptr.To[bool](false),
+										AllowPrivilegeEscalation: ptr.To(true),
+										ReadOnlyRootFilesystem:   ptr.To(false),
+									},
+								},
+							},
+							InitContainers: []corev1.Container{
+								{
+									Image: "openshift/haproxy-v28:v4.0",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
 									},
 								},
 							},

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2333,6 +2333,46 @@ $ModLoad omstdout.so
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
+	routerPod, err := getRouterPod(context.TODO(), ic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// makes a HTTP request to the router so the log scanner has something to collect.
+	clientPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ping-router",
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "curl",
+					Image:   routerPod.Spec.Containers[0].Image,
+					Command: []string{"/bin/curl"},
+					Args: []string{
+						"-ksS", "http://" + routerPod.Status.PodIP,
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	if err := kclient.Create(context.TODO(), clientPod); err != nil {
+		t.Fatalf("failed to create pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), clientPod); err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			t.Fatalf("failed to delete pod %s/%s: %v", clientPod.Namespace, clientPod.Name, err)
+		}
+	}()
+
 	// Scan the syslog logs to make sure some requests get logged;
 	// the kubelet's health probes should get logged.
 	kubeConfig, err := config.GetConfig()
@@ -2419,26 +2459,10 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	// Get the deployment's pods.  We will use these to curl a route and to
-	// scan access logs.
-	deployment := &appsv1.Deployment{}
-	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-	}
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	// We will use the router's pod to curl a route and to scan access logs.
+	routerPod, err := getRouterPod(context.TODO(), ic)
 	if err != nil {
-		t.Fatalf("router deployment has invalid spec.selector: %v", err)
-	}
-	podList := &corev1.PodList{}
-	if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		t.Fatalf("failed to list pods for ingresscontroller: %v", err)
-	}
-	if len(podList.Items) != 1 {
-		var podNames []string
-		for i := range podList.Items {
-			podNames = append(podNames, podList.Items[i].Name)
-		}
-		t.Fatalf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+		t.Fatal(err)
 	}
 
 	// Make a request to the console route.
@@ -2450,19 +2474,22 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "loggingmaxlengthtest",
-			Namespace: podList.Items[0].Namespace,
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:    "curl",
-					Image:   podList.Items[0].Spec.Containers[0].Image,
+					Image:   routerPod.Spec.Containers[0].Image,
 					Command: []string{"/bin/curl"},
 					Args: []string{
 						"-k",
 						"-o", "/dev/null", "-s",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
+						route.Spec.Host + ":443:" + routerPod.Status.PodIP,
 						"https://" + route.Spec.Host,
 					},
 				},
@@ -2475,6 +2502,16 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
+	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: clientPod.Name + "-netpol", Namespace: clientPod.Namespace})
+	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
+			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+		}
+	}()
+
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
 		t.Fatalf("failed to get kube config: %v", err)
@@ -2485,18 +2522,17 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 	}
 
 	err = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-		pod := podList.Items[0]
-		readCloser, err := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		readCloser, err := client.CoreV1().Pods(routerPod.Namespace).GetLogs(routerPod.Name, &corev1.PodLogOptions{
 			Container: "logs",
 			Follow:    false,
 		}).Stream(context.TODO())
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		data, err := io.ReadAll(readCloser)
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		scanner := bufio.NewScanner(bytes.NewBuffer(data))
@@ -2514,7 +2550,7 @@ func TestContainerLoggingMaxLength(t *testing.T) {
 			// the POD name can be different for each test and how the name is build can be changed in the future, so it is not possible to
 			// set a fixed value for the test
 			if strings.Contains(line, "8192abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=") && (length >= 8100 && length <= 8400) {
-				t.Logf("found log message for maxLength and the length is equals to 8192 chars in pod %s logs", pod.Name)
+				t.Logf("found log message for maxLength and the length is equals to 8192 chars in pod %s logs", routerPod.Name)
 				found = true
 				break
 			}
@@ -2554,26 +2590,10 @@ func TestContainerLoggingMinLength(t *testing.T) {
 		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
 
-	// Get the deployment's pods.  We will use these to curl a route and to
-	// scan access logs.
-	deployment := &appsv1.Deployment{}
-	if err := kclient.Get(context.TODO(), controller.RouterDeploymentName(ic), deployment); err != nil {
-		t.Fatalf("failed to get ingresscontroller deployment: %v", err)
-	}
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	// We will use the router's pod to curl a route and to scan access logs.
+	routerPod, err := getRouterPod(context.TODO(), ic)
 	if err != nil {
-		t.Fatalf("router deployment has invalid spec.selector: %v", err)
-	}
-	podList := &corev1.PodList{}
-	if err := kclient.List(context.TODO(), podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		t.Fatalf("failed to list pods for ingresscontroller: %v", err)
-	}
-	if len(podList.Items) != 1 {
-		var podNames []string
-		for i := range podList.Items {
-			podNames = append(podNames, podList.Items[i].Name)
-		}
-		t.Fatalf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+		t.Fatal(err)
 	}
 
 	// Make a request to the console route.
@@ -2585,19 +2605,22 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	clientPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "loggingminlengthtest",
-			Namespace: podList.Items[0].Namespace,
+			Namespace: routerPod.Namespace,
+			Labels: map[string]string{
+				"type": "test-pod",
+			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:    "curl",
-					Image:   podList.Items[0].Spec.Containers[0].Image,
+					Image:   routerPod.Spec.Containers[0].Image,
 					Command: []string{"/bin/curl"},
 					Args: []string{
 						"-k",
 						"-o", "/dev/null", "-s",
 						"--resolve",
-						route.Spec.Host + ":443:" + podList.Items[0].Status.PodIP,
+						route.Spec.Host + ":443:" + routerPod.Status.PodIP,
 						"https://" + route.Spec.Host,
 					},
 				},
@@ -2610,6 +2633,16 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
+	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: clientPod.Namespace})
+	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
+		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.TODO(), networkPolicy); err != nil {
+			t.Fatalf("failed to delete network policy %s: %v", networkPolicy.Name, err)
+		}
+	}()
+
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
 		t.Fatalf("failed to get kube config: %v", err)
@@ -2620,18 +2653,17 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	}
 
 	err = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-		pod := podList.Items[0]
-		readCloser, err := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		readCloser, err := client.CoreV1().Pods(routerPod.Namespace).GetLogs(routerPod.Name, &corev1.PodLogOptions{
 			Container: "logs",
 			Follow:    false,
 		}).Stream(context.TODO())
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		data, err := io.ReadAll(readCloser)
 		if err != nil {
-			t.Logf("failed to read logs from pod %s: %v", pod.Name, err)
+			t.Logf("failed to read logs from pod %s: %v", routerPod.Name, err)
 			return false, nil
 		}
 		scanner := bufio.NewScanner(bytes.NewBuffer(data))
@@ -2649,7 +2681,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 			// the POD name can be different for each test and how the name is build can be changed in the future, so it is not possible to
 			// set a fixed value for the test
 			if strings.Contains(line, "0480abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@@@@@@@=") && (length >= 450 && length <= 650) {
-				t.Logf("found log message for minLength and the length is equals to 480 chars in pod %s logs", pod.Name)
+				t.Logf("found log message for minLength and the length is equals to 480 chars in pod %s logs", routerPod.Name)
 				found = true
 				break
 			}
@@ -4158,6 +4190,40 @@ func TestIngressOperatorCacheIsNotGlobal(t *testing.T) {
 		}
 		return false, nil
 	})
+}
+
+func getRouterPod(ctx context.Context, ic *operatorv1.IngressController) (*corev1.Pod, error) {
+	deployment := &appsv1.Deployment{}
+	if err := kclient.Get(ctx, controller.RouterDeploymentName(ic), deployment); err != nil {
+		return nil, fmt.Errorf("failed to get ingresscontroller deployment: %w", err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("router deployment has invalid spec.selector: %w", err)
+	}
+
+	// wait for router to have one single pod, in case of unexpected events like node reload
+	var routerPod *corev1.Pod
+	var pollErr error
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		podList := &corev1.PodList{}
+		if err := kclient.List(ctx, podList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			pollErr = fmt.Errorf("failed to list pods for ingresscontroller: %w", err)
+			return false, nil
+		}
+		if len(podList.Items) != 1 {
+			var podNames []string
+			for i := range podList.Items {
+				podNames = append(podNames, podList.Items[i].Name)
+			}
+			pollErr = fmt.Errorf("expected ingress controller %s to have exactly 1 router pod, but it has %d: %s", ic.Name, len(podList.Items), strings.Join(podNames, ", "))
+			return false, nil
+		}
+		routerPod = &podList.Items[0]
+		pollErr = nil
+		return true, nil
+	})
+	return routerPod, pollErr
 }
 
 func newNodePortController(name types.NamespacedName, domain string) *operatorv1.IngressController {


### PR DESCRIPTION
Adding a new container to deploy HAProxy. This is a first but fully functional implementation that allows starting e2e and exploratory tests using the new topology.

Key differences from the final version:

* The same image is used both on router and haproxy containers; and
* It is not possible to select HAProxy version.

This is due to some other and still pending stories that will handle both a new API field and building HAProxy image for all supported versions.

e2e tests updated in order to send a HTTP request to the router, because on the single container / embedded HAProxy, it is the reload-haproxy script the one sending the HTTP request the e2e test expects, and the new implementation does not use the reload script anymore.

This PR reintroduces #1439 which [failed](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-claude-payload-agent/2070211723750543360/artifacts/claude-payload-agent/openshift-claude-payload-agent/artifacts/payload-analysis-5.0.0-0.ci-2026-06-25-182114-summary.html) on a post-merge test.

https://redhat.atlassian.net/browse/NE-2664