### PR TITLE
[release-4.21] OCPBUGS-94189: Add INFO logs alongside event recorder calls

### DIFF
--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -206,6 +206,7 @@ func (r *reconciler) createCanaryCertificate(ctx context.Context, certificate *c
 		return err
 	}
 
+	log.Info("Created canary certificate secret", "namespace", certificate.Namespace, "name", certificate.Name)
 	r.recorder.Event(certificate, "Normal", "CreatedCanaryCertificate", "created canary certificate")
 	return nil
 }
@@ -220,6 +221,7 @@ func (r *reconciler) updateCanaryCertificate(ctx context.Context, current, desir
 	if err := r.client.Update(ctx, updated); err != nil {
 		return false, err
 	}
+	log.Info("Updated canary certificate secret", "namespace", updated.Namespace, "name", updated.Name)
 	r.recorder.Event(updated, "Normal", "UpdatedCanaryCertificate", "updated canary certificate")
 	return true, nil
 }

--- a/pkg/operator/controller/certificate-publisher/publish_ca.go
+++ b/pkg/operator/controller/certificate-publisher/publish_ca.go
@@ -40,6 +40,7 @@ func (r *reconciler) ensureConfigMap(name types.NamespacedName, desired *corev1.
 		if deleted, err := r.deleteRouterCAConfigMap(current); err != nil {
 			return fmt.Errorf("failed to ensure %q in %q was unpublished: %v", name.Name, name.Namespace, err)
 		} else if deleted {
+			log.Info("Unpublished router CA configmap", "name", name.Name, "namespace", name.Namespace)
 			r.recorder.Eventf(current, "Normal", "UnpublishedRouterCA", "Unpublished %q in %q", name.Name, name.Namespace)
 		}
 	case desired != nil && current == nil:
@@ -50,12 +51,14 @@ func (r *reconciler) ensureConfigMap(name types.NamespacedName, desired *corev1.
 			if err != nil {
 				return err
 			}
+			log.Info("Published router CA configmap", "name", desired.Name, "namespace", desired.Namespace)
 			r.recorder.Eventf(new, "Normal", "PublishedRouterCA", "Published %q in %q", desired.Name, desired.Namespace)
 		}
 	case desired != nil && current != nil:
 		if updated, err := r.updateRouterCAConfigMap(current, desired); err != nil {
 			return fmt.Errorf("failed to update published %q in %q: %v", desired.Name, desired.Namespace, err)
 		} else if updated {
+			log.Info("Updated published router CA configmap", "name", desired.Name, "namespace", desired.Namespace)
 			r.recorder.Eventf(current, "Normal", "UpdatedPublishedRouterCA", "Updated the published %q in %q", desired.Name, desired.Namespace)
 		}
 	}

--- a/pkg/operator/controller/certificate-publisher/publish_certs.go
+++ b/pkg/operator/controller/certificate-publisher/publish_certs.go
@@ -34,6 +34,7 @@ func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingr
 		if deleted, err := r.deleteRouterCertsGlobalSecret(current); err != nil {
 			return fmt.Errorf("failed to ensure router certificates secret was unpublished: %v", err)
 		} else if deleted {
+			log.Info("Unpublished router certificates secret", "namespace", current.Namespace, "name", current.Name)
 			r.recorder.Eventf(current, "Normal", "UnpublishedRouterCertificates", "Unpublished router certificates")
 		}
 	case desired != nil && current == nil:
@@ -44,12 +45,14 @@ func (r *reconciler) ensureRouterCertsGlobalSecret(secrets []corev1.Secret, ingr
 			if err != nil {
 				return err
 			}
+			log.Info("Published router certificates secret", "namespace", new.Namespace, "name", new.Name)
 			r.recorder.Eventf(new, "Normal", "PublishedRouterCertificates", "Published router certificates")
 		}
 	case desired != nil && current != nil:
 		if updated, err := r.updateRouterCertsGlobalSecret(current, desired); err != nil {
 			return fmt.Errorf("failed to update published router certificates secret: %v", err)
 		} else if updated {
+			log.Info("Updated published router certificates secret", "namespace", current.Namespace, "name", current.Name)
 			r.recorder.Eventf(current, "Normal", "UpdatedPublishedRouterCertificates", "Updated the published router certificates")
 		}
 	}

--- a/pkg/operator/controller/certificate/ca.go
+++ b/pkg/operator/controller/certificate/ca.go
@@ -38,6 +38,7 @@ func (r *reconciler) ensureRouterCASecret() (*corev1.Secret, error) {
 		if err != nil {
 			return nil, err
 		}
+		log.Info("Created default wildcard CA certificate secret", "namespace", new.Namespace, "name", new.Name)
 		r.recorder.Event(new, "Normal", "CreatedWildcardCACert", "Created a default wildcard CA certificate")
 		return new, nil
 

--- a/pkg/operator/controller/certificate/default_cert.go
+++ b/pkg/operator/controller/certificate/default_cert.go
@@ -48,6 +48,7 @@ func (r *reconciler) ensureDefaultCertificateForIngress(caSecret *corev1.Secret,
 		if deleted, err := r.deleteRouterDefaultCertificate(current); err != nil {
 			return true, fmt.Errorf("failed to delete default certificate: %v", err)
 		} else if deleted {
+			log.Info("Deleted default wildcard certificate secret", "namespace", current.Namespace, "name", current.Name)
 			r.recorder.Eventf(ci, "Normal", "DeletedDefaultCertificate", "Deleted default wildcard certificate %q", current.Name)
 			return false, nil
 		}
@@ -55,6 +56,7 @@ func (r *reconciler) ensureDefaultCertificateForIngress(caSecret *corev1.Secret,
 		if created, err := r.createRouterDefaultCertificate(desired); err != nil {
 			return false, fmt.Errorf("failed to create default certificate: %v", err)
 		} else if created {
+			log.Info("Created default wildcard certificate secret", "namespace", desired.Namespace, "name", desired.Name)
 			r.recorder.Eventf(ci, "Normal", "CreatedDefaultCertificate", "Created default wildcard certificate %q", desired.Name)
 			return true, nil
 		}

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -166,6 +166,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// zero TTLs, simply ignore the record until the TTL is updated by the ingresscontroller controller. Report
 	// this through events so we can detect problems with our migration.
 	if record.Spec.RecordTTL <= 0 {
+		log.Info("DNSRecord missing TTL, skipping until updated", "namespace", record.Namespace, "name", record.Name)
 		r.recorder.Eventf(record, "Warning", "ZeroTTL", "Record is missing TTL and will be temporarily ignored; the TTL will be automatically updated and the record will be retried.")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -332,12 +332,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if err := r.admit(ingress, ingressConfig, platformStatus, dnsConfig, alreadyAdmitted); err != nil {
 			switch err := err.(type) {
 			case *admissionRejection:
+				log.Info("IngressController rejected", "namespace", ingress.Namespace, "name", ingress.Name, "reason", err.Reason)
 				r.recorder.Event(ingress, "Warning", "Rejected", err.Reason)
 				return reconcile.Result{}, nil
 			default:
 				return reconcile.Result{}, fmt.Errorf("failed to admit ingresscontroller: %v", err)
 			}
 		}
+		log.Info("IngressController admitted", "namespace", ingress.Namespace, "name", ingress.Name)
 		r.recorder.Event(ingress, "Normal", "Admitted", "ingresscontroller passed validation")
 		// Just re-queue for simplicity
 		return reconcile.Result{Requeue: true}, nil
@@ -404,6 +406,7 @@ func (r *reconciler) admit(current *operatorv1.IngressController, ingressConfig 
 	updated.Status.ObservedGeneration = updated.Generation
 
 	if !domainMatchesBaseDomain {
+		log.Info("Domain does not match base domain, DNS management disabled", "namespace", updated.Namespace, "name", updated.Name, "domain", updated.Status.Domain, "baseDomain", dnsConfig.Spec.BaseDomain)
 		r.recorder.Eventf(updated, "Warning", "DomainNotMatching", fmt.Sprintf("Domain [%s] of ingresscontroller does not match the baseDomain [%s] of the cluster DNS config, so DNS management is not supported.", updated.Status.Domain, dnsConfig.Spec.BaseDomain))
 	}
 


### PR DESCRIPTION
## Summary

Cherry-pick of commit `9fe57a518dc5` from PR #1402 (commit 2), which was incorrectly dropped during the 4.21 backport (PR #1442).

PR #1402 commit 1 switched the CIO log level from DEBUG to INFO. This made `recorder.Event()` calls invisible in operator logs because controller-runtime echoes them at DEBUG level. Commit 2 added `log.Info()` calls alongside 16 event recorder calls to restore visibility. During the 4.21 backport, the entire commit was dropped due to a single conflict in `canary/daemonset.go`.

This cherry-pick resolves the conflict by skipping the one log line in `canary/daemonset.go` that references cert-hash-rotation code not present on release-4.21. The remaining 15 `log.Info()` additions across 7 files apply cleanly.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-94189

## Changes

- `canary-certificate/controller.go` — 2 log.Info() calls (certificate creation/deletion)
- `certificate-publisher/publish_ca.go` — 3 log.Info() calls (CA publishing)
- `certificate-publisher/publish_certs.go` — 3 log.Info() calls (cert publishing)
- `certificate/ca.go` — 1 log.Info() call (CA creation)
- `certificate/default_cert.go` — 2 log.Info() calls (default cert lifecycle)
- `dns/controller.go` — 1 log.Info() call (DNS record events)
- `ingress/controller.go` — 3 log.Info() calls (admission/status events)

## Test plan

- [x] `go build ./...` passes
- [ ] CI passes