### PR TITLE
[release-4.14] OCPBUGS-86711: Add configuration override for X-SSL strip

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -90,9 +90,10 @@ const (
 
 	WorkloadPartitioningManagement = "target.workload.openshift.io/management"
 
-	RouterClientAuthPolicy = "ROUTER_MUTUAL_TLS_AUTH"
-	RouterClientAuthCA     = "ROUTER_MUTUAL_TLS_AUTH_CA"
-	RouterClientAuthFilter = "ROUTER_MUTUAL_TLS_AUTH_FILTER"
+	RouterClientAuthPolicy      = "ROUTER_MUTUAL_TLS_AUTH"
+	RouterClientAuthCA          = "ROUTER_MUTUAL_TLS_AUTH_CA"
+	RouterClientAuthFilter      = "ROUTER_MUTUAL_TLS_AUTH_FILTER"
+	RouterMutualTLSHeaderFilter = "ROUTER_MUTUAL_TLS_HEADER_FILTER"
 
 	RouterEnableCompression    = "ROUTER_ENABLE_COMPRESSION"
 	RouterCompressionMIMETypes = "ROUTER_COMPRESSION_MIME"
@@ -514,6 +515,7 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		LoadBalancingAlgorithm string `json:"loadBalancingAlgorithm"`
 		DynamicConfigManager   string `json:"dynamicConfigManager"`
 		ContStats              string `json:"contStats"`
+		MutualTLSHeaderFilter  string `json:"mutualTLSHeaderFilter"`
 	}
 	if len(ci.Spec.UnsupportedConfigOverrides.Raw) > 0 {
 		if err := json.Unmarshal(ci.Spec.UnsupportedConfigOverrides.Raw, &unsupportedConfigOverrides); err != nil {
@@ -570,6 +572,13 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, ingressController
 		env = append(env, corev1.EnvVar{
 			Name:  RouterHAProxyContstats,
 			Value: "true",
+		})
+	}
+
+	if v, err := strconv.ParseBool(unsupportedConfigOverrides.MutualTLSHeaderFilter); err == nil && !v {
+		env = append(env, corev1.EnvVar{
+			Name:  RouterMutualTLSHeaderFilter,
+			Value: "false",
 		})
 	}
 

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -1083,6 +1083,66 @@ func TestDesiredRouterDeploymentClientTLS(t *testing.T) {
 	}
 }
 
+func TestDesiredRouterDeploymentMutualTLSHeaderFilter(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		unsupportedConfigOverrides string
+		expectedEnv                []envData
+	}{
+		{
+			name:                       "not-set",
+			unsupportedConfigOverrides: `{}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+		{
+			name:                       "set-to-false",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"false"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", true, "false"},
+			},
+		},
+		{
+			name:                       "set-to-true",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"true"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+		{
+			name:                       "set-to-invalid-value",
+			unsupportedConfigOverrides: `{"mutualTLSHeaderFilter":"banana"}`,
+			expectedEnv: []envData{
+				{"ROUTER_MUTUAL_TLS_HEADER_FILTER", false, ""},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ic := &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: operatorv1.IngressControllerSpec{
+					UnsupportedConfigOverrides: runtime.RawExtension{
+						Raw: []byte(tc.unsupportedConfigOverrides),
+					},
+				},
+				Status: operatorv1.IngressControllerStatus{
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.PrivateStrategyType,
+					},
+				},
+			}
+
+			deployment, err := desiredRouterDeployment(ic, ingressControllerImage, &configv1.Ingress{}, &configv1.Infrastructure{}, &configv1.APIServer{}, &configv1.Network{}, false, false, nil, &configv1.Proxy{})
+			assert.NoError(t, err)
+			assert.NoError(t, checkDeploymentEnvironment(t, deployment, tc.expectedEnv))
+		})
+	}
+}
+
 func checkContainerPort(t *testing.T, d *appsv1.Deployment, portName string, port int32) {
 	t.Helper()
 	for _, p := range d.Spec.Template.Spec.Containers[0].Ports {


### PR DESCRIPTION
Router strips X-SSL headers from HTTP listeners. In some cases a Load Balancer may be doing TLS termination and sending traffic to router with these headers. While this topology is not supported, there is a need for a knob to allow these users to rollback this validation assuming the risks of allowing the router to accept the X-SSL headers on the HTTP listener

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the router’s mutual TLS header filter through the operator’s unsupported override settings.
  * When set to `false`, the router deployment now includes the corresponding environment variable to disable the filter; when enabled or invalid, no change is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->