### PR TITLE
OCPBUGS-62627: Suppress Progressing during infrastructure-driven ingress unavailability

### DIFF
--- a/pkg/operator/controller/status/controller.go
+++ b/pkg/operator/controller/status/controller.go
@@ -652,6 +652,44 @@ func checkAllIngressesAvailable(ingresses []operatorv1.IngressController) bool {
 	return len(ingresses) != 0
 }
 
+// allUnavailableIngressesInfrastructureDriven returns true if every
+// unavailable IngressController has a DeploymentRollingOut condition whose
+// reason indicates an infrastructure-driven event (node reboot, pod
+// eviction) rather than a deliberate configuration rollout.
+func allUnavailableIngressesInfrastructureDriven(ingresses []operatorv1.IngressController) bool {
+	infrastructureReasons := sets.New[string](
+		ingress.ReasonReplicasStabilizing,
+		ingress.ReasonPodsStarting,
+	)
+	foundUnavailable := false
+	for _, ic := range ingresses {
+		available := false
+		for _, c := range ic.Status.Conditions {
+			if c.Type == operatorv1.IngressControllerAvailableConditionType && c.Status == operatorv1.ConditionTrue {
+				available = true
+				break
+			}
+		}
+		if available {
+			continue
+		}
+		foundUnavailable = true
+		infraDriven := false
+		for _, c := range ic.Status.Conditions {
+			if c.Type == ingress.IngressControllerDeploymentRollingOutConditionType &&
+				c.Status == operatorv1.ConditionTrue &&
+				infrastructureReasons.Has(c.Reason) {
+				infraDriven = true
+				break
+			}
+		}
+		if !infraDriven {
+			return false
+		}
+	}
+	return foundUnavailable
+}
+
 // computeOperatorDegradedCondition computes the operator's current Degraded status state.
 func computeOperatorDegradedCondition(state operatorState) configv1.ClusterOperatorStatusCondition {
 	degradedCondition := configv1.ClusterOperatorStatusCondition{
@@ -911,7 +949,7 @@ func computeOperatorProgressingCondition(ingresscontrollers []operatorv1.Ingress
 		}
 	}
 
-	if !allIngressesAvailable {
+	if !allIngressesAvailable && !allUnavailableIngressesInfrastructureDriven(ingresscontrollers) {
 		messages = append(messages, "Not all ingress controllers are available.")
 		progressing = true
 	}

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -21,15 +21,15 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description                  string
-		noNamespace                  bool
-		allIngressesAvailable        bool
-		someIngressProgressing       bool
-		deploymentRollingOutReason   string
-		reportedVersions             versions
-		oldVersions                  versions
-		curVersions                  versions
-		expectProgressing            configv1.ConditionStatus
+		description                string
+		noNamespace                bool
+		allIngressesAvailable      bool
+		someIngressProgressing     bool
+		deploymentRollingOutReason string
+		reportedVersions           versions
+		oldVersions                versions
+		curVersions                versions
+		expectProgressing          configv1.ConditionStatus
 	}{
 		{
 			description:           "all ingress controllers are available",

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -21,14 +21,15 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description            string
-		noNamespace            bool
-		allIngressesAvailable  bool
-		someIngressProgressing bool
-		reportedVersions       versions
-		oldVersions            versions
-		curVersions            versions
-		expectProgressing      configv1.ConditionStatus
+		description                  string
+		noNamespace                  bool
+		allIngressesAvailable        bool
+		someIngressProgressing       bool
+		deploymentRollingOutReason   string
+		reportedVersions             versions
+		oldVersions                  versions
+		curVersions                  versions
+		expectProgressing            configv1.ConditionStatus
 	}{
 		{
 			description:           "all ingress controllers are available",
@@ -44,6 +45,21 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 		{
 			description:       "all ingress controllers are not available",
 			expectProgressing: configv1.ConditionTrue,
+		},
+		{
+			description:                "unavailable due to infrastructure-driven replicas stabilizing",
+			deploymentRollingOutReason: ingress.ReasonReplicasStabilizing,
+			expectProgressing:          configv1.ConditionFalse,
+		},
+		{
+			description:                "unavailable due to infrastructure-driven pods starting",
+			deploymentRollingOutReason: ingress.ReasonPodsStarting,
+			expectProgressing:          configv1.ConditionFalse,
+		},
+		{
+			description:                "unavailable due to genuine deployment rollout",
+			deploymentRollingOutReason: ingress.ReasonDeploymentRollingOut,
+			expectProgressing:          configv1.ConditionTrue,
 		},
 		{
 			description:           "versions match",
@@ -156,10 +172,17 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 					}},
 				},
 			}
-			ingresscontrollers = append(ingresscontrollers, ic)
 			if tc.someIngressProgressing {
-				ingresscontrollers[0].Status.Conditions[0].Status = operatorv1.ConditionTrue
+				ic.Status.Conditions[0].Status = operatorv1.ConditionTrue
 			}
+			if len(tc.deploymentRollingOutReason) > 0 {
+				ic.Status.Conditions = append(ic.Status.Conditions, operatorv1.OperatorCondition{
+					Type:   ingress.IngressControllerDeploymentRollingOutConditionType,
+					Status: operatorv1.ConditionTrue,
+					Reason: tc.deploymentRollingOutReason,
+				})
+			}
+			ingresscontrollers = append(ingresscontrollers, ic)
 
 			actual := computeOperatorProgressingCondition(ingresscontrollers, tc.allIngressesAvailable, oldVersions, reportedVersions, tc.curVersions.operator, tc.curVersions.operand1, tc.curVersions.operand2)
 			conditionsCmpOpts := []cmp.Option{

--- a/pkg/operator/controller/status/controller_test.go
+++ b/pkg/operator/controller/status/controller_test.go
@@ -21,15 +21,16 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description                  string
-		noNamespace                  bool
-		allIngressesAvailable        bool
-		someIngressProgressing       bool
-		deploymentRollingOutReason   string
-		reportedVersions             versions
-		oldVersions                  versions
-		curVersions                  versions
-		expectProgressing            configv1.ConditionStatus
+		description                          string
+		noNamespace                          bool
+		allIngressesAvailable                bool
+		someIngressProgressing               bool
+		deploymentRollingOutReason           string
+		additionalDeploymentRollingOutReason string
+		reportedVersions                     versions
+		oldVersions                          versions
+		curVersions                          versions
+		expectProgressing                    configv1.ConditionStatus
 	}{
 		{
 			description:           "all ingress controllers are available",
@@ -60,6 +61,12 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 			description:                "unavailable due to genuine deployment rollout",
 			deploymentRollingOutReason: ingress.ReasonDeploymentRollingOut,
 			expectProgressing:          configv1.ConditionTrue,
+		},
+		{
+			description:                          "mixed infra and non-infra unavailability blocks suppression",
+			deploymentRollingOutReason:           ingress.ReasonReplicasStabilizing,
+			additionalDeploymentRollingOutReason: ingress.ReasonDeploymentRollingOut,
+			expectProgressing:                    configv1.ConditionTrue,
 		},
 		{
 			description:           "versions match",
@@ -183,6 +190,24 @@ func Test_computeOperatorProgressingCondition(t *testing.T) {
 				})
 			}
 			ingresscontrollers = append(ingresscontrollers, ic)
+			if len(tc.additionalDeploymentRollingOutReason) > 0 {
+				ic2 := operatorv1.IngressController{
+					Status: operatorv1.IngressControllerStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:   operatorv1.OperatorStatusTypeProgressing,
+								Status: operatorv1.ConditionFalse,
+							},
+							{
+								Type:   ingress.IngressControllerDeploymentRollingOutConditionType,
+								Status: operatorv1.ConditionTrue,
+								Reason: tc.additionalDeploymentRollingOutReason,
+							},
+						},
+					},
+				}
+				ingresscontrollers = append(ingresscontrollers, ic2)
+			}
 
 			actual := computeOperatorProgressingCondition(ingresscontrollers, tc.allIngressesAvailable, oldVersions, reportedVersions, tc.curVersions.operator, tc.curVersions.operand1, tc.curVersions.operand2)
 			conditionsCmpOpts := []cmp.Option{


### PR DESCRIPTION
## Summary

- Suppress cluster operator `Progressing=True` when ingress controllers are temporarily unavailable due to infrastructure-driven events (node reboots, pod evictions) during MCO upgrades
- The existing fix on this branch handles `DeploymentRollingOut` reason filtering at the IngressController level (~70% of flakes). This commit covers the remaining ~30% caused by the independent `allIngressesAvailable` check at the cluster operator level
- Adds `allUnavailableIngressesInfrastructureDriven()` helper that inspects each unavailable controller's `DeploymentRollingOut` condition reason (`ReplicasStabilizing`, `PodsStarting`) before suppressing the progressing signal

## Test plan

- [x] Unit tests added for infrastructure-driven unavailability (`ReplicasStabilizing`, `PodsStarting` → not progressing)
- [x] Unit test added for genuine rollout (`DeploymentRollingOut` → still progressing)
- [x] Existing tests pass (`go test ./pkg/operator/controller/status/...` and `go test ./pkg/operator/controller/ingress/...`)
- [ ] Verify in CI that the flake rate for `clusteroperator/ingress should stay Progressing=False while MCO is Progressing=True` decreases

🤖 Generated with [Claude Code](https://claude.com/claude-code)