### PR TITLE
NE-2218: Add new HAProxy 2.8 and 3.2 image references

### DIFF
--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -52,6 +52,10 @@ spec:
               fieldPath: metadata.namespace
         - name: IMAGE
           value: openshift/origin-haproxy-router:v4.0
+        - name: HAPROXY_28_IMAGE
+          value: openshift/origin-haproxy:v2.8
+        - name: HAPROXY_32_IMAGE
+          value: openshift/origin-haproxy:v3.2
         - name: CANARY_IMAGE
           value: openshift/origin-cluster-ingress-operator:latest
         - name: GATEWAY_API_OPERATOR_CATALOG

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -81,6 +81,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: IMAGE
               value: openshift/origin-haproxy-router:v4.0
+            - name: HAPROXY_28_IMAGE
+              value: openshift/origin-haproxy:v2.8
+            - name: HAPROXY_32_IMAGE
+              value: openshift/origin-haproxy:v3.2
             - name: CANARY_IMAGE
               value: openshift/origin-cluster-ingress-operator:latest
             - name: GATEWAY_API_OPERATOR_CATALOG

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,6 +10,14 @@ spec:
     from:
       kind: "DockerImage"
       name: "openshift/origin-haproxy-router:v4.0"
+  - name: haproxy-router-haproxy28
+    from:
+      kind: "DockerImage"
+      name: "openshift/origin-haproxy:v2.8"
+  - name: haproxy-router-haproxy32
+    from:
+      kind: "DockerImage"
+      name: "openshift/origin-haproxy:v3.2"
   - name: kube-rbac-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
Add minimum implementation linking the new HAProxy 2.8 and 3.2 images into image-references.

https://redhat.atlassian.net/browse/NE-2218