### PR TITLE
[release-4.21] OCPBUGS-98966: Bump Istio version from v1.27.3 to v1.27.8

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -35,8 +35,8 @@ const (
 	defaultTrustedCABundle           = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 	defaultGatewayAPIOperatorCatalog = "redhat-operators"
 	defaultGatewayAPIOperatorChannel = "stable"
-	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.2.0"
-	defaultIstioVersion              = "v1.27.3"
+	defaultGatewayAPIOperatorVersion = "servicemeshoperator3.v3.3.1"
+	defaultIstioVersion              = "v1.27.8"
 )
 
 type StartOptions struct {

--- a/manifests/02-deployment-ibm-cloud-managed.yaml
+++ b/manifests/02-deployment-ibm-cloud-managed.yaml
@@ -59,9 +59,9 @@ spec:
         - name: GATEWAY_API_OPERATOR_CHANNEL
           value: stable
         - name: GATEWAY_API_OPERATOR_VERSION
-          value: servicemeshoperator3.v3.2.0
+          value: servicemeshoperator3.v3.3.1
         - name: ISTIO_VERSION
-          value: v1.27.3
+          value: v1.27.8
         image: openshift/origin-cluster-ingress-operator:latest
         imagePullPolicy: IfNotPresent
         name: ingress-operator

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -88,9 +88,9 @@ spec:
             - name: GATEWAY_API_OPERATOR_CHANNEL
               value: stable
             - name: GATEWAY_API_OPERATOR_VERSION
-              value: servicemeshoperator3.v3.2.0
+              value: servicemeshoperator3.v3.3.1
             - name: ISTIO_VERSION
-              value: v1.27.3
+              value: v1.27.8
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

Bumps the default Istio version from v1.27.3 to v1.27.8 on release-4.21 to pick up important CVE fixes for Istio. The vendored Sail Library (OSSM 3.3.1) already includes Helm charts for v1.27.8, so no vendor update is needed.

Since 4.22+ ships OSSM 3.3.1 with Istio 1.28.5, this bump to 1.27.8 does not surpass the fix equivalence of 4.22 — Istio 1.27.8 is the latest patch for the 1.27 stream within OSSM 3.3.1, and was released in the same wave as 1.28.5.

Also updates the OSSM operator version references from 3.2.0 to 3.3.1 to reflect the current Sail Library version. These values are only used by the OLM path and are no longer active, but were misleading.

## Changes

- `cmd/ingress-operator/start.go`: `defaultIstioVersion` v1.27.3 → v1.27.8, `defaultGatewayAPIOperatorVersion` 3.2.0 → 3.3.1
- `manifests/02-deployment.yaml`: `ISTIO_VERSION` v1.27.3 → v1.27.8, `GATEWAY_API_OPERATOR_VERSION` 3.2.0 → 3.3.1
- `manifests/02-deployment-ibm-cloud-managed.yaml`: same as above

## Verification

- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)