### PR TITLE
NE-2836: Set Accepted=False and Prometheus alert for ListenerSets on managed Gateways

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -18,6 +18,7 @@ import (
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	canarycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	routemetricscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/route-metrics"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 
@@ -256,6 +257,10 @@ func start(opts *StartOptions) error {
 	log.Info("registering Prometheus metrics for status_controller")
 	if err := statuscontroller.RegisterMetrics(); err != nil {
 		log.Error(err, "unable to register metrics for status_controller")
+	}
+	log.Info("registering Prometheus metrics for listenerset_status_controller")
+	if err := listenersetstatuscontroller.RegisterMetrics(); err != nil {
+		log.Error(err, "unable to register metrics for listenerset_status_controller")
 	}
 
 	// Set up and start the file watcher.

--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -180,6 +180,8 @@ rules:
   - grpcroutes
   - referencegrants
   - backendtlspolicies
+  - listenersets
+  - listenersets/status
   verbs:
   - '*'
 

--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -88,6 +88,15 @@ spec:
             AWS NLB that may have hairpin connection failures. Connections from pods to routes
             served by router pods on the same node may time out. Set the NLB protocol field to
             PROXY to fix, or TCP to keep current behavior. See the alert description for commands.
+      - alert: ListenerSetOnManagedGateway
+        expr: ingress_operator_listenerset_on_managed_gateway == 1
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: ListenerSet targeting an OpenShift-managed Gateway detected
+          description: "This alert fires when a ListenerSet resource targets an OpenShift-managed Gateway. ListenerSets are not supported by the OpenShift Gateway API implementation. Remove the ListenerSet or retarget it to a non-OpenShift-managed Gateway."
+          message: "ListenerSet {{ $labels.listenerset_namespace }}/{{ $labels.listenerset_name }} is targeting an OpenShift-managed Gateway and will not be reconciled. On a future upgrade, this ListenerSet may become active and could cause unexpected traffic routing."
       # Recording rules related to route metrics for sending via telemetry
       - expr: min(route_metrics_controller_routes_per_shard)
         record: cluster:route_metrics_controller_routes_per_shard:min

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -8,6 +8,7 @@ import (
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 
 	"k8s.io/client-go/tools/record"
 
@@ -193,6 +194,25 @@ func (r *reconciler) ensureDependentControllers(ctx context.Context) error {
 		})); err != nil {
 		return fmt.Errorf("failed to add field indexer: %w", err)
 	}
+	// Index ListenerSets by parent Gateway after CRDs are installed.
+	if err := r.fieldIndexer.IndexField(
+		context.Background(),
+		&gatewayapiv1.ListenerSet{},
+		listenersetstatuscontroller.ListenerSetParentGatewayIndex,
+		client.IndexerFunc(func(o client.Object) []string {
+			ls, ok := o.(*gatewayapiv1.ListenerSet)
+			if !ok {
+				return []string{}
+			}
+			parentNS := ls.GetNamespace()
+			if ls.Spec.ParentRef.Namespace != nil {
+				parentNS = string(*ls.Spec.ParentRef.Namespace)
+			}
+			return []string{parentNS + "/" + string(ls.Spec.ParentRef.Name)}
+		})); err != nil {
+		return fmt.Errorf("failed to add ListenerSet field indexer: %w", err)
+	}
+
 	for i := range r.config.DependentControllers {
 		c := &r.config.DependentControllers[i]
 		go func() {

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -4,8 +4,8 @@
 // ListenerSets, so CIO disables ListenerSet reconciliation via
 // PILOT_IGNORE_RESOURCES. This controller ensures users are informed
 // that their ListenerSets will not be reconciled. It also exposes a
-// Prometheus gauge to enable alerting when ListenerSets exist on
-// managed Gateways.
+// per-ListenerSet Prometheus gauge to enable alerting when ListenerSets
+// exist on managed Gateways.
 package listenerset_status
 
 import (
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,15 +39,19 @@ const (
 	// ReasonUnsupportedByController is the reason set on the Accepted
 	// condition when a ListenerSet targets an OpenShift-managed Gateway.
 	ReasonUnsupportedByController = "UnsupportedByController"
+
+	// listenerSetParentGatewayIndex is the field index key for looking up
+	// ListenerSets by their parent Gateway name (namespace/name).
+	listenerSetParentGatewayIndex = "spec.parentRef.gateway"
 )
 
 var (
 	log = logf.Logger.WithName(controllerName)
 
-	listenerSetOnManagedGatewayMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	listenerSetOnManagedGatewayMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ingress_operator_listenerset_on_managed_gateway",
 		Help: "Set to 1 when a ListenerSet targets an OpenShift-managed Gateway. ListenerSets are not yet supported and may cause unexpected traffic behavior on upgrade.",
-	})
+	}, []string{"listenerset_namespace", "listenerset_name"})
 )
 
 func RegisterMetrics() error {
@@ -69,33 +72,78 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		return nil, err
 	}
 
-	// Use a single synthetic key so that any ListenerSet or GatewayClass
-	// change triggers one global reconcile. The reconciler lists all
-	// ListenerSets and managed GatewayClasses to compute the full
-	// picture, so per-resource reconciliation would be redundant.
-	toReconcile := func(_ context.Context, _ client.Object) []reconcile.Request {
-		return []reconcile.Request{{
-			NamespacedName: types.NamespacedName{Name: "listenerset-check"},
-		}}
+	// Index ListenerSets by their parent Gateway (namespace/name) so that
+	// Gateway changes can enqueue only the affected ListenerSets.
+	if err := operatorCache.IndexField(context.Background(), &gatewayapiv1.ListenerSet{}, listenerSetParentGatewayIndex, func(o client.Object) []string {
+		ls := o.(*gatewayapiv1.ListenerSet)
+		parentNS := ls.Namespace
+		if ls.Spec.ParentRef.Namespace != nil {
+			parentNS = string(*ls.Spec.ParentRef.Namespace)
+		}
+		return []string{parentNS + "/" + string(ls.Spec.ParentRef.Name)}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create index for ListenerSets: %w", err)
 	}
 
-	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.ListenerSet{}, handler.EnqueueRequestsFromMapFunc(toReconcile))); err != nil {
+	// Watch ListenerSets directly — each ListenerSet reconciles itself.
+	// Only reconcile on create, delete, or parentRef changes.
+	listenerSetPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldLS, okOld := e.ObjectOld.(*gatewayapiv1.ListenerSet)
+			newLS, okNew := e.ObjectNew.(*gatewayapiv1.ListenerSet)
+			if !okOld || !okNew {
+				return false
+			}
+			return string(oldLS.Spec.ParentRef.Name) != string(newLS.Spec.ParentRef.Name) ||
+				parentRefNamespace(oldLS) != parentRefNamespace(newLS)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.ListenerSet{}, &handler.EnqueueRequestForObject{}, listenerSetPredicate)); err != nil {
 		return nil, fmt.Errorf("failed to watch ListenerSets: %w", err)
 	}
 
+	// Watch Gateways — when a Gateway's class changes or it is deleted,
+	// enqueue the ListenerSets that target it via the index.
 	gatewayHasOurController := operatorcontroller.GatewayHasOurController(log, operatorCache, false)
+	gatewayToListenerSets := func(ctx context.Context, o client.Object) []reconcile.Request {
+		key := o.GetNamespace() + "/" + o.GetName()
+		var listenerSets gatewayapiv1.ListenerSetList
+		if err := operatorCache.List(ctx, &listenerSets, client.MatchingFields{listenerSetParentGatewayIndex: key}); err != nil {
+			log.Error(err, "failed to list ListenerSets for Gateway", "gateway", key)
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, ls := range listenerSets.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name},
+			})
+		}
+		return requests
+	}
 	gatewayPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return gatewayHasOurController(e.Object) },
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldGW, okOld := e.ObjectOld.(*gatewayapiv1.Gateway)
+			newGW, okNew := e.ObjectNew.(*gatewayapiv1.Gateway)
+			if !okOld || !okNew {
+				return false
+			}
+			if oldGW.Spec.GatewayClassName == newGW.Spec.GatewayClassName {
+				return false
+			}
 			return gatewayHasOurController(e.ObjectOld) || gatewayHasOurController(e.ObjectNew)
 		},
 		DeleteFunc:  func(e event.DeleteEvent) bool { return gatewayHasOurController(e.Object) },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
-	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(toReconcile), gatewayPredicate)); err != nil {
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToListenerSets), gatewayPredicate)); err != nil {
 		return nil, fmt.Errorf("failed to watch Gateways: %w", err)
 	}
 
+	// Watch GatewayClasses — when our GatewayClass is created or deleted,
+	// enqueue all ListenerSets so they can re-evaluate.
 	isOurGatewayClass := func(o client.Object) bool {
 		gc, ok := o.(*gatewayapiv1.GatewayClass)
 		if !ok {
@@ -103,14 +151,27 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		}
 		return gc.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
 	}
-	gatewayClassPredicate := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool { return isOurGatewayClass(e.Object) },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isOurGatewayClass(e.ObjectOld) || isOurGatewayClass(e.ObjectNew)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool { return isOurGatewayClass(e.Object) },
+	gatewayClassToListenerSets := func(ctx context.Context, _ client.Object) []reconcile.Request {
+		var listenerSets gatewayapiv1.ListenerSetList
+		if err := operatorCache.List(ctx, &listenerSets); err != nil {
+			log.Error(err, "failed to list ListenerSets for GatewayClass change")
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, ls := range listenerSets.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name},
+			})
+		}
+		return requests
 	}
-	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(toReconcile), gatewayClassPredicate)); err != nil {
+	gatewayClassPredicate := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isOurGatewayClass(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isOurGatewayClass(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(gatewayClassToListenerSets), gatewayClassPredicate)); err != nil {
 		return nil, fmt.Errorf("failed to watch GatewayClasses: %w", err)
 	}
 
@@ -122,69 +183,60 @@ type reconciler struct {
 	cache  cache.Cache
 }
 
+// Reconcile handles a single ListenerSet. It checks whether the
+// ListenerSet targets an OpenShift-managed Gateway and sets
+// Accepted=False if so.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log.Info("reconciling", "request", request)
+	log.Info("reconciling", "listenerset", request.NamespacedName)
 
-	gatewayClassList := gatewayapiv1.GatewayClassList{}
-	if err := r.cache.List(ctx, &gatewayClassList, client.MatchingFields{
-		operatorcontroller.GatewayClassIndexFieldName: operatorcontroller.OpenShiftGatewayClassControllerName,
-	}); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list gateway classes: %w", err)
+	ls := &gatewayapiv1.ListenerSet{}
+	if err := r.cache.Get(ctx, request.NamespacedName, ls); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// ListenerSet was deleted — clean up metric.
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get ListenerSet %s: %w", request.NamespacedName, err)
 	}
-	if len(gatewayClassList.Items) == 0 {
-		listenerSetOnManagedGatewayMetric.Set(0)
+
+	parentNS := ls.Namespace
+	if ls.Spec.ParentRef.Namespace != nil {
+		parentNS = string(*ls.Spec.ParentRef.Namespace)
+	}
+	parentName := types.NamespacedName{Namespace: parentNS, Name: string(ls.Spec.ParentRef.Name)}
+
+	gw := &gatewayapiv1.Gateway{}
+	if err := r.cache.Get(ctx, parentName, gw); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get Gateway %s: %w", parentName, err)
+	}
+
+	gcName := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
+	gc := &gatewayapiv1.GatewayClass{}
+	if err := r.cache.Get(ctx, gcName, gc); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get GatewayClass %s: %w", gcName, err)
+	}
+
+	if gc.Spec.ControllerName != operatorcontroller.OpenShiftGatewayClassControllerName {
+		listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
 		return reconcile.Result{}, nil
 	}
-	ourClassNames := make(map[string]bool, len(gatewayClassList.Items))
-	for _, gc := range gatewayClassList.Items {
-		ourClassNames[gc.Name] = true
+
+	// ListenerSet targets an OpenShift-managed Gateway.
+	listenerSetOnManagedGatewayMetric.WithLabelValues(request.Namespace, request.Name).Set(1)
+
+	if err := r.setListenerSetNotAccepted(ctx, ls); err != nil {
+		return reconcile.Result{}, err
 	}
 
-	gatewayList := gatewayapiv1.GatewayList{}
-	if err := r.cache.List(ctx, &gatewayList); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list gateways: %w", err)
-	}
-	type gatewayKey struct{ name, namespace string }
-	ourGateways := make(map[gatewayKey]bool)
-	for _, gw := range gatewayList.Items {
-		if ourClassNames[string(gw.Spec.GatewayClassName)] {
-			ourGateways[gatewayKey{gw.Name, gw.Namespace}] = true
-		}
-	}
-
-	listenerSetList := gatewayapiv1.ListenerSetList{}
-	if err := r.cache.List(ctx, &listenerSetList); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list listenersets: %w", err)
-	}
-
-	// Set Accepted=False on all ListenerSets targeting our Gateways regardless
-	// of whether the Gateway's AllowedListeners would permit attachment.
-	// Since PILOT_IGNORE_RESOURCES prevents Istio from setting any status,
-	// this is the only signal the user gets that ListenerSets are unsupported.
-	found := false
-	var errs []error
-	for i := range listenerSetList.Items {
-		ls := &listenerSetList.Items[i]
-		parentNS := ls.Namespace
-		if ls.Spec.ParentRef.Namespace != nil {
-			parentNS = string(*ls.Spec.ParentRef.Namespace)
-		}
-		if !ourGateways[gatewayKey{string(ls.Spec.ParentRef.Name), parentNS}] {
-			continue
-		}
-		found = true
-		if err := r.setListenerSetNotAccepted(ctx, ls); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	if found {
-		listenerSetOnManagedGatewayMetric.Set(1)
-	} else {
-		listenerSetOnManagedGatewayMetric.Set(0)
-	}
-
-	return reconcile.Result{}, utilerrors.NewAggregate(errs)
+	return reconcile.Result{}, nil
 }
 
 func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
@@ -194,7 +246,7 @@ func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewaya
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: ls.Generation,
 		Reason:             ReasonUnsupportedByController,
-		Message:            "ListenerSets are not yet supported by the OpenShift Gateway API implementation. This ListenerSet will not be reconciled.",
+		Message:            "ListenerSets are not yet supported by the OpenShift Gateway API implementation. This ListenerSet will not be reconciled. On a future upgrade, this ListenerSet may become active and could cause unexpected traffic routing.",
 	})
 	if !changed {
 		return nil
@@ -204,4 +256,11 @@ func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewaya
 	}
 	log.Info("set ListenerSet Accepted=False", "listenerset", ls.Name, "namespace", ls.Namespace)
 	return nil
+}
+
+func parentRefNamespace(ls *gatewayapiv1.ListenerSet) string {
+	if ls.Spec.ParentRef.Namespace != nil {
+		return string(*ls.Spec.ParentRef.Namespace)
+	}
+	return ls.Namespace
 }

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -1,6 +1,6 @@
 // The listenerset-status controller watches for ListenerSet resources
 // targeting OpenShift-managed Gateways and sets Accepted=False on them.
-// Istio does not correctly implement hostname conflict resolution for
+// Current Istio (1.30.1) does not correctly implement hostname conflict resolution for
 // ListenerSets, so CIO disables ListenerSet reconciliation via
 // PILOT_IGNORE_RESOURCES. This controller ensures users are informed
 // that their ListenerSets will not be reconciled. It also exposes a
@@ -20,12 +20,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -50,7 +52,10 @@ var (
 )
 
 func RegisterMetrics() error {
-	return prometheus.Register(listenerSetOnManagedGatewayMetric)
+	if err := prometheus.Register(listenerSetOnManagedGatewayMetric); err != nil {
+		return fmt.Errorf("failed to register ListenerSet metric: %w", err)
+	}
+	return nil
 }
 
 func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
@@ -75,22 +80,38 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 	}
 
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.ListenerSet{}, handler.EnqueueRequestsFromMapFunc(toReconcile))); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to watch ListenerSets: %w", err)
 	}
 
-	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(toReconcile))); err != nil {
-		return nil, err
+	gatewayHasOurController := operatorcontroller.GatewayHasOurController(log, operatorCache, false)
+	gatewayPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return gatewayHasOurController(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return gatewayHasOurController(e.ObjectOld) || gatewayHasOurController(e.ObjectNew)
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return gatewayHasOurController(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(toReconcile), gatewayPredicate)); err != nil {
+		return nil, fmt.Errorf("failed to watch Gateways: %w", err)
 	}
 
-	gatewayClassPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+	isOurGatewayClass := func(o client.Object) bool {
 		gc, ok := o.(*gatewayapiv1.GatewayClass)
 		if !ok {
 			return false
 		}
 		return gc.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
-	})
+	}
+	gatewayClassPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return isOurGatewayClass(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isOurGatewayClass(e.ObjectOld) || isOurGatewayClass(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool { return isOurGatewayClass(e.Object) },
+	}
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(toReconcile), gatewayClassPredicate)); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to watch GatewayClasses: %w", err)
 	}
 
 	return c, nil
@@ -141,6 +162,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Since PILOT_IGNORE_RESOURCES prevents Istio from setting any status,
 	// this is the only signal the user gets that ListenerSets are unsupported.
 	found := false
+	var errs []error
 	for i := range listenerSetList.Items {
 		ls := &listenerSetList.Items[i]
 		parentNS := ls.Namespace
@@ -148,14 +170,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			parentNS = string(*ls.Spec.ParentRef.Namespace)
 		}
 		if !ourGateways[gatewayKey{string(ls.Spec.ParentRef.Name), parentNS}] {
-			if err := r.clearListenerSetNotAccepted(ctx, ls); err != nil {
-				log.Error(err, "failed to clear ListenerSet status", "listenerset", ls.Name, "namespace", ls.Namespace)
-			}
 			continue
 		}
 		found = true
 		if err := r.setListenerSetNotAccepted(ctx, ls); err != nil {
-			log.Error(err, "failed to set ListenerSet status", "listenerset", ls.Name, "namespace", ls.Namespace)
+			errs = append(errs, err)
 		}
 	}
 
@@ -165,7 +184,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		listenerSetOnManagedGatewayMetric.Set(0)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, utilerrors.NewAggregate(errs)
 }
 
 func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
@@ -184,19 +203,5 @@ func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewaya
 		return fmt.Errorf("failed to patch ListenerSet %s/%s status: %w", ls.Namespace, ls.Name, err)
 	}
 	log.Info("set ListenerSet Accepted=False", "listenerset", ls.Name, "namespace", ls.Namespace)
-	return nil
-}
-
-func (r *reconciler) clearListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
-	found := meta.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
-	if found == nil || found.Reason != ReasonUnsupportedByController {
-		return nil
-	}
-	updated := ls.DeepCopy()
-	meta.RemoveStatusCondition(&updated.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
-	if err := r.client.Status().Patch(ctx, updated, client.MergeFrom(ls)); err != nil {
-		return fmt.Errorf("failed to clear ListenerSet %s/%s status: %w", ls.Namespace, ls.Name, err)
-	}
-	log.Info("cleared ListenerSet Accepted condition", "listenerset", ls.Name, "namespace", ls.Namespace)
 	return nil
 }

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -1,0 +1,202 @@
+// The listenerset-status controller watches for ListenerSet resources
+// targeting OpenShift-managed Gateways and sets Accepted=False on them.
+// Istio does not correctly implement hostname conflict resolution for
+// ListenerSets, so CIO disables ListenerSet reconciliation via
+// PILOT_IGNORE_RESOURCES. This controller ensures users are informed
+// that their ListenerSets will not be reconciled. It also exposes a
+// Prometheus gauge to enable alerting when ListenerSets exist on
+// managed Gateways.
+package listenerset_status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	controllerName = "listenerset_status_controller"
+
+	// ReasonUnsupportedByController is the reason set on the Accepted
+	// condition when a ListenerSet targets an OpenShift-managed Gateway.
+	ReasonUnsupportedByController = "UnsupportedByController"
+)
+
+var (
+	log = logf.Logger.WithName(controllerName)
+
+	listenerSetOnManagedGatewayMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ingress_operator_listenerset_on_managed_gateway",
+		Help: "Set to 1 when a ListenerSet targets an OpenShift-managed Gateway. ListenerSets are not yet supported and may cause unexpected traffic behavior on upgrade.",
+	})
+)
+
+func RegisterMetrics() error {
+	return prometheus.Register(listenerSetOnManagedGatewayMetric)
+}
+
+func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
+	operatorCache := mgr.GetCache()
+	r := &reconciler{
+		client: mgr.GetClient(),
+		cache:  operatorCache,
+	}
+	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: r})
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a single synthetic key so that any ListenerSet or GatewayClass
+	// change triggers one global reconcile. The reconciler lists all
+	// ListenerSets and managed GatewayClasses to compute the full
+	// picture, so per-resource reconciliation would be redundant.
+	toReconcile := func(_ context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: "listenerset-check"},
+		}}
+	}
+
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.ListenerSet{}, handler.EnqueueRequestsFromMapFunc(toReconcile))); err != nil {
+		return nil, err
+	}
+
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(toReconcile))); err != nil {
+		return nil, err
+	}
+
+	gatewayClassPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		gc, ok := o.(*gatewayapiv1.GatewayClass)
+		if !ok {
+			return false
+		}
+		return gc.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
+	})
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(toReconcile), gatewayClassPredicate)); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+type reconciler struct {
+	client client.Client
+	cache  cache.Cache
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log.Info("reconciling", "request", request)
+
+	gatewayClassList := gatewayapiv1.GatewayClassList{}
+	if err := r.cache.List(ctx, &gatewayClassList, client.MatchingFields{
+		operatorcontroller.GatewayClassIndexFieldName: operatorcontroller.OpenShiftGatewayClassControllerName,
+	}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list gateway classes: %w", err)
+	}
+	if len(gatewayClassList.Items) == 0 {
+		listenerSetOnManagedGatewayMetric.Set(0)
+		return reconcile.Result{}, nil
+	}
+	ourClassNames := make(map[string]bool, len(gatewayClassList.Items))
+	for _, gc := range gatewayClassList.Items {
+		ourClassNames[gc.Name] = true
+	}
+
+	gatewayList := gatewayapiv1.GatewayList{}
+	if err := r.cache.List(ctx, &gatewayList); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list gateways: %w", err)
+	}
+	type gatewayKey struct{ name, namespace string }
+	ourGateways := make(map[gatewayKey]bool)
+	for _, gw := range gatewayList.Items {
+		if ourClassNames[string(gw.Spec.GatewayClassName)] {
+			ourGateways[gatewayKey{gw.Name, gw.Namespace}] = true
+		}
+	}
+
+	listenerSetList := gatewayapiv1.ListenerSetList{}
+	if err := r.cache.List(ctx, &listenerSetList); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list listenersets: %w", err)
+	}
+
+	// Set Accepted=False on all ListenerSets targeting our Gateways regardless
+	// of whether the Gateway's AllowedListeners would permit attachment.
+	// Since PILOT_IGNORE_RESOURCES prevents Istio from setting any status,
+	// this is the only signal the user gets that ListenerSets are unsupported.
+	found := false
+	for i := range listenerSetList.Items {
+		ls := &listenerSetList.Items[i]
+		parentNS := ls.Namespace
+		if ls.Spec.ParentRef.Namespace != nil {
+			parentNS = string(*ls.Spec.ParentRef.Namespace)
+		}
+		if !ourGateways[gatewayKey{string(ls.Spec.ParentRef.Name), parentNS}] {
+			if err := r.clearListenerSetNotAccepted(ctx, ls); err != nil {
+				log.Error(err, "failed to clear ListenerSet status", "listenerset", ls.Name, "namespace", ls.Namespace)
+			}
+			continue
+		}
+		found = true
+		if err := r.setListenerSetNotAccepted(ctx, ls); err != nil {
+			log.Error(err, "failed to set ListenerSet status", "listenerset", ls.Name, "namespace", ls.Namespace)
+		}
+	}
+
+	if found {
+		listenerSetOnManagedGatewayMetric.Set(1)
+	} else {
+		listenerSetOnManagedGatewayMetric.Set(0)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
+	updated := ls.DeepCopy()
+	changed := meta.SetStatusCondition(&updated.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayapiv1.ListenerSetConditionAccepted),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: ls.Generation,
+		Reason:             ReasonUnsupportedByController,
+		Message:            "ListenerSets are not yet supported by the OpenShift Gateway API implementation. This ListenerSet will not be reconciled.",
+	})
+	if !changed {
+		return nil
+	}
+	if err := r.client.Status().Patch(ctx, updated, client.MergeFrom(ls)); err != nil {
+		return fmt.Errorf("failed to patch ListenerSet %s/%s status: %w", ls.Namespace, ls.Name, err)
+	}
+	log.Info("set ListenerSet Accepted=False", "listenerset", ls.Name, "namespace", ls.Namespace)
+	return nil
+}
+
+func (r *reconciler) clearListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
+	found := meta.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+	if found == nil || found.Reason != ReasonUnsupportedByController {
+		return nil
+	}
+	updated := ls.DeepCopy()
+	meta.RemoveStatusCondition(&updated.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+	if err := r.client.Status().Patch(ctx, updated, client.MergeFrom(ls)); err != nil {
+		return fmt.Errorf("failed to clear ListenerSet %s/%s status: %w", ls.Namespace, ls.Name, err)
+	}
+	log.Info("cleared ListenerSet Accepted condition", "listenerset", ls.Name, "namespace", ls.Namespace)
+	return nil
+}

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -40,9 +40,9 @@ const (
 	// condition when a ListenerSet targets an OpenShift-managed Gateway.
 	ReasonUnsupportedByController = "UnsupportedByController"
 
-	// listenerSetParentGatewayIndex is the field index key for looking up
+	// ListenerSetParentGatewayIndex is the field index key for looking up
 	// ListenerSets by their parent Gateway name (namespace/name).
-	listenerSetParentGatewayIndex = "spec.parentRef.gateway"
+	ListenerSetParentGatewayIndex = "spec.parentRef.gateway"
 )
 
 var (
@@ -72,19 +72,6 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		return nil, err
 	}
 
-	// Index ListenerSets by their parent Gateway (namespace/name) so that
-	// Gateway changes can enqueue only the affected ListenerSets.
-	if err := operatorCache.IndexField(context.Background(), &gatewayapiv1.ListenerSet{}, listenerSetParentGatewayIndex, func(o client.Object) []string {
-		ls := o.(*gatewayapiv1.ListenerSet)
-		parentNS := ls.Namespace
-		if ls.Spec.ParentRef.Namespace != nil {
-			parentNS = string(*ls.Spec.ParentRef.Namespace)
-		}
-		return []string{parentNS + "/" + string(ls.Spec.ParentRef.Name)}
-	}); err != nil {
-		return nil, fmt.Errorf("failed to create index for ListenerSets: %w", err)
-	}
-
 	// Watch ListenerSets directly — each ListenerSet reconciles itself.
 	// Only reconcile on create, delete, or parentRef changes.
 	listenerSetPredicate := predicate.Funcs{
@@ -110,7 +97,7 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 	gatewayToListenerSets := func(ctx context.Context, o client.Object) []reconcile.Request {
 		key := o.GetNamespace() + "/" + o.GetName()
 		var listenerSets gatewayapiv1.ListenerSetList
-		if err := operatorCache.List(ctx, &listenerSets, client.MatchingFields{listenerSetParentGatewayIndex: key}); err != nil {
+		if err := operatorCache.List(ctx, &listenerSets, client.MatchingFields{ListenerSetParentGatewayIndex: key}); err != nil {
 			log.Error(err, "failed to list ListenerSets for Gateway", "gateway", key)
 			return nil
 		}
@@ -151,7 +138,7 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		}
 		return gc.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
 	}
-	gatewayClassToListenerSets := func(ctx context.Context, _ client.Object) []reconcile.Request {
+	reconcileAllListenerSets := func(ctx context.Context, _ client.Object) []reconcile.Request {
 		var listenerSets gatewayapiv1.ListenerSetList
 		if err := operatorCache.List(ctx, &listenerSets); err != nil {
 			log.Error(err, "failed to list ListenerSets for GatewayClass change")
@@ -171,7 +158,7 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		DeleteFunc:  func(e event.DeleteEvent) bool { return isOurGatewayClass(e.Object) },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
-	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(gatewayClassToListenerSets), gatewayClassPredicate)); err != nil {
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(reconcileAllListenerSets), gatewayClassPredicate)); err != nil {
 		return nil, fmt.Errorf("failed to watch GatewayClasses: %w", err)
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -36,6 +36,7 @@ import (
 	crlcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/crl"
 	dnscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/dns"
 	gatewaylabelercontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-labeler"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	gatewaynetworkpolicycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-networkpolicy"
 	gatewayservicednscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-service-dns"
 	gatewaystatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-status"
@@ -47,6 +48,7 @@ import (
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 	"github.com/openshift/library-go/pkg/operator/events"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -376,18 +378,31 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		return nil, fmt.Errorf("failed to create gateway-networkpolicy controller: %w", err)
 	}
 
+	dependentControllers := []controller.Controller{
+		gatewayClassController,
+		gatewayServiceDNSController,
+		gatewayLabelController,
+		gatewayStatusController,
+		gatewayNetworkPolicyController,
+	}
+
+	var listenerSetCRD apiextensionsv1.CustomResourceDefinition
+	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "listenersets.gateway.networking.k8s.io"}, &listenerSetCRD); err != nil {
+		log.Info("ListenerSet CRD not found, skipping listenerset-status controller")
+	} else {
+		listenerSetStatusController, err := listenersetstatuscontroller.NewUnmanaged(mgr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create listenerset-status controller: %w", err)
+		}
+		dependentControllers = append(dependentControllers, listenerSetStatusController)
+	}
+
 	// Set up the gatewayapi controller.
 	if _, err := gatewayapicontroller.New(mgr, gatewayapicontroller.Config{
 		MarketplaceEnabled:              marketplaceEnabled,
 		OperatorLifecycleManagerEnabled: olmEnabled,
 		GatewayAPIWithoutOLMEnabled:     gatewayAPIWithoutOLMEnabled,
-		DependentControllers: []controller.Controller{
-			gatewayClassController,
-			gatewayServiceDNSController,
-			gatewayLabelController,
-			gatewayStatusController,
-			gatewayNetworkPolicyController,
-		},
+		DependentControllers:            dependentControllers,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayapi controller: %w", err)
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -382,21 +382,19 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		return nil, fmt.Errorf("failed to create listenerset-status controller: %w", err)
 	}
 
-	dependentControllers := []controller.Controller{
-		gatewayClassController,
-		gatewayServiceDNSController,
-		gatewayLabelController,
-		gatewayStatusController,
-		gatewayNetworkPolicyController,
-		listenerSetStatusController,
-	}
-
 	// Set up the gatewayapi controller.
 	if _, err := gatewayapicontroller.New(mgr, gatewayapicontroller.Config{
 		MarketplaceEnabled:              marketplaceEnabled,
 		OperatorLifecycleManagerEnabled: olmEnabled,
 		GatewayAPIWithoutOLMEnabled:     gatewayAPIWithoutOLMEnabled,
-		DependentControllers:            dependentControllers,
+		DependentControllers: []controller.Controller{
+			gatewayClassController,
+			gatewayServiceDNSController,
+			gatewayLabelController,
+			gatewayStatusController,
+			gatewayNetworkPolicyController,
+			listenerSetStatusController,
+		},
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayapi controller: %w", err)
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -36,7 +36,6 @@ import (
 	crlcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/crl"
 	dnscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/dns"
 	gatewaylabelercontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-labeler"
-	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	gatewaynetworkpolicycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-networkpolicy"
 	gatewayservicednscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-service-dns"
 	gatewaystatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/gateway-status"
@@ -45,10 +44,10 @@ import (
 	ingress "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 	ingressclasscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingressclass"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 	"github.com/openshift/library-go/pkg/operator/events"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -378,23 +377,18 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		return nil, fmt.Errorf("failed to create gateway-networkpolicy controller: %w", err)
 	}
 
+	listenerSetStatusController, err := listenersetstatuscontroller.NewUnmanaged(mgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listenerset-status controller: %w", err)
+	}
+
 	dependentControllers := []controller.Controller{
 		gatewayClassController,
 		gatewayServiceDNSController,
 		gatewayLabelController,
 		gatewayStatusController,
 		gatewayNetworkPolicyController,
-	}
-
-	var listenerSetCRD apiextensionsv1.CustomResourceDefinition
-	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "listenersets.gateway.networking.k8s.io"}, &listenerSetCRD); err != nil {
-		log.Info("ListenerSet CRD not found, skipping listenerset-status controller")
-	} else {
-		listenerSetStatusController, err := listenersetstatuscontroller.NewUnmanaged(mgr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create listenerset-status controller: %w", err)
-		}
-		dependentControllers = append(dependentControllers, listenerSetStatusController)
+		listenerSetStatusController,
 	}
 
 	// Set up the gatewayapi controller.

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1714,7 +1714,6 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 // testListenerSetNotAccepted verifies that a ListenerSet targeting an
 // OpenShift-managed Gateway gets Accepted=False.
 func testListenerSetNotAccepted(t *testing.T) {
-
 	lsName := names.SimpleNameGenerator.GenerateName("test-listenerset-")
 	ls := &gatewayapiv1.ListenerSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -17,6 +17,7 @@ import (
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	util "github.com/openshift/cluster-ingress-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,6 +137,7 @@ func TestGatewayAPI(t *testing.T) {
 	t.Run("testGatewayAPIListenerSetIgnored", testGatewayAPIListenerSetIgnored)
 	t.Run("testOperatorDegradedCondition", testOperatorDegradedCondition)
 	t.Run("testGatewayOpenshiftConditions", testGatewayOpenshiftConditions)
+	t.Run("testListenerSetNotAccepted", testListenerSetNotAccepted)
 	if gatewayAPIWithoutOLMEnabled {
 		t.Run("testGatewayAPIIstioUninstallSailLibrary", testGatewayAPIIstioUninstallSailLibrary)
 	}
@@ -1707,4 +1709,129 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 	}
 
 	return errs
+}
+
+// testListenerSetNotAccepted verifies that a ListenerSet targeting an
+// OpenShift-managed Gateway gets Accepted=False, and that a ListenerSet
+// targeting a non-existent gateway does not get any conditions set.
+func testListenerSetNotAccepted(t *testing.T) {
+	t.Helper()
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := kclient.Get(context.TODO(), types.NamespacedName{Name: "listenersets.gateway.networking.k8s.io"}, &crd); err != nil {
+		t.Skip("ListenerSet CRD not installed, skipping")
+	}
+
+	// Test 1: ListenerSet on our Gateway should get Accepted=False.
+	lsName := names.SimpleNameGenerator.GenerateName("test-listenerset-")
+	ls := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lsName,
+			Namespace: operatorcontroller.DefaultOperandNamespace,
+		},
+		Spec: gatewayapiv1.ListenerSetSpec{
+			ParentRef: gatewayapiv1.ParentGatewayReference{
+				Name: gatewayapiv1.ObjectName(testGatewayName),
+			},
+			Listeners: []gatewayapiv1.ListenerEntry{
+				{
+					Name:     "test-listener",
+					Port:     8443,
+					Protocol: gatewayapiv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	t.Logf("creating ListenerSet %s/%s targeting gateway %s", ls.Namespace, ls.Name, testGatewayName)
+	if err := kclient.Create(context.TODO(), ls); err != nil {
+		t.Fatalf("failed to create ListenerSet: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := kclient.Delete(context.TODO(), ls); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("failed to delete ListenerSet: %v", err)
+			}
+		}
+	})
+
+	t.Log("verifying ListenerSet gets Accepted=False")
+	nsName := types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}
+	require.Eventually(t, func() bool {
+		if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
+			t.Logf("failed to get ListenerSet: %v", err)
+			return false
+		}
+		cond := condutils.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+		if cond == nil {
+			return false
+		}
+		return cond.Status == metav1.ConditionFalse && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
+	}, 2*time.Minute, 2*time.Second, "ListenerSet did not get Accepted=False")
+
+	// Test 2: ListenerSet targeting a non-existent gateway should not get
+	// Accepted=False from CIO.
+	unrelatedName := names.SimpleNameGenerator.GenerateName("test-listenerset-unrelated-")
+	unrelatedLS := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      unrelatedName,
+			Namespace: operatorcontroller.DefaultOperandNamespace,
+		},
+		Spec: gatewayapiv1.ListenerSetSpec{
+			ParentRef: gatewayapiv1.ParentGatewayReference{
+				Name: "non-existent-gateway",
+			},
+			Listeners: []gatewayapiv1.ListenerEntry{
+				{
+					Name:     "test-listener",
+					Port:     8443,
+					Protocol: gatewayapiv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	t.Logf("creating unrelated ListenerSet %s/%s", unrelatedLS.Namespace, unrelatedLS.Name)
+	if err := kclient.Create(context.TODO(), unrelatedLS); err != nil {
+		t.Fatalf("failed to create unrelated ListenerSet: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := kclient.Delete(context.TODO(), unrelatedLS); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("failed to delete unrelated ListenerSet: %v", err)
+			}
+		}
+	})
+
+	t.Log("verifying unrelated ListenerSet does NOT get Accepted=False from CIO")
+	unrelatedNSName := types.NamespacedName{Namespace: unrelatedLS.Namespace, Name: unrelatedLS.Name}
+	assert.Never(t, func() bool {
+		if err := kclient.Get(context.TODO(), unrelatedNSName, unrelatedLS); err != nil {
+			t.Logf("failed to get unrelated ListenerSet: %v", err)
+			return false
+		}
+		cond := condutils.FindStatusCondition(unrelatedLS.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+		return cond != nil && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
+	}, 30*time.Second, 2*time.Second, "unrelated ListenerSet unexpectedly got Accepted=False from CIO")
+
+	// Test 3: Changing the parentRef away from a managed Gateway should clear
+	// the Accepted=False condition set by CIO.
+	t.Log("updating ListenerSet to target a non-existent gateway")
+	if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
+		t.Fatalf("failed to get ListenerSet before update: %v", err)
+	}
+	ls.Spec.ParentRef.Name = "non-existent-gateway"
+	if err := kclient.Update(context.TODO(), ls); err != nil {
+		t.Fatalf("failed to update ListenerSet parentRef: %v", err)
+	}
+
+	t.Log("verifying Accepted condition is cleared after re-targeting")
+	require.Eventually(t, func() bool {
+		if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
+			t.Logf("failed to get ListenerSet: %v", err)
+			return false
+		}
+		cond := condutils.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+		return cond == nil || cond.Reason != listenersetstatuscontroller.ReasonUnsupportedByController
+	}, 2*time.Minute, 2*time.Second, "Accepted=False was not cleared after re-targeting ListenerSet")
 }

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -1712,17 +1712,9 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 }
 
 // testListenerSetNotAccepted verifies that a ListenerSet targeting an
-// OpenShift-managed Gateway gets Accepted=False, and that a ListenerSet
-// targeting a non-existent gateway does not get any conditions set.
+// OpenShift-managed Gateway gets Accepted=False.
 func testListenerSetNotAccepted(t *testing.T) {
-	t.Helper()
 
-	var crd apiextensionsv1.CustomResourceDefinition
-	if err := kclient.Get(context.TODO(), types.NamespacedName{Name: "listenersets.gateway.networking.k8s.io"}, &crd); err != nil {
-		t.Skip("ListenerSet CRD not installed, skipping")
-	}
-
-	// Test 1: ListenerSet on our Gateway should get Accepted=False.
 	lsName := names.SimpleNameGenerator.GenerateName("test-listenerset-")
 	ls := &gatewayapiv1.ListenerSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1744,11 +1736,11 @@ func testListenerSetNotAccepted(t *testing.T) {
 	}
 
 	t.Logf("creating ListenerSet %s/%s targeting gateway %s", ls.Namespace, ls.Name, testGatewayName)
-	if err := kclient.Create(context.TODO(), ls); err != nil {
+	if err := kclient.Create(t.Context(), ls); err != nil {
 		t.Fatalf("failed to create ListenerSet: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := kclient.Delete(context.TODO(), ls); err != nil {
+		if err := kclient.Delete(context.Background(), ls); err != nil {
 			if !errors.IsNotFound(err) {
 				t.Logf("failed to delete ListenerSet: %v", err)
 			}
@@ -1757,8 +1749,8 @@ func testListenerSetNotAccepted(t *testing.T) {
 
 	t.Log("verifying ListenerSet gets Accepted=False")
 	nsName := types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}
-	require.Eventually(t, func() bool {
-		if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
+	assert.Eventually(t, func() bool {
+		if err := kclient.Get(t.Context(), nsName, ls); err != nil {
 			t.Logf("failed to get ListenerSet: %v", err)
 			return false
 		}
@@ -1768,70 +1760,4 @@ func testListenerSetNotAccepted(t *testing.T) {
 		}
 		return cond.Status == metav1.ConditionFalse && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
 	}, 2*time.Minute, 2*time.Second, "ListenerSet did not get Accepted=False")
-
-	// Test 2: ListenerSet targeting a non-existent gateway should not get
-	// Accepted=False from CIO.
-	unrelatedName := names.SimpleNameGenerator.GenerateName("test-listenerset-unrelated-")
-	unrelatedLS := &gatewayapiv1.ListenerSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      unrelatedName,
-			Namespace: operatorcontroller.DefaultOperandNamespace,
-		},
-		Spec: gatewayapiv1.ListenerSetSpec{
-			ParentRef: gatewayapiv1.ParentGatewayReference{
-				Name: "non-existent-gateway",
-			},
-			Listeners: []gatewayapiv1.ListenerEntry{
-				{
-					Name:     "test-listener",
-					Port:     8443,
-					Protocol: gatewayapiv1.HTTPSProtocolType,
-				},
-			},
-		},
-	}
-
-	t.Logf("creating unrelated ListenerSet %s/%s", unrelatedLS.Namespace, unrelatedLS.Name)
-	if err := kclient.Create(context.TODO(), unrelatedLS); err != nil {
-		t.Fatalf("failed to create unrelated ListenerSet: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := kclient.Delete(context.TODO(), unrelatedLS); err != nil {
-			if !errors.IsNotFound(err) {
-				t.Logf("failed to delete unrelated ListenerSet: %v", err)
-			}
-		}
-	})
-
-	t.Log("verifying unrelated ListenerSet does NOT get Accepted=False from CIO")
-	unrelatedNSName := types.NamespacedName{Namespace: unrelatedLS.Namespace, Name: unrelatedLS.Name}
-	assert.Never(t, func() bool {
-		if err := kclient.Get(context.TODO(), unrelatedNSName, unrelatedLS); err != nil {
-			t.Logf("failed to get unrelated ListenerSet: %v", err)
-			return false
-		}
-		cond := condutils.FindStatusCondition(unrelatedLS.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
-		return cond != nil && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
-	}, 30*time.Second, 2*time.Second, "unrelated ListenerSet unexpectedly got Accepted=False from CIO")
-
-	// Test 3: Changing the parentRef away from a managed Gateway should clear
-	// the Accepted=False condition set by CIO.
-	t.Log("updating ListenerSet to target a non-existent gateway")
-	if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
-		t.Fatalf("failed to get ListenerSet before update: %v", err)
-	}
-	ls.Spec.ParentRef.Name = "non-existent-gateway"
-	if err := kclient.Update(context.TODO(), ls); err != nil {
-		t.Fatalf("failed to update ListenerSet parentRef: %v", err)
-	}
-
-	t.Log("verifying Accepted condition is cleared after re-targeting")
-	require.Eventually(t, func() bool {
-		if err := kclient.Get(context.TODO(), nsName, ls); err != nil {
-			t.Logf("failed to get ListenerSet: %v", err)
-			return false
-		}
-		cond := condutils.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
-		return cond == nil || cond.Reason != listenersetstatuscontroller.ReasonUnsupportedByController
-	}, 2*time.Minute, 2*time.Second, "Accepted=False was not cleared after re-targeting ListenerSet")
 }


### PR DESCRIPTION
## Summary

Sets `Accepted=False` on ListenerSets targeting OpenShift-managed Gateways and exposes a per-ListenerSet Prometheus metric with an alert.

Istio 1.30 has a [conflict resolution bug](https://github.com/istio/istio/pull/60775) for ListenerSets that could allow hostname hijacking. CIO disables ListenerSet reconciliation via `PILOT_IGNORE_RESOURCES`, but users can still create ListenerSets that would become active on a future upgrade when the ignore is removed.

## Changes

- **New controller** (`listenerset-status`): per-ListenerSet reconciliation — watches ListenerSets, Gateways, and GatewayClasses. For any ListenerSet targeting an OpenShift-managed Gateway, sets `Accepted=False` with reason `UnsupportedByController`. Uses a field index on ListenerSets by parent Gateway for targeted lookups (index created in `ensureDependentControllers` after CRDs are installed). Predicates filter to only relevant changes (parentRef, gatewayClassName, create/delete).
- **Prometheus metric** (`ingress_operator_listenerset_on_managed_gateway`): GaugeVec with `listenerset_namespace` and `listenerset_name` labels, set to 1 per ListenerSet targeting a managed Gateway. Cleaned up when the ListenerSet is deleted or the parent Gateway is deleted.
- **PrometheusRule alert** (`ListenerSetOnManagedGateway`): fires per-ListenerSet after 5m, severity `info`. Message identifies the specific ListenerSet and warns about potential activation on future upgrade.
- **RBAC**: adds `listenersets` and `listenersets/status` to the CIO ClusterRole.
- **E2E test**: verifies a ListenerSet targeting a managed Gateway gets `Accepted=False` with `UnsupportedByController` reason.

Jira: [NE-2836](https://redhat.atlassian.net/browse/NE-2836)

🤖 Generated with [Claude Code](https://claude.com/claude-code)