### PR TITLE
OCPBUGS-98088: Use /healthz for router startup probe

### DIFF
--- a/pkg/manifests/assets/router/deployment.yaml
+++ b/pkg/manifests/assets/router/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           startupProbe:
             failureThreshold: 120
             httpGet:
-              path: /healthz/ready
+              path: /healthz
               port: 1936
               scheme: HTTP
             periodSeconds: 1


### PR DESCRIPTION
The startup probe previously used /healthz/ready, which requires the router to have synced its first route within the 2-minute failure threshold. On resource-constrained clusters or during slow provisioning, the bootstrap process can exceed this window, causing the router pod to crashloop.

Switching the startup probe to /healthz checks only that the router process is alive, allowing the readiness probe to gate traffic until the initial sync completes. This lets the router remain not-ready during a slow bootstrap rather than restarting repeatedly.

https://redhat.atlassian.net/browse/OCPBUGS-98088