### PR TITLE
OCPBUGS-86841: Add BackendTLSPolicy to Gateway API e2e CRD test coverage

### DIFF
--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -57,6 +57,7 @@ var crdNames = []string{
 	"grpcroutes.gateway.networking.k8s.io",
 	"httproutes.gateway.networking.k8s.io",
 	"referencegrants.gateway.networking.k8s.io",
+	"backendtlspolicies.gateway.networking.k8s.io",
 }
 
 // List of Istio CRDs for testing installation and ownership.

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -390,6 +390,10 @@ func buildGWAPICRDFromName(name string) *apiextensionsv1.CustomResourceDefinitio
 	case "referencegrants":
 		kind = "ReferenceGrant"
 		versions = []map[string]bool{{"v1beta1": true}}
+	case "backendtlspolicies":
+		singular = "backendtlspolicy"
+		kind = "BackendTLSPolicy"
+		versions = []map[string]bool{{"v1": true /*storage version*/}, {"v1alpha3": false}}
 	case "tests":
 		kind = "Test"
 		versions = []map[string]bool{{"v1": true}}


### PR DESCRIPTION
## Summary

Add `backendtlspolicies.gateway.networking.k8s.io` to the `crdNames` list and the corresponding case in `buildGWAPICRDFromName`, so BackendTLSPolicy is exercised by the existing CRD existence, delete/recreate lifecycle, and VAP protection tests.

Split from #1467 per reviewer request.

Assisted with Claude