### PR TITLE
OCPBUGS-99775: Update TestHTTPHeaderBufferSize for HAProxy 3.2 response code change

### DIFF
--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -235,8 +235,9 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPodInvalidRequest, DefaultRetryTimeout) })
 
-	// Check curl pod logs for a 400 response since the sent headers
-	// are too large for HAProxy.
+	// Check curl pod logs for a 400 or 431 response since the sent headers
+	// are too large for HAProxy. HAProxy 2.8 returns 400 Bad request,
+	// while HAProxy 3.2+ returns 431 Request Header Fields Too Large (RFC 6585).
 	pollErr = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
 		readCloser, err := cl.CoreV1().Pods(clientPodInvalidRequest.Namespace).GetLogs(clientPodInvalidRequest.Name, &corev1.PodLogOptions{
 			Container: "curl",
@@ -254,7 +255,7 @@ func TestHTTPHeaderBufferSize(t *testing.T) {
 		}()
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, "400 Bad request") {
+			if strings.Contains(line, "400 Bad request") || strings.Contains(line, "431 Request Header Fields Too Large") {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
## Summary

HAProxy 3.2 returns `431 Request Header Fields Too Large` ([RFC 6585 §5](https://datatracker.ietf.org/doc/html/rfc6585#section-5)) when request headers exceed the configured buffer size, whereas HAProxy 2.8 returned a generic `400 Bad Request`. This is the correct, standards-compliant behavior — HAProxy added it in commit [bc967758a2](https://github.com/haproxy/haproxy/commit/bc967758a2) to address [haproxy/haproxy#1309](https://github.com/haproxy/haproxy/issues/1309).

The default HAProxy version was bumped from 2.8 to 3.2 in [openshift/router#792](https://github.com/openshift/router/pull/792). This PR updates `TestHTTPHeaderBufferSize` to accept both `400` and `431` so the test passes against either HAProxy version.

## Changes

- `test/e2e/http_header_buffer_test.go`: Accept `431 Request Header Fields Too Large` in addition to `400 Bad request` when checking curl output for oversized header responses.