### PR TITLE
OCPBUGS-TBD: Disable Istio CRL configmap creation

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -141,6 +141,7 @@ func Test_Reconcile(t *testing.T) {
 							"PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API":         "false",
 							"ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT":             "false",
 							"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY":            "true",
+							"PILOT_ENABLE_CA_CRL":                              "false",
 							"PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS": "false",
 						},
 						ExtraContainerArgs: []string{},
@@ -268,6 +269,7 @@ func Test_Reconcile(t *testing.T) {
 			"PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API":         "false",
 			"ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT":             "false",
 			"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY":            "true",
+			"PILOT_ENABLE_CA_CRL":                              "false",
 			"PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS": "false",
 		}
 		if gieEnabled {

--- a/pkg/operator/controller/gatewayclass/istio_olm.go
+++ b/pkg/operator/controller/gatewayclass/istio_olm.go
@@ -152,6 +152,12 @@ func gatewayAPIPilotEnv(enableInferenceExtension bool) map[string]string {
 		// Only create CA Bundle CM in namespaces where there are
 		// Gateway API Gateways
 		"PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY": "true",
+		// Disable CRL configmap creation. CRL is for revoking
+		// intermediate CA certificates in service mesh deployments
+		// with plugged-in enterprise CAs. We use a self-signed CA
+		// for internal control plane traffic and don't support
+		// custom CAs, so CRL serves no purpose.
+		"PILOT_ENABLE_CA_CRL": "false",
 		// Don't copy labels or annotations from gateways to resources
 		// that Istiod creates for that gateway.  This is an Istio-
 		// specific behavior which might not be supported by other


### PR DESCRIPTION
## Summary

Disables CRL (Certificate Revocation List) configmap creation by setting `PILOT_ENABLE_CA_CRL=false` in istiod's pilot env vars.

Istio 1.30 introduced CRL support ([istio/istio#56308](https://github.com/istio/istio/pull/56308)) with `PILOT_ENABLE_CA_CRL=true` by default, which creates an `istio-ca-crl` configmap. CRL is for revoking intermediate CA certificates used in istiod-to-proxy mTLS — internal control plane traffic, not north-south ingress Gateway API traffic. We don't support custom CAs for our Istio control plane, and CRL requires a user to manually mount a revocation list into istiod, which isn't something that happens automatically.

This is safe to merge ahead of the Istio 1.30 bump — unrecognized env vars are silently ignored by older Istio versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)