### PR TITLE
NE-2833: Replace deprecated io/ioutil usage

### DIFF
--- a/cmd/ingress-operator/render.go
+++ b/cmd/ingress-operator/render.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -50,7 +49,7 @@ func render(dir string, prefix string) error {
 
 	for _, file := range files {
 		outputFile := filepath.Join(dir, prefix+filepath.Base(file))
-		if err := ioutil.WriteFile(outputFile, manifests.MustAsset(file), 0640); err != nil {
+		if err := os.WriteFile(outputFile, manifests.MustAsset(file), 0640); err != nil {
 			return fmt.Errorf("failed to write %q: %v", outputFile, err)
 		}
 		fmt.Printf("wrote %s\n", outputFile)

--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -223,7 +222,7 @@ func start(opts *StartOptions) error {
 			return fmt.Errorf("failed to add file %q to watcher: %v", opts.ShutdownFile, err)
 		}
 		log.Info("watching file", "filename", opts.ShutdownFile)
-		orig, err = ioutil.ReadFile(opts.ShutdownFile)
+		orig, err = os.ReadFile(opts.ShutdownFile)
 		if err != nil {
 			return fmt.Errorf("failed to read watcher file %q: %v", opts.ShutdownFile, err)
 		}
@@ -239,7 +238,7 @@ func start(opts *StartOptions) error {
 					cancel()
 					return
 				}
-				latest, err := ioutil.ReadFile(opts.ShutdownFile)
+				latest, err := os.ReadFile(opts.ShutdownFile)
 				if err != nil {
 					log.Error(err, "failed to read watched file", "filename", opts.ShutdownFile)
 					cancel()

--- a/pkg/operator/controller/canary/http.go
+++ b/pkg/operator/controller/canary/http.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -87,7 +87,7 @@ func probeRouteEndpoint(route *routev1.Route) error {
 	defer response.Body.Close()
 
 	// Read response body
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("error reading canary response body: %v", err)
 	}


### PR DESCRIPTION
Replace all occurrences of the deprecated `io/ioutil` package with modern equivalents: `os.WriteFile`, `os.ReadFile`, and `io.ReadAll`.