### PR TITLE
OCPBUGS-100186: Rename network policy in TestContainerLoggingMinLength

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -2646,7 +2646,7 @@ func TestContainerLoggingMinLength(t *testing.T) {
 	}
 	t.Cleanup(func() { deleteWithRetryOnError(t, context.Background(), clientPod, DefaultRetryTimeout) })
 
-	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "syslog-netpol", Namespace: clientPod.Namespace})
+	networkPolicy := buildTestPodNetworkPolicy(types.NamespacedName{Name: "minlength-netpol", Namespace: clientPod.Namespace})
 	if err := kclient.Create(context.TODO(), networkPolicy); err != nil {
 		t.Fatalf("failed to create network policy %s: %v", networkPolicy.Name, err)
 	}


### PR DESCRIPTION
The tests TestContainerLoggingMinLength and TestSyslogLogging are creating network policy resource with the same name. Whenever these tests run at the same time, one of them fails with "NetworkPolicy already exists" error.

Changing the name of the resource in TestContainerLoggingMinLength allows them to run at the same time without issues.

https://redhat.atlassian.net/browse/OCPBUGS-100186