### PR TITLE
NE-2834: Replace deprecated math/rand.Read in e2e test

### DIFF
--- a/test/e2e/http_header_buffer_test.go
+++ b/test/e2e/http_header_buffer_test.go
@@ -6,8 +6,8 @@ package e2e
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"strings"
 	"testing"
 	"time"


### PR DESCRIPTION
Replace the `math/rand` import with `crypto/rand` in the `randomString` helper.  `math/rand.Read` was deprecated in Go 1.20 in favor of `crypto/rand.Read`, which is functionally equivalent here.