### PR TITLE
OCPBUGS-101783: reconcile canary certificate on dependency creation

### DIFF
--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -85,7 +85,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		defaultIC := &operatorv1.IngressController{}
 		if err := reconciler.client.Get(context.Background(), defaultICName, defaultIC); err != nil {
 			if !errors.IsNotFound(err) {
-				log.Error(err, "Failed to get default IngressController")
+				log.Error(err, "Failed to get default IngressController", "namespace", defaultICName.Namespace, "name", defaultICName.Name)
 			}
 			return false
 		}
@@ -98,7 +98,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	// reconcile target: the canary certificate's secret.
 	enqueueRequestForCanaryCertificate := handler.EnqueueRequestsFromMapFunc(toCanaryCertificate)
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &corev1.Secret{}, enqueueRequestForCanaryCertificate, predicate.Or(isCanaryCert, isDefaultIngressCert))); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to watch Secrets: %w", err)
 	}
 
 	// The certificate Secret can be observed before the default IngressController
@@ -109,7 +109,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		return isDefaultIngressControllerDependency(o, config.OperatorNamespace)
 	})
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorv1.IngressController{}, enqueueRequestForCanaryCertificate, predicate.And(isDefaultIngressController, predicate.GenerationChangedPredicate{}))); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to watch IngressControllers: %w", err)
 	}
 
 	// The canary DaemonSet supplies the certificate's controller owner reference.
@@ -117,7 +117,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	// controller-runtime's rate-limited error retry.
 	isCanaryDaemonSet := predicate.NewPredicateFuncs(isCanaryDaemonSetDependency)
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &appsv1.DaemonSet{}, enqueueRequestForCanaryCertificate, predicate.And(isCanaryDaemonSet, predicate.GenerationChangedPredicate{}))); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to watch DaemonSets: %w", err)
 	}
 	return c, nil
 }

--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -54,8 +54,9 @@ type reconciler struct {
 // New creates the canary certificate controller
 //
 // The canary certificate controller mirrors the default ingress controller's
-// certificate into the canary's namespace. It watches the canary's certificate
-// and the default ingress controller's certificate.
+// certificate into the canary's namespace. It watches the canary's certificate,
+// the default ingress controller's certificate, and the other resources that
+// reconciliation depends on.
 func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	operatorCache := mgr.GetCache()
 	reconciler := &reconciler{
@@ -68,9 +69,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		return nil, err
 	}
 	// Watch for updates on the canary's certificate.
-	isCanaryCert := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetName() == operatorcontroller.CanaryCertificateName().Name && o.GetNamespace() == operatorcontroller.CanaryCertificateName().Namespace
-	})
+	isCanaryCert := predicate.NewPredicateFuncs(isCanaryCertificate)
 	// Also watch for updates on the default ingress controller's certificate.
 	// Because the default ingress controller's certificate name can be set at
 	// runtime, a Get() needs to be done to determine the correct certificate.
@@ -85,7 +84,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		}
 		defaultIC := &operatorv1.IngressController{}
 		if err := reconciler.client.Get(context.Background(), defaultICName, defaultIC); err != nil {
-			log.Error(err, "Failed to get default IngressController")
+			if !errors.IsNotFound(err) {
+				log.Error(err, "Failed to get default IngressController")
+			}
 			return false
 		}
 
@@ -95,13 +96,55 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	})
 	// Regardless of which certificate changed, this controller only has one
 	// reconcile target: the canary certificate's secret.
-	enqueueRequestForCanaryCertificate := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		return []reconcile.Request{{NamespacedName: operatorcontroller.CanaryCertificateName()}}
-	})
+	enqueueRequestForCanaryCertificate := handler.EnqueueRequestsFromMapFunc(toCanaryCertificate)
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &corev1.Secret{}, enqueueRequestForCanaryCertificate, predicate.Or(isCanaryCert, isDefaultIngressCert))); err != nil {
 		return nil, err
 	}
+
+	// The certificate Secret can be observed before the default IngressController
+	// exists. Watch the IngressController so that dependency creation order cannot
+	// permanently discard that Secret event. Generation filtering avoids
+	// reconciling on status-only updates.
+	isDefaultIngressController := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return isDefaultIngressControllerDependency(o, config.OperatorNamespace)
+	})
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorv1.IngressController{}, enqueueRequestForCanaryCertificate, predicate.And(isDefaultIngressController, predicate.GenerationChangedPredicate{}))); err != nil {
+		return nil, err
+	}
+
+	// The canary DaemonSet supplies the certificate's controller owner reference.
+	// Its creation or replacement must also retry reconciliation independently of
+	// controller-runtime's rate-limited error retry.
+	isCanaryDaemonSet := predicate.NewPredicateFuncs(isCanaryDaemonSetDependency)
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &appsv1.DaemonSet{}, enqueueRequestForCanaryCertificate, predicate.And(isCanaryDaemonSet, predicate.GenerationChangedPredicate{}))); err != nil {
+		return nil, err
+	}
 	return c, nil
+}
+
+// toCanaryCertificate maps any relevant dependency event to the controller's
+// single reconciliation target.
+func toCanaryCertificate(_ context.Context, _ client.Object) []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: operatorcontroller.CanaryCertificateName()}}
+}
+
+func isCanaryCertificate(o client.Object) bool {
+	return hasNamespacedName(o, operatorcontroller.CanaryCertificateName())
+}
+
+func isDefaultIngressControllerDependency(o client.Object, operatorNamespace string) bool {
+	return hasNamespacedName(o, types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      manifests.DefaultIngressControllerName,
+	})
+}
+
+func isCanaryDaemonSetDependency(o client.Object) bool {
+	return hasNamespacedName(o, operatorcontroller.CanaryDaemonSetName())
+}
+
+func hasNamespacedName(o client.Object, name types.NamespacedName) bool {
+	return o.GetNamespace() == name.Namespace && o.GetName() == name.Name
 }
 
 // Reconcile ensures the canary's certificate mirrors the default ingress

--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -84,7 +84,9 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		}
 		defaultIC := &operatorv1.IngressController{}
 		if err := reconciler.client.Get(context.Background(), defaultICName, defaultIC); err != nil {
-			log.Error(err, "Failed to get default IngressController")
+			if !errors.IsNotFound(err) {
+				log.Error(err, "Failed to get default IngressController", "namespace", defaultICName.Namespace, "name", defaultICName.Name)
+			}
 			return false
 		}
 

--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -129,22 +129,18 @@ func toCanaryCertificate(_ context.Context, _ client.Object) []reconcile.Request
 }
 
 func isCanaryCertificate(o client.Object) bool {
-	return hasNamespacedName(o, operatorcontroller.CanaryCertificateName())
+	return operatorcontroller.HasNamespacedName(o, operatorcontroller.CanaryCertificateName())
 }
 
 func isDefaultIngressControllerDependency(o client.Object, operatorNamespace string) bool {
-	return hasNamespacedName(o, types.NamespacedName{
+	return operatorcontroller.HasNamespacedName(o, types.NamespacedName{
 		Namespace: operatorNamespace,
 		Name:      manifests.DefaultIngressControllerName,
 	})
 }
 
 func isCanaryDaemonSetDependency(o client.Object) bool {
-	return hasNamespacedName(o, operatorcontroller.CanaryDaemonSetName())
-}
-
-func hasNamespacedName(o client.Object, name types.NamespacedName) bool {
-	return o.GetNamespace() == name.Namespace && o.GetName() == name.Name
+	return operatorcontroller.HasNamespacedName(o, operatorcontroller.CanaryDaemonSetName())
 }
 
 // Reconcile ensures the canary's certificate mirrors the default ingress

--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -54,8 +54,9 @@ type reconciler struct {
 // New creates the canary certificate controller
 //
 // The canary certificate controller mirrors the default ingress controller's
-// certificate into the canary's namespace. It watches the canary's certificate
-// and the default ingress controller's certificate.
+// certificate into the canary's namespace. It watches the canary's certificate,
+// the default ingress controller's certificate, and the other resources that
+// reconciliation depends on.
 func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	operatorCache := mgr.GetCache()
 	reconciler := &reconciler{
@@ -95,13 +96,53 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 	})
 	// Regardless of which certificate changed, this controller only has one
 	// reconcile target: the canary certificate's secret.
-	enqueueRequestForCanaryCertificate := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		return []reconcile.Request{{NamespacedName: operatorcontroller.CanaryCertificateName()}}
-	})
+	enqueueRequestForCanaryCertificate := handler.EnqueueRequestsFromMapFunc(toCanaryCertificate)
 	if err := c.Watch(source.Kind[client.Object](operatorCache, &corev1.Secret{}, enqueueRequestForCanaryCertificate, predicate.Or(isCanaryCert, isDefaultIngressCert))); err != nil {
 		return nil, err
 	}
+
+	// The certificate Secret can be observed before the default IngressController
+	// exists. Watch the IngressController so that dependency creation order cannot
+	// permanently discard that Secret event. Generation filtering avoids
+	// reconciling on status-only updates.
+	isDefaultIngressController := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return isDefaultIngressControllerDependency(o, config.OperatorNamespace)
+	})
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &operatorv1.IngressController{}, enqueueRequestForCanaryCertificate, predicate.And(isDefaultIngressController, predicate.GenerationChangedPredicate{}))); err != nil {
+		return nil, err
+	}
+
+	// The canary DaemonSet supplies the certificate's controller owner reference.
+	// Its creation or replacement must also retry reconciliation independently of
+	// controller-runtime's rate-limited error retry.
+	isCanaryDaemonSet := predicate.NewPredicateFuncs(isCanaryDaemonSetDependency)
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &appsv1.DaemonSet{}, enqueueRequestForCanaryCertificate, predicate.And(isCanaryDaemonSet, predicate.GenerationChangedPredicate{}))); err != nil {
+		return nil, err
+	}
 	return c, nil
+}
+
+// toCanaryCertificate maps any relevant dependency event to the controller's
+// single reconciliation target.
+func toCanaryCertificate(_ context.Context, _ client.Object) []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: operatorcontroller.CanaryCertificateName()}}
+}
+
+// hasNamespacedName returns true if the given object has the given namespace
+// and name.
+func hasNamespacedName(o client.Object, name types.NamespacedName) bool {
+	return o.GetNamespace() == name.Namespace && o.GetName() == name.Name
+}
+
+func isDefaultIngressControllerDependency(o client.Object, operatorNamespace string) bool {
+	return hasNamespacedName(o, types.NamespacedName{
+		Namespace: operatorNamespace,
+		Name:      manifests.DefaultIngressControllerName,
+	})
+}
+
+func isCanaryDaemonSetDependency(o client.Object) bool {
+	return hasNamespacedName(o, operatorcontroller.CanaryDaemonSetName())
 }
 
 // Reconcile ensures the canary's certificate mirrors the default ingress

--- a/pkg/operator/controller/canary-certificate/controller.go
+++ b/pkg/operator/controller/canary-certificate/controller.go
@@ -69,9 +69,7 @@ func New(mgr manager.Manager, config Config) (controller.Controller, error) {
 		return nil, err
 	}
 	// Watch for updates on the canary's certificate.
-	isCanaryCert := predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return o.GetName() == operatorcontroller.CanaryCertificateName().Name && o.GetNamespace() == operatorcontroller.CanaryCertificateName().Namespace
-	})
+	isCanaryCert := predicate.NewPredicateFuncs(isCanaryCertificate)
 	// Also watch for updates on the default ingress controller's certificate.
 	// Because the default ingress controller's certificate name can be set at
 	// runtime, a Get() needs to be done to determine the correct certificate.
@@ -132,6 +130,10 @@ func toCanaryCertificate(_ context.Context, _ client.Object) []reconcile.Request
 // and name.
 func hasNamespacedName(o client.Object, name types.NamespacedName) bool {
 	return o.GetNamespace() == name.Namespace && o.GetName() == name.Name
+}
+
+func isCanaryCertificate(o client.Object) bool {
+	return hasNamespacedName(o, operatorcontroller.CanaryCertificateName())
 }
 
 func isDefaultIngressControllerDependency(o client.Object, operatorNamespace string) bool {

--- a/pkg/operator/controller/canary-certificate/controller_test.go
+++ b/pkg/operator/controller/canary-certificate/controller_test.go
@@ -1,11 +1,100 @@
 package canarycertificate
 
 import (
+	"context"
 	"testing"
 
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestCanaryCertificateDependencyEvents(t *testing.T) {
+	config := Config{
+		OperatorNamespace: "openshift-ingress-operator",
+		OperandNamespace:  "openshift-ingress",
+	}
+	defaultIngressControllerName := types.NamespacedName{
+		Namespace: config.OperatorNamespace,
+		Name:      manifests.DefaultIngressControllerName,
+	}
+
+	testCases := []struct {
+		description string
+		object      client.Object
+		expected    types.NamespacedName
+		matches     func(client.Object) bool
+	}{
+		{
+			description: "default ingress controller",
+			object: &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{
+				Namespace: defaultIngressControllerName.Namespace,
+				Name:      defaultIngressControllerName.Name,
+			}},
+			expected: defaultIngressControllerName,
+			matches: func(object client.Object) bool {
+				return isDefaultIngressControllerDependency(object, config.OperatorNamespace)
+			},
+		},
+		{
+			description: "canary daemonset",
+			object: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+				Namespace: operatorcontroller.CanaryDaemonSetName().Namespace,
+				Name:      operatorcontroller.CanaryDaemonSetName().Name,
+			}},
+			expected: operatorcontroller.CanaryDaemonSetName(),
+			matches:  isCanaryDaemonSetDependency,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if !hasNamespacedName(tc.object, tc.expected) {
+				t.Fatalf("expected %s/%s to match", tc.expected.Namespace, tc.expected.Name)
+			}
+			if !tc.matches(tc.object) {
+				t.Fatalf("expected dependency predicate to match %s/%s", tc.expected.Namespace, tc.expected.Name)
+			}
+
+			requests := toCanaryCertificate(context.Background(), tc.object)
+			if len(requests) != 1 || requests[0].NamespacedName != operatorcontroller.CanaryCertificateName() {
+				t.Fatalf("expected one request for %v, got %#v", operatorcontroller.CanaryCertificateName(), requests)
+			}
+		})
+	}
+}
+
+func TestCanaryCertificateDependencyPredicatesRejectUnrelatedObjects(t *testing.T) {
+	operatorNamespace := "openshift-ingress-operator"
+	testCases := []struct {
+		object  client.Object
+		matches func(client.Object) bool
+	}{
+		{
+			object:  &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: operatorcontroller.CanaryDaemonSetName().Namespace, Name: "unrelated"}},
+			matches: isCanaryDaemonSetDependency,
+		},
+		{
+			object: &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Namespace: operatorNamespace, Name: "unrelated"}},
+			matches: func(object client.Object) bool {
+				return isDefaultIngressControllerDependency(object, operatorNamespace)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		if tc.matches(tc.object) {
+			t.Fatalf("unexpected dependency match for %s/%s", tc.object.GetNamespace(), tc.object.GetName())
+		}
+	}
+}
 
 func Test_canaryCertificateChanged(t *testing.T) {
 	trueVar := true

--- a/pkg/operator/controller/canary-certificate/controller_test.go
+++ b/pkg/operator/controller/canary-certificate/controller_test.go
@@ -53,6 +53,15 @@ func TestCanaryCertificateDependencyEvents(t *testing.T) {
 			expected: operatorcontroller.CanaryDaemonSetName(),
 			matches:  isCanaryDaemonSetDependency,
 		},
+		{
+			description: "canary certificate",
+			object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Namespace: operatorcontroller.CanaryCertificateName().Namespace,
+				Name:      operatorcontroller.CanaryCertificateName().Name,
+			}},
+			expected: operatorcontroller.CanaryCertificateName(),
+			matches:  isCanaryCertificate,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -81,6 +90,10 @@ func TestCanaryCertificateDependencyPredicatesRejectUnrelatedObjects(t *testing.
 		{
 			object:  &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: operatorcontroller.CanaryDaemonSetName().Namespace, Name: "unrelated"}},
 			matches: isCanaryDaemonSetDependency,
+		},
+		{
+			object:  &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "unrelated", Name: operatorcontroller.CanaryCertificateName().Name}},
+			matches: isCanaryCertificate,
 		},
 		{
 			object: &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Namespace: operatorNamespace, Name: "unrelated"}},

--- a/pkg/operator/controller/canary-certificate/controller_test.go
+++ b/pkg/operator/controller/canary-certificate/controller_test.go
@@ -66,7 +66,7 @@ func TestCanaryCertificateDependencyEvents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			if !hasNamespacedName(tc.object, tc.expected) {
+			if !operatorcontroller.HasNamespacedName(tc.object, tc.expected) {
 				t.Fatalf("expected %s/%s to match", tc.expected.Namespace, tc.expected.Name)
 			}
 			if !tc.matches(tc.object) {

--- a/pkg/operator/controller/canary-certificate/controller_test.go
+++ b/pkg/operator/controller/canary-certificate/controller_test.go
@@ -1,11 +1,113 @@
 package canarycertificate
 
 import (
+	"context"
 	"testing"
 
+	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestCanaryCertificateDependencyEvents(t *testing.T) {
+	config := Config{
+		OperatorNamespace: "openshift-ingress-operator",
+		OperandNamespace:  "openshift-ingress",
+	}
+	defaultIngressControllerName := types.NamespacedName{
+		Namespace: config.OperatorNamespace,
+		Name:      manifests.DefaultIngressControllerName,
+	}
+
+	testCases := []struct {
+		description string
+		object      client.Object
+		expected    types.NamespacedName
+		matches     func(client.Object) bool
+	}{
+		{
+			description: "default ingress controller",
+			object: &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{
+				Namespace: defaultIngressControllerName.Namespace,
+				Name:      defaultIngressControllerName.Name,
+			}},
+			expected: defaultIngressControllerName,
+			matches: func(object client.Object) bool {
+				return isDefaultIngressControllerDependency(object, config.OperatorNamespace)
+			},
+		},
+		{
+			description: "canary daemonset",
+			object: &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+				Namespace: operatorcontroller.CanaryDaemonSetName().Namespace,
+				Name:      operatorcontroller.CanaryDaemonSetName().Name,
+			}},
+			expected: operatorcontroller.CanaryDaemonSetName(),
+			matches:  isCanaryDaemonSetDependency,
+		},
+		{
+			description: "canary certificate",
+			object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Namespace: operatorcontroller.CanaryCertificateName().Namespace,
+				Name:      operatorcontroller.CanaryCertificateName().Name,
+			}},
+			expected: operatorcontroller.CanaryCertificateName(),
+			matches:  isCanaryCertificate,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if !hasNamespacedName(tc.object, tc.expected) {
+				t.Fatalf("expected %s/%s to match", tc.expected.Namespace, tc.expected.Name)
+			}
+			if !tc.matches(tc.object) {
+				t.Fatalf("expected dependency predicate to match %s/%s", tc.expected.Namespace, tc.expected.Name)
+			}
+
+			requests := toCanaryCertificate(context.Background(), tc.object)
+			if len(requests) != 1 || requests[0].NamespacedName != operatorcontroller.CanaryCertificateName() {
+				t.Fatalf("expected one request for %v, got %#v", operatorcontroller.CanaryCertificateName(), requests)
+			}
+		})
+	}
+}
+
+func TestHasNamespacedNameRejectsUnrelatedDependencies(t *testing.T) {
+	operatorNamespace := "openshift-ingress-operator"
+	testCases := []struct {
+		object  client.Object
+		matches func(client.Object) bool
+	}{
+		{
+			object:  &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: operatorcontroller.CanaryDaemonSetName().Namespace, Name: "unrelated"}},
+			matches: isCanaryDaemonSetDependency,
+		},
+		{
+			object:  &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "unrelated", Name: operatorcontroller.CanaryCertificateName().Name}},
+			matches: isCanaryCertificate,
+		},
+		{
+			object: &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Namespace: operatorNamespace, Name: "unrelated"}},
+			matches: func(object client.Object) bool {
+				return isDefaultIngressControllerDependency(object, operatorNamespace)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		if tc.matches(tc.object) {
+			t.Fatalf("unexpected dependency match for %s/%s", tc.object.GetNamespace(), tc.object.GetName())
+		}
+	}
+}
 
 func Test_canaryCertificateChanged(t *testing.T) {
 	trueVar := true

--- a/pkg/operator/controller/names.go
+++ b/pkg/operator/controller/names.go
@@ -11,6 +11,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -384,4 +386,8 @@ func IstiodNetworkPolicyName() types.NamespacedName {
 		Name:      "istiod-allow",
 		Namespace: "openshift-ingress",
 	}
+}
+
+func HasNamespacedName(o client.Object, name types.NamespacedName) bool {
+	return o.GetNamespace() == name.Namespace && o.GetName() == name.Name
 }


### PR DESCRIPTION
The canary-certificate controller can permanently miss reconciliation when its dependencies are created in an unlucky order. It watches only Secrets, and its default-certificate predicate rejects the Secret event when the default IngressController does not exist yet. If the IngressController appears afterward, no watched event retries the controller.

A failed 5.0 HyperShift AKS job captured the exact race: the default certificate existed, its initial event was rejected at 02:25:32.434Z, and the default IngressController appeared about two seconds later. `canary-serving-cert` was never created; every canary pod remained Pending on the missing Secret, the Service had no endpoints, the admitted route returned EOF, and ingress degraded. A same-payload control with safe object ordering created the certificate successfully. This was the job's sole terminal cause, for a conservative historical impact of one green Prow job.

This change:
- watches the default IngressController and the canary DaemonSet, the two non-Secret reconciliation dependencies;
- maps their semantic create/update/delete events to the single canary-certificate request;
- filters status-only updates with the generation predicate;
- treats an expected not-yet-created IngressController in the Secret predicate as dependency-not-ready rather than a noisy error;
- adds focused predicate and event-mapping coverage, including unrelated-resource rejection.

Validation:
- `GOTOOLCHAIN=auto GOMAXPROCS=2 go test -mod=vendor -p=2 ./pkg/operator/controller/canary-certificate`
- `git diff --check`

Representative job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aks/2082648859074367488