### PR TITLE
OCPBUGS-100435: Set Accepted=False and Prometheus alert for ListenerSets on managed Gateways

### DIFF
--- a/cmd/ingress-operator/start.go
+++ b/cmd/ingress-operator/start.go
@@ -17,6 +17,7 @@ import (
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	canarycontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/canary"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	routemetricscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/route-metrics"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 
@@ -255,6 +256,10 @@ func start(opts *StartOptions) error {
 	log.Info("registering Prometheus metrics for status_controller")
 	if err := statuscontroller.RegisterMetrics(); err != nil {
 		log.Error(err, "unable to register metrics for status_controller")
+	}
+	log.Info("registering Prometheus metrics for listenerset_status_controller")
+	if err := listenersetstatuscontroller.RegisterMetrics(); err != nil {
+		log.Error(err, "unable to register metrics for listenerset_status_controller")
 	}
 
 	// Set up and start the file watcher.

--- a/manifests/00-cluster-role.yaml
+++ b/manifests/00-cluster-role.yaml
@@ -180,6 +180,8 @@ rules:
   - grpcroutes
   - referencegrants
   - backendtlspolicies
+  - listenersets
+  - listenersets/status
   verbs:
   - '*'
 

--- a/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
+++ b/manifests/0000_90_ingress-operator_03_prometheusrules.yaml
@@ -88,6 +88,15 @@ spec:
             AWS NLB that may have hairpin connection failures. Connections from pods to routes
             served by router pods on the same node may time out. Set the NLB protocol field to
             PROXY to fix, or TCP to keep current behavior. See the alert description for commands.
+      - alert: ListenerSetOnManagedGateway
+        expr: ingress_operator_listenerset_on_managed_gateway == 1
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: ListenerSet targeting an OpenShift-managed Gateway detected
+          description: "This alert fires when a ListenerSet resource targets an OpenShift-managed Gateway. ListenerSets are not supported by the OpenShift Gateway API implementation. Remove the ListenerSet or retarget it to a non-OpenShift-managed Gateway."
+          message: "ListenerSet {{ $labels.listenerset_namespace }}/{{ $labels.listenerset_name }} is targeting an OpenShift-managed Gateway and will not be reconciled. On a future upgrade, this ListenerSet may become active and could cause unexpected traffic routing."
       # Recording rules related to route metrics for sending via telemetry
       - expr: min(route_metrics_controller_routes_per_shard)
         record: cluster:route_metrics_controller_routes_per_shard:min

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -161,6 +161,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
+	if established, err := r.allManagedCRDsEstablished(ctx); err != nil {
+		return reconcile.Result{}, err
+	} else if !established {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	if err := r.ensureDependentControllers(ctx); err != nil {
 		log.Error(err, "failed to ensure dependent controllers, will retry")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -224,4 +230,30 @@ func (r *reconciler) ensureDependentControllers(ctx context.Context) error {
 
 	r.controllersStarted = true
 	return nil
+}
+
+// allManagedCRDsEstablished checks that all managed Gateway API CRDs
+// are established and served by the API server before dependent
+// controllers attempt to create field indexes on those types.
+func (r *reconciler) allManagedCRDsEstablished(ctx context.Context) (bool, error) {
+	for _, managed := range managedCRDs {
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err := r.client.Get(ctx, types.NamespacedName{Name: managed.Name}, &crd); err != nil {
+			return false, fmt.Errorf("failed to get CRD %s: %w", managed.Name, err)
+		}
+		if !isCRDEstablished(&crd) {
+			log.Info("CRD not yet established, will retry", "name", managed.Name)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func isCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, c := range crd.Status.Conditions {
+		if c.Type == apiextensionsv1.Established {
+			return c.Status == apiextensionsv1.ConditionTrue
+		}
+	}
+	return false
 }

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -8,6 +8,7 @@ import (
 
 	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 
 	"k8s.io/client-go/tools/record"
 
@@ -193,6 +194,25 @@ func (r *reconciler) ensureDependentControllers(ctx context.Context) error {
 		})); err != nil {
 		return fmt.Errorf("failed to add field indexer: %w", err)
 	}
+	// Index ListenerSets by parent Gateway after CRDs are installed.
+	if err := r.fieldIndexer.IndexField(
+		context.Background(),
+		&gatewayapiv1.ListenerSet{},
+		listenersetstatuscontroller.ListenerSetParentGatewayIndex,
+		client.IndexerFunc(func(o client.Object) []string {
+			ls, ok := o.(*gatewayapiv1.ListenerSet)
+			if !ok {
+				return []string{}
+			}
+			parentNS := ls.GetNamespace()
+			if ls.Spec.ParentRef.Namespace != nil {
+				parentNS = string(*ls.Spec.ParentRef.Namespace)
+			}
+			return []string{parentNS + "/" + string(ls.Spec.ParentRef.Name)}
+		})); err != nil {
+		return fmt.Errorf("failed to add ListenerSet field indexer: %w", err)
+	}
+
 	for i := range r.config.DependentControllers {
 		c := &r.config.DependentControllers[i]
 		go func() {

--- a/pkg/operator/controller/gatewayapi/controller.go
+++ b/pkg/operator/controller/gatewayapi/controller.go
@@ -15,6 +15,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -239,6 +240,10 @@ func (r *reconciler) allManagedCRDsEstablished(ctx context.Context) (bool, error
 	for _, managed := range managedCRDs {
 		var crd apiextensionsv1.CustomResourceDefinition
 		if err := r.client.Get(ctx, types.NamespacedName{Name: managed.Name}, &crd); err != nil {
+			if errors.IsNotFound(err) {
+				log.Info("CRD not yet created, will retry", "name", managed.Name)
+				return false, nil
+			}
 			return false, fmt.Errorf("failed to get CRD %s: %w", managed.Name, err)
 		}
 		if !isCRDEstablished(&crd) {

--- a/pkg/operator/controller/gatewayapi/controller_test.go
+++ b/pkg/operator/controller/gatewayapi/controller_test.go
@@ -70,6 +70,7 @@ func Test_Reconcile(t *testing.T) {
 		// whose status is expected to be updated by the test.
 		expectStatusUpdate []client.Object
 		expectStartCtrl    bool
+		expectRequeue      bool
 	}{
 		{
 			name:               "gateway API enabled",
@@ -91,6 +92,29 @@ func Test_Reconcile(t *testing.T) {
 				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
 			},
 			expectUpdate:    []client.Object{},
+			expectDelete:    []client.Object{},
+			expectStartCtrl: false,
+			expectRequeue:   true,
+		},
+		{
+			name:               "gateway API enabled with established CRDs",
+			marketplaceEnabled: true,
+			olmEnabled:         true,
+			existingObjects:    append(establishedManagedCRDs(), co("ingress")),
+			expectCreate: []client.Object{
+				clusterRole("system:openshift:gateway-api:aggregate-to-admin"),
+				clusterRole("system:openshift:gateway-api:aggregate-to-view"),
+			},
+			expectUpdate: []client.Object{
+				crd("gatewayclasses.gateway.networking.k8s.io"),
+				crd("gateways.gateway.networking.k8s.io"),
+				crd("grpcroutes.gateway.networking.k8s.io"),
+				crd("httproutes.gateway.networking.k8s.io"),
+				crd("referencegrants.gateway.networking.k8s.io"),
+				crd("backendtlspolicies.gateway.networking.k8s.io"),
+				crd("listenersets.gateway.networking.k8s.io"),
+				crd("tlsroutes.gateway.networking.k8s.io"),
+			},
 			expectDelete:    []client.Object{},
 			expectStartCtrl: true,
 		},
@@ -146,7 +170,8 @@ func Test_Reconcile(t *testing.T) {
 			expectStatusUpdate: []client.Object{
 				coWithExtension("ingress", `{"unmanagedGatewayAPICRDNames":"another.test.gateway.networking.k8s.io,invalid.test.gateway.networking.k8s.io"}`),
 			},
-			expectStartCtrl: true,
+			expectStartCtrl: false,
+			expectRequeue:   true,
 		},
 		{
 			name:               "unmanaged gateway API CRDs removed",
@@ -175,7 +200,8 @@ func Test_Reconcile(t *testing.T) {
 			expectStatusUpdate: []client.Object{
 				coWithExtension("ingress", `{}`),
 			},
-			expectStartCtrl: true,
+			expectStartCtrl: false,
+			expectRequeue:   true,
 		},
 		{
 			name:               "third party CRDs",
@@ -205,7 +231,8 @@ func Test_Reconcile(t *testing.T) {
 			expectDelete: []client.Object{},
 			// Third party CRDs have no impact on cluster operator status.
 			expectStatusUpdate: []client.Object{},
-			expectStartCtrl:    true,
+			expectStartCtrl:    false,
+			expectRequeue:      true,
 		},
 	}
 
@@ -258,7 +285,11 @@ func Test_Reconcile(t *testing.T) {
 			}
 			res, err := reconciler.Reconcile(context.Background(), req)
 			assert.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
+			if tc.expectRequeue {
+				assert.Equal(t, reconcile.Result{RequeueAfter: 10 * time.Second}, res, "expected requeue after 10s")
+			} else {
+				assert.Equal(t, reconcile.Result{}, res)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			select {
@@ -272,7 +303,7 @@ func Test_Reconcile(t *testing.T) {
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Labels", "Annotations", "ResourceVersion"),
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
-				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec"),
+				cmpopts.IgnoreFields(apiextensionsv1.CustomResourceDefinition{}, "Spec", "Status"),
 				cmpopts.IgnoreFields(rbacv1.ClusterRole{}, "Rules", "AggregationRule"),
 			}
 			if diff := cmp.Diff(tc.expectCreate, cl.Added, cmpOpts...); diff != "" {
@@ -298,10 +329,11 @@ func TestReconcileOnlyStartsControllerOnce(t *testing.T) {
 	rbacv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithRuntimeObjects(
+		WithRuntimeObjects(append(establishedManagedCRDs(),
 			&configv1.ClusterOperator{
 				ObjectMeta: metav1.ObjectMeta{Name: "ingress"},
-			}).
+			},
+		)...).
 		WithIndex(&apiextensionsv1.CustomResourceDefinition{}, "gatewayAPICRD", client.IndexerFunc(func(o client.Object) []string {
 			// Assume that there are no unmanaged CRDs.
 			return []string{}
@@ -362,4 +394,19 @@ type FakeIndexer struct{}
 
 func (indexer FakeIndexer) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	return nil
+}
+
+func establishedManagedCRDs() []runtime.Object {
+	var objs []runtime.Object
+	for _, managed := range managedCRDs {
+		objs = append(objs, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: managed.Name},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+					{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+				},
+			},
+		})
+	}
+	return objs
 }

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	ctrlruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -55,7 +56,7 @@ var (
 )
 
 func RegisterMetrics() error {
-	if err := prometheus.Register(listenerSetOnManagedGatewayMetric); err != nil {
+	if err := ctrlruntimemetrics.Registry.Register(listenerSetOnManagedGatewayMetric); err != nil {
 		return fmt.Errorf("failed to register ListenerSet metric: %w", err)
 	}
 	return nil

--- a/pkg/operator/controller/listenerset-status/controller.go
+++ b/pkg/operator/controller/listenerset-status/controller.go
@@ -1,0 +1,253 @@
+// The listenerset-status controller watches for ListenerSet resources
+// targeting OpenShift-managed Gateways and sets Accepted=False on them.
+// Current Istio (1.30.1) does not correctly implement hostname conflict resolution for
+// ListenerSets, so CIO disables ListenerSet reconciliation via
+// PILOT_IGNORE_RESOURCES. This controller ensures users are informed
+// that their ListenerSets will not be reconciled. It also exposes a
+// per-ListenerSet Prometheus gauge to enable alerting when ListenerSets
+// exist on managed Gateways.
+package listenerset_status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	logf "github.com/openshift/cluster-ingress-operator/pkg/log"
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	controllerName = "listenerset_status_controller"
+
+	// ReasonUnsupportedByController is the reason set on the Accepted
+	// condition when a ListenerSet targets an OpenShift-managed Gateway.
+	ReasonUnsupportedByController = "UnsupportedByController"
+
+	// ListenerSetParentGatewayIndex is the field index key for looking up
+	// ListenerSets by their parent Gateway name (namespace/name).
+	ListenerSetParentGatewayIndex = "spec.parentRef.gateway"
+)
+
+var (
+	log = logf.Logger.WithName(controllerName)
+
+	listenerSetOnManagedGatewayMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ingress_operator_listenerset_on_managed_gateway",
+		Help: "Set to 1 when a ListenerSet targets an OpenShift-managed Gateway. ListenerSets are not yet supported and may cause unexpected traffic behavior on upgrade.",
+	}, []string{"listenerset_namespace", "listenerset_name"})
+)
+
+func RegisterMetrics() error {
+	if err := prometheus.Register(listenerSetOnManagedGatewayMetric); err != nil {
+		return fmt.Errorf("failed to register ListenerSet metric: %w", err)
+	}
+	return nil
+}
+
+func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
+	operatorCache := mgr.GetCache()
+	r := &reconciler{
+		client: mgr.GetClient(),
+		cache:  operatorCache,
+	}
+	c, err := controller.NewUnmanaged(controllerName, controller.Options{Reconciler: r})
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch ListenerSets directly — each ListenerSet reconciles itself.
+	// Only reconcile on create, delete, or parentRef changes.
+	listenerSetPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldLS, okOld := e.ObjectOld.(*gatewayapiv1.ListenerSet)
+			newLS, okNew := e.ObjectNew.(*gatewayapiv1.ListenerSet)
+			if !okOld || !okNew {
+				return false
+			}
+			return string(oldLS.Spec.ParentRef.Name) != string(newLS.Spec.ParentRef.Name) ||
+				parentRefNamespace(oldLS) != parentRefNamespace(newLS)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.ListenerSet{}, &handler.EnqueueRequestForObject{}, listenerSetPredicate)); err != nil {
+		return nil, fmt.Errorf("failed to watch ListenerSets: %w", err)
+	}
+
+	// Watch Gateways — when a Gateway's class changes or it is deleted,
+	// enqueue the ListenerSets that target it via the index.
+	gatewayHasOurController := operatorcontroller.GatewayHasOurController(log, operatorCache, false)
+	gatewayToListenerSets := func(ctx context.Context, o client.Object) []reconcile.Request {
+		key := o.GetNamespace() + "/" + o.GetName()
+		var listenerSets gatewayapiv1.ListenerSetList
+		if err := operatorCache.List(ctx, &listenerSets, client.MatchingFields{ListenerSetParentGatewayIndex: key}); err != nil {
+			log.Error(err, "failed to list ListenerSets for Gateway", "gateway", key)
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, ls := range listenerSets.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name},
+			})
+		}
+		return requests
+	}
+	gatewayPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return gatewayHasOurController(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldGW, okOld := e.ObjectOld.(*gatewayapiv1.Gateway)
+			newGW, okNew := e.ObjectNew.(*gatewayapiv1.Gateway)
+			if !okOld || !okNew {
+				return false
+			}
+			if oldGW.Spec.GatewayClassName == newGW.Spec.GatewayClassName {
+				return false
+			}
+			return gatewayHasOurController(e.ObjectOld) || gatewayHasOurController(e.ObjectNew)
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return gatewayHasOurController(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToListenerSets), gatewayPredicate)); err != nil {
+		return nil, fmt.Errorf("failed to watch Gateways: %w", err)
+	}
+
+	// Watch GatewayClasses — when our GatewayClass is created or deleted,
+	// enqueue all ListenerSets so they can re-evaluate.
+	isOurGatewayClass := func(o client.Object) bool {
+		gc, ok := o.(*gatewayapiv1.GatewayClass)
+		if !ok {
+			return false
+		}
+		return gc.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
+	}
+	reconcileAllListenerSets := func(ctx context.Context, _ client.Object) []reconcile.Request {
+		var listenerSets gatewayapiv1.ListenerSetList
+		if err := operatorCache.List(ctx, &listenerSets); err != nil {
+			log.Error(err, "failed to list ListenerSets for GatewayClass change")
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, ls := range listenerSets.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name},
+			})
+		}
+		return requests
+	}
+	gatewayClassPredicate := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isOurGatewayClass(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isOurGatewayClass(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+	if err := c.Watch(source.Kind[client.Object](operatorCache, &gatewayapiv1.GatewayClass{}, handler.EnqueueRequestsFromMapFunc(reconcileAllListenerSets), gatewayClassPredicate)); err != nil {
+		return nil, fmt.Errorf("failed to watch GatewayClasses: %w", err)
+	}
+
+	return c, nil
+}
+
+type reconciler struct {
+	client client.Client
+	cache  cache.Cache
+}
+
+// Reconcile handles a single ListenerSet. It checks whether the
+// ListenerSet targets an OpenShift-managed Gateway and sets
+// Accepted=False if so.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log.Info("reconciling", "listenerset", request.NamespacedName)
+
+	ls := &gatewayapiv1.ListenerSet{}
+	if err := r.cache.Get(ctx, request.NamespacedName, ls); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// ListenerSet was deleted — clean up metric.
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get ListenerSet %s: %w", request.NamespacedName, err)
+	}
+
+	parentNS := ls.Namespace
+	if ls.Spec.ParentRef.Namespace != nil {
+		parentNS = string(*ls.Spec.ParentRef.Namespace)
+	}
+	parentName := types.NamespacedName{Namespace: parentNS, Name: string(ls.Spec.ParentRef.Name)}
+
+	gw := &gatewayapiv1.Gateway{}
+	if err := r.cache.Get(ctx, parentName, gw); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get Gateway %s: %w", parentName, err)
+	}
+
+	gcName := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
+	gc := &gatewayapiv1.GatewayClass{}
+	if err := r.cache.Get(ctx, gcName, gc); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get GatewayClass %s: %w", gcName, err)
+	}
+
+	if gc.Spec.ControllerName != operatorcontroller.OpenShiftGatewayClassControllerName {
+		listenerSetOnManagedGatewayMetric.DeleteLabelValues(request.Namespace, request.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// ListenerSet targets an OpenShift-managed Gateway.
+	listenerSetOnManagedGatewayMetric.WithLabelValues(request.Namespace, request.Name).Set(1)
+
+	if err := r.setListenerSetNotAccepted(ctx, ls); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) setListenerSetNotAccepted(ctx context.Context, ls *gatewayapiv1.ListenerSet) error {
+	updated := ls.DeepCopy()
+	changed := meta.SetStatusCondition(&updated.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayapiv1.ListenerSetConditionAccepted),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: ls.Generation,
+		Reason:             ReasonUnsupportedByController,
+		Message:            "ListenerSets are not yet supported by the OpenShift Gateway API implementation. This ListenerSet will not be reconciled. On a future upgrade, this ListenerSet may become active and could cause unexpected traffic routing.",
+	})
+	if !changed {
+		return nil
+	}
+	if err := r.client.Status().Patch(ctx, updated, client.MergeFrom(ls)); err != nil {
+		return fmt.Errorf("failed to patch ListenerSet %s/%s status: %w", ls.Namespace, ls.Name, err)
+	}
+	log.Info("set ListenerSet Accepted=False", "listenerset", ls.Name, "namespace", ls.Namespace)
+	return nil
+}
+
+func parentRefNamespace(ls *gatewayapiv1.ListenerSet) string {
+	if ls.Spec.ParentRef.Namespace != nil {
+		return string(*ls.Spec.ParentRef.Namespace)
+	}
+	return ls.Namespace
+}

--- a/pkg/operator/controller/listenerset-status/controller_test.go
+++ b/pkg/operator/controller/listenerset-status/controller_test.go
@@ -1,0 +1,231 @@
+package listenerset_status
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	ctrltestutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	gc := &gatewayapiv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-default",
+		},
+		Spec: gatewayapiv1.GatewayClassSpec{
+			ControllerName: operatorcontroller.OpenShiftGatewayClassControllerName,
+		},
+	}
+	unmanagedGC := &gatewayapiv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-class",
+		},
+		Spec: gatewayapiv1.GatewayClassSpec{
+			ControllerName: "example.com/other-controller",
+		},
+	}
+	gw := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "openshift-ingress",
+		},
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: "openshift-default",
+			Listeners: []gatewayapiv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayapiv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+	ls := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ls",
+			Namespace: "openshift-ingress",
+		},
+		Spec: gatewayapiv1.ListenerSetSpec{
+			ParentRef: gatewayapiv1.ParentGatewayReference{
+				Name: "test-gw",
+			},
+			Listeners: []gatewayapiv1.ListenerEntry{
+				{
+					Name:     "extra",
+					Port:     8443,
+					Protocol: gatewayapiv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: ls.Namespace,
+			Name:      ls.Name,
+		},
+	}
+
+	tests := []struct {
+		name            string
+		objects         []runtime.Object
+		expectedMetric  string
+		expectedCount   int
+		expectCondition bool
+		// removeObject, if set, is called after the first reconcile
+		// to delete an object before a second reconcile that should
+		// clean up the metric.
+		removeObject func(t *testing.T, r *reconciler)
+	}{
+		{
+			name:    "metric and condition set when ListenerSet targets managed Gateway",
+			objects: []runtime.Object{gc, gw, ls},
+			expectedMetric: `
+# HELP ingress_operator_listenerset_on_managed_gateway Set to 1 when a ListenerSet targets an OpenShift-managed Gateway. ListenerSets are not yet supported and may cause unexpected traffic behavior on upgrade.
+# TYPE ingress_operator_listenerset_on_managed_gateway gauge
+ingress_operator_listenerset_on_managed_gateway{listenerset_name="test-ls",listenerset_namespace="openshift-ingress"} 1
+`,
+			expectedCount:   1,
+			expectCondition: true,
+		},
+		{
+			name:          "metric cleared when ListenerSet not found",
+			objects:       []runtime.Object{gc, gw},
+			expectedCount: 0,
+		},
+		{
+			name:          "metric cleared when Gateway not found",
+			objects:       []runtime.Object{gc, ls},
+			expectedCount: 0,
+		},
+		{
+			name:          "metric cleared when GatewayClass not found",
+			objects:       []runtime.Object{gw, ls},
+			expectedCount: 0,
+		},
+		{
+			name:          "metric cleared when GatewayClass has different controller",
+			objects:       []runtime.Object{unmanagedGC, gwWithClass("other-class"), ls},
+			expectedCount: 0,
+		},
+		{
+			name:          "metric cleaned up after ListenerSet deletion",
+			objects:       []runtime.Object{gc, gw, ls},
+			expectedCount: 0,
+			removeObject: func(t *testing.T, r *reconciler) {
+				if err := r.client.Delete(context.Background(), ls.DeepCopy()); err != nil {
+					t.Fatalf("failed to delete ListenerSet: %v", err)
+				}
+			},
+		},
+		{
+			name:          "metric cleaned up after Gateway deletion",
+			objects:       []runtime.Object{gc, gw, ls},
+			expectedCount: 0,
+			removeObject: func(t *testing.T, r *reconciler) {
+				if err := r.client.Delete(context.Background(), gw.DeepCopy()); err != nil {
+					t.Fatalf("failed to delete Gateway: %v", err)
+				}
+			},
+		},
+		{
+			name:          "metric cleaned up after GatewayClass deletion",
+			objects:       []runtime.Object{gc, gw, ls},
+			expectedCount: 0,
+			removeObject: func(t *testing.T, r *reconciler) {
+				if err := r.client.Delete(context.Background(), gc.DeepCopy()); err != nil {
+					t.Fatalf("failed to delete GatewayClass: %v", err)
+				}
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := gatewayapiv1.Install(scheme); err != nil {
+		t.Fatalf("failed to install gateway API scheme: %v", err)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			listenerSetOnManagedGatewayMetric.Reset()
+
+			clientObjects := make([]runtime.Object, len(tc.objects))
+			copy(clientObjects, tc.objects)
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(clientObjects...).
+				WithStatusSubresource(&gatewayapiv1.ListenerSet{}).
+				Build()
+			informer := informertest.FakeInformers{Scheme: scheme}
+			fakeCache := ctrltestutil.FakeCache{Informers: &informer, Reader: cl}
+
+			r := &reconciler{
+				client: cl,
+				cache:  fakeCache,
+			}
+
+			_, err := r.Reconcile(context.Background(), request)
+			assert.NoError(t, err)
+
+			if tc.removeObject != nil {
+				assert.Equal(t, 1, promtestutil.CollectAndCount(listenerSetOnManagedGatewayMetric), "metric should be set before deletion")
+				tc.removeObject(t, r)
+				_, err = r.Reconcile(context.Background(), request)
+				assert.NoError(t, err)
+			}
+
+			count := promtestutil.CollectAndCount(listenerSetOnManagedGatewayMetric)
+			assert.Equal(t, tc.expectedCount, count, "unexpected metric count")
+
+			if tc.expectedMetric != "" {
+				err := promtestutil.CollectAndCompare(listenerSetOnManagedGatewayMetric, strings.NewReader(tc.expectedMetric))
+				assert.NoError(t, err, "metric mismatch")
+			}
+
+			if tc.expectCondition {
+				updatedLS := &gatewayapiv1.ListenerSet{}
+				err := cl.Get(context.Background(), request.NamespacedName, updatedLS)
+				assert.NoError(t, err)
+				cond := apimeta.FindStatusCondition(updatedLS.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+				if assert.NotNil(t, cond, "Accepted condition should be set") {
+					assert.Equal(t, metav1.ConditionFalse, cond.Status)
+					assert.Equal(t, ReasonUnsupportedByController, cond.Reason)
+				}
+			}
+		})
+	}
+}
+
+func gwWithClass(className string) *gatewayapiv1.Gateway {
+	return &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "openshift-ingress",
+		},
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: gatewayapiv1.ObjectName(className),
+			Listeners: []gatewayapiv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayapiv1.HTTPProtocolType,
+				},
+			},
+		},
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -44,6 +44,7 @@ import (
 	ingress "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 	ingresscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingress"
 	ingressclasscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/ingressclass"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	statuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/status"
 	"github.com/openshift/library-go/pkg/operator/events"
 
@@ -376,6 +377,11 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 		return nil, fmt.Errorf("failed to create gateway-networkpolicy controller: %w", err)
 	}
 
+	listenerSetStatusController, err := listenersetstatuscontroller.NewUnmanaged(mgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listenerset-status controller: %w", err)
+	}
+
 	// Set up the gatewayapi controller.
 	if _, err := gatewayapicontroller.New(mgr, gatewayapicontroller.Config{
 		MarketplaceEnabled:              marketplaceEnabled,
@@ -387,6 +393,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 			gatewayLabelController,
 			gatewayStatusController,
 			gatewayNetworkPolicyController,
+			listenerSetStatusController,
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayapi controller: %w", err)

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -15,10 +15,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	iov1 "github.com/openshift/api/operatoringress/v1"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
 	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	util "github.com/openshift/cluster-ingress-operator/pkg/util"
+	"github.com/openshift/library-go/test/library/metrics"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	condutils "k8s.io/apimachinery/pkg/api/meta"
@@ -31,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 
@@ -1712,51 +1717,180 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 }
 
 // testListenerSetNotAccepted verifies that a ListenerSet targeting an
-// OpenShift-managed Gateway gets Accepted=False.
+// OpenShift-managed Gateway gets Accepted=False and that the Prometheus
+// metric is set and cleaned up on both ListenerSet deletion and Gateway
+// deletion.
 func testListenerSetNotAccepted(t *testing.T) {
-	lsName := names.SimpleNameGenerator.GenerateName("test-listenerset-")
-	ls := &gatewayapiv1.ListenerSet{
+	gwName := names.SimpleNameGenerator.GenerateName("test-ls-gw-")
+	gw := &gatewayapiv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      lsName,
+			Name:      gwName,
 			Namespace: operatorcontroller.DefaultOperandNamespace,
 		},
-		Spec: gatewayapiv1.ListenerSetSpec{
-			ParentRef: gatewayapiv1.ParentGatewayReference{
-				Name: gatewayapiv1.ObjectName(testGatewayName),
-			},
-			Listeners: []gatewayapiv1.ListenerEntry{
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: operatorcontroller.OpenShiftDefaultGatewayClassName,
+			Listeners: []gatewayapiv1.Listener{
 				{
-					Name:     "test-listener",
-					Port:     8443,
-					Protocol: gatewayapiv1.HTTPSProtocolType,
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayapiv1.HTTPProtocolType,
 				},
 			},
 		},
 	}
-
-	t.Logf("creating ListenerSet %s/%s targeting gateway %s", ls.Namespace, ls.Name, testGatewayName)
-	if err := kclient.Create(t.Context(), ls); err != nil {
-		t.Fatalf("failed to create ListenerSet: %v", err)
+	t.Logf("creating Gateway %s/%s", gw.Namespace, gw.Name)
+	if err := kclient.Create(t.Context(), gw); err != nil {
+		t.Fatalf("failed to create Gateway: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := kclient.Delete(context.Background(), ls); err != nil {
+		if err := kclient.Delete(context.Background(), gw); err != nil {
 			if !errors.IsNotFound(err) {
-				t.Logf("failed to delete ListenerSet: %v", err)
+				t.Logf("failed to delete Gateway: %v", err)
 			}
 		}
 	})
 
-	t.Log("verifying ListenerSet gets Accepted=False")
-	nsName := types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}
+	createListenerSet := func(name string) *gatewayapiv1.ListenerSet {
+		ls := &gatewayapiv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: operatorcontroller.DefaultOperandNamespace,
+			},
+			Spec: gatewayapiv1.ListenerSetSpec{
+				ParentRef: gatewayapiv1.ParentGatewayReference{
+					Name: gatewayapiv1.ObjectName(gwName),
+				},
+				Listeners: []gatewayapiv1.ListenerEntry{
+					{
+						Name:     "test-listener",
+						Port:     8443,
+						Protocol: gatewayapiv1.HTTPSProtocolType,
+					},
+				},
+			},
+		}
+		t.Logf("creating ListenerSet %s/%s targeting gateway %s", ls.Namespace, ls.Name, gwName)
+		if err := kclient.Create(t.Context(), ls); err != nil {
+			t.Fatalf("failed to create ListenerSet: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := kclient.Delete(context.Background(), ls); err != nil {
+				if !errors.IsNotFound(err) {
+					t.Logf("failed to delete ListenerSet: %v", err)
+				}
+			}
+		})
+		return ls
+	}
+
+	ls1Name := names.SimpleNameGenerator.GenerateName("test-listenerset-")
+	ls2Name := names.SimpleNameGenerator.GenerateName("test-listenerset-")
+	ls1 := createListenerSet(ls1Name)
+	ls2 := createListenerSet(ls2Name)
+
+	for _, ls := range []*gatewayapiv1.ListenerSet{ls1, ls2} {
+		t.Logf("verifying ListenerSet %s gets Accepted=False", ls.Name)
+		nsName := types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}
+		lsCopy := ls
+		assert.Eventually(t, func() bool {
+			if err := kclient.Get(t.Context(), nsName, lsCopy); err != nil {
+				t.Logf("failed to get ListenerSet: %v", err)
+				return false
+			}
+			cond := condutils.FindStatusCondition(lsCopy.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+			if cond == nil {
+				return false
+			}
+			return cond.Status == metav1.ConditionFalse && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
+		}, 2*time.Minute, 2*time.Second, "ListenerSet %s did not get Accepted=False", ls.Name)
+	}
+
+	prometheusClient := createPrometheusClient(t)
+	metricQuery1 := fmt.Sprintf(`ingress_operator_listenerset_on_managed_gateway{listenerset_name="%s",listenerset_namespace="%s"}`, ls1Name, operatorcontroller.DefaultOperandNamespace)
+	metricQuery2 := fmt.Sprintf(`ingress_operator_listenerset_on_managed_gateway{listenerset_name="%s",listenerset_namespace="%s"}`, ls2Name, operatorcontroller.DefaultOperandNamespace)
+
+	t.Log("verifying Prometheus metrics are set for both ListenerSets")
+	assertMetricValue(t, prometheusClient, metricQuery1, 1, "Prometheus metric was not set for ListenerSet 1")
+	assertMetricValue(t, prometheusClient, metricQuery2, 1, "Prometheus metric was not set for ListenerSet 2")
+
+	// Delete ListenerSet 1 directly and verify its metric is cleaned up.
+	t.Logf("deleting ListenerSet %s and verifying metric cleanup", ls1Name)
+	if err := kclient.Delete(t.Context(), ls1); err != nil {
+		if !errors.IsNotFound(err) {
+			t.Fatalf("failed to delete ListenerSet: %v", err)
+		}
+	}
+	assertMetricGone(t, prometheusClient, metricQuery1, "Prometheus metric was not cleaned up after ListenerSet deletion")
+
+	// Delete the Gateway and verify ListenerSet 2's metric is also cleaned up.
+	t.Logf("deleting Gateway %s and verifying ListenerSet %s metric cleanup", gwName, ls2Name)
+	if err := kclient.Delete(t.Context(), gw); err != nil {
+		if !errors.IsNotFound(err) {
+			t.Fatalf("failed to delete Gateway: %v", err)
+		}
+	}
+	assertMetricGone(t, prometheusClient, metricQuery2, "Prometheus metric was not cleaned up after Gateway deletion")
+}
+
+func createPrometheusClient(t *testing.T) prometheusv1.API {
+	t.Helper()
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		t.Fatalf("failed to get kube config: %v", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to create kube client: %v", err)
+	}
+	routeClient, err := routev1client.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to create route client: %v", err)
+	}
+	prometheusClient, err := metrics.NewPrometheusClient(t.Context(), kubeClient, routeClient)
+	if err != nil {
+		t.Fatalf("failed to create Prometheus client: %v", err)
+	}
+	return prometheusClient
+}
+
+func assertMetricValue(t *testing.T, client prometheusv1.API, query string, expected float64, msg string) {
+	t.Helper()
 	assert.Eventually(t, func() bool {
-		if err := kclient.Get(t.Context(), nsName, ls); err != nil {
-			t.Logf("failed to get ListenerSet: %v", err)
+		result, _, err := client.Query(t.Context(), query, time.Now())
+		if err != nil {
+			t.Logf("failed to query Prometheus: %v", err)
 			return false
 		}
-		cond := condutils.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
-		if cond == nil {
+		vector, ok := result.(model.Vector)
+		if !ok {
+			t.Logf("unexpected result type: %T", result)
 			return false
 		}
-		return cond.Status == metav1.ConditionFalse && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
-	}, 2*time.Minute, 2*time.Second, "ListenerSet did not get Accepted=False")
+		if len(vector) == 0 {
+			t.Logf("metric not yet available (empty vector)")
+			return false
+		}
+		t.Logf("metric found: labels=%v value=%v", vector[0].Metric, vector[0].Value)
+		return float64(vector[0].Value) == expected
+	}, 2*time.Minute, 5*time.Second, msg)
+}
+
+func assertMetricGone(t *testing.T, client prometheusv1.API, query string, msg string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		result, _, err := client.Query(t.Context(), query, time.Now())
+		if err != nil {
+			t.Logf("failed to query Prometheus: %v", err)
+			return false
+		}
+		vector, ok := result.(model.Vector)
+		if !ok {
+			return false
+		}
+		if len(vector) > 0 {
+			t.Logf("metric still present: labels=%v value=%v", vector[0].Metric, vector[0].Value)
+			return false
+		}
+		return true
+	}, 2*time.Minute, 5*time.Second, msg)
 }

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -17,6 +17,7 @@ import (
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	operatorclient "github.com/openshift/cluster-ingress-operator/pkg/operator/client"
 	operatorcontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	listenersetstatuscontroller "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/listenerset-status"
 	util "github.com/openshift/cluster-ingress-operator/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,6 +137,7 @@ func TestGatewayAPI(t *testing.T) {
 	t.Run("testGatewayAPIListenerSetIgnored", testGatewayAPIListenerSetIgnored)
 	t.Run("testOperatorDegradedCondition", testOperatorDegradedCondition)
 	t.Run("testGatewayOpenshiftConditions", testGatewayOpenshiftConditions)
+	t.Run("testListenerSetNotAccepted", testListenerSetNotAccepted)
 	if gatewayAPIWithoutOLMEnabled {
 		t.Run("testGatewayAPIIstioUninstallSailLibrary", testGatewayAPIIstioUninstallSailLibrary)
 	}
@@ -1707,4 +1709,54 @@ func ensureGatewayObjectSuccess(t *testing.T, ns *corev1.Namespace) []string {
 	}
 
 	return errs
+}
+
+// testListenerSetNotAccepted verifies that a ListenerSet targeting an
+// OpenShift-managed Gateway gets Accepted=False.
+func testListenerSetNotAccepted(t *testing.T) {
+	lsName := names.SimpleNameGenerator.GenerateName("test-listenerset-")
+	ls := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lsName,
+			Namespace: operatorcontroller.DefaultOperandNamespace,
+		},
+		Spec: gatewayapiv1.ListenerSetSpec{
+			ParentRef: gatewayapiv1.ParentGatewayReference{
+				Name: gatewayapiv1.ObjectName(testGatewayName),
+			},
+			Listeners: []gatewayapiv1.ListenerEntry{
+				{
+					Name:     "test-listener",
+					Port:     8443,
+					Protocol: gatewayapiv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	t.Logf("creating ListenerSet %s/%s targeting gateway %s", ls.Namespace, ls.Name, testGatewayName)
+	if err := kclient.Create(t.Context(), ls); err != nil {
+		t.Fatalf("failed to create ListenerSet: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := kclient.Delete(context.Background(), ls); err != nil {
+			if !errors.IsNotFound(err) {
+				t.Logf("failed to delete ListenerSet: %v", err)
+			}
+		}
+	})
+
+	t.Log("verifying ListenerSet gets Accepted=False")
+	nsName := types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}
+	assert.Eventually(t, func() bool {
+		if err := kclient.Get(t.Context(), nsName, ls); err != nil {
+			t.Logf("failed to get ListenerSet: %v", err)
+			return false
+		}
+		cond := condutils.FindStatusCondition(ls.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+		if cond == nil {
+			return false
+		}
+		return cond.Status == metav1.ConditionFalse && cond.Reason == listenersetstatuscontroller.ReasonUnsupportedByController
+	}, 2*time.Minute, 2*time.Second, "ListenerSet did not get Accepted=False")
 }


### PR DESCRIPTION
## Summary

Re-introduces #1513 (reverted in #1537) with fixes for the CRD establishment race that broke HyperShift conformance ([TRT-2874](https://redhat.atlassian.net/browse/TRT-2874)) and the Prometheus metric registry issue.

### Fixes over #1513

- **CRD establishment race**: `Reconcile` now verifies all managed Gateway API CRDs are established before calling `ensureDependentControllers`. Previously, if a CRD was not yet served by the API server when `IndexField` ran, it failed. On retry, indexes that succeeded on the first attempt could not be re-registered, causing a permanent `indexer conflict` error that blocked all Gateway API functionality.
- **Prometheus metric registry**: Changed `prometheus.Register()` to `ctrlruntimemetrics.Registry.Register()` so the metric is served on the controller-runtime metrics endpoint that Prometheus actually scrapes.

### New test coverage

- E2e: creates two ListenerSets, verifies Accepted=False and metrics, deletes one directly (metric cleanup), deletes Gateway (second metric cleanup)
- Unit: 8 table-driven cases covering metric set/cleanup for all reconcile paths including GatewayClass deletion, plus Accepted=False condition verification
- Unit: `Test_Reconcile` cases for CRD establishment (requeue when not established, start controllers when established)

## Test plan

- [ ] `testListenerSetNotAccepted` e2e passes (metric set and cleaned up)
- [ ] HyperShift conformance: `GatewayAPIController` tests pass (no indexer conflict)
- [ ] `ListenerSetOnManagedGateway` alert fires in console
- [ ] Unit tests pass: `go test ./pkg/operator/controller/listenerset-status/ ./pkg/operator/controller/gatewayapi/`

Bug: https://issues.redhat.com/browse/OCPBUGS-100435
Reverts revert: #1537
Original: #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)