### PR TITLE
OCPBUGS-104205: Increase DNS record readiness timeout to 5 minutes

### DIFF
--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -954,7 +954,7 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]b
 
 	var expectationsMet bool
 
-	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		haveExpectNotPresent := false
 		// expectationsMet starts true and gets set to false when some expectation is not met.
 		expectationsMet = true


### PR DESCRIPTION
## Summary

Increases the `assertExpectedDNSRecords` timeout from 2 minutes (`DefaultRetryTimeout`) to 5 minutes.

The `multipleGatewaysSameListenerHostname` e2e test flakes on Azure because two Gateways with the same listener hostname cause a `DomainAlreadyInUse` conflict. The DNS controller retries and resolves the conflict in ~2.5 minutes, but the 2-minute test timeout expires first.

Comparison of failing vs passing CI runs shows identical DNS controller behavior — both get `DomainAlreadyInUse`, both resolve after ~2.5 minutes. The only difference is whether the test timeout hits first.

## Test plan

- [ ] `testGatewayAPIDNS/multipleGatewaysSameListenerHostname` passes on Azure e2e

Bug: https://issues.redhat.com/browse/OCPBUGS-104205

🤖 Generated with [Claude Code](https://claude.com/claude-code)