### PR TITLE
OCPBUGS-86050: Update ROUTER_CURVES environment variable for go 1.26

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -93,6 +93,22 @@ var (
 		"TLS_AES_256_GCM_SHA384",
 	)
 
+	// fipsApprovedTLSGroups is the ordered list of TLS key exchange groups
+	// approved for use under FIPS 140-3 / NIST SP 800-56Ar3. It includes
+	// NIST P-curves (secp256r1, secp384r1, secp521r1) and their corresponding
+	// ML-KEM post-quantum hybrids (SecP256r1MLKEM768, SecP384r1MLKEM1024,
+	// approved as of Go 1.26). The order is deliberate: classical ECDH groups
+	// first for broad compatibility, then PQ hybrids.
+	// X25519-based groups (X25519, X25519MLKEM768) are excluded — see
+	// nonFIPSGroups.
+	fipsApprovedTLSGroups = []string{
+		string(configv1.TLSGroupSecP256r1),
+		string(configv1.TLSGroupSecP384r1),
+		string(configv1.TLSGroupSecP521r1),
+		string(configv1.TLSGroupSecP256r1MLKEM768),
+		string(configv1.TLSGroupSecP384r1MLKEM1024),
+	}
+
 	// nonFIPSGroups is the set of TLS groups that are NOT approved for use
 	// under FIPS 140-3 / NIST SP 800-56Ar3. X25519 and X25519MLKEM768 rely
 	// on Curve25519 arithmetic which is excluded from the FIPS-approved list

--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1111,22 +1111,21 @@ func desiredRouterDeployment(ci *operatorv1.IngressController, config *Config, i
 		}
 	}
 
-	// If FIPS is enabled on this cluster, we cannot use ML-KEM or X25519 in
-	// the TLS supportedGroups (aka curves). ML-KEM and X25519 are not
-	// supported by OpenSSL FIPS 140-3.
+	// If FIPS is enabled on this cluster, we cannot use X25519-based groups
+	// (X25519, X25519MLKEM768) in the TLS supportedGroups (aka curves).
+	// These groups rely on Curve25519 arithmetic which is excluded from the
+	// FIPS-approved list. Note: ML-KEM groups based on NIST P-curves
+	// (SecP256r1MLKEM768, SecP384r1MLKEM1024) are FIPS-approved as of Go 1.26.
+	// X25519-based groups are not supported by OpenSSL FIPS 140-3.
 	// See https://redhat.atlassian.net/browse/TRT-2597 and Appendix D of
 	// https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
-	// If filtering empties the list, fall back to the FIPS-compliant defaults
-	// (secp256r1:secp384r1:secp521r1) so the router always has at least one
-	// usable group.
+	// If filtering empties the list, fall back to the FIPS-approved groups
+	// (secp256r1:secp384r1:secp521r1:SecP256r1MLKEM768:SecP384r1MLKEM1024)
+	// so the router always has at least one usable group.
 	if isFIPSEnabled {
 		tlsGroupList = slices.DeleteFunc(tlsGroupList, nonFIPSGroups.Has)
 		if len(tlsGroupList) == 0 {
-			tlsGroupList = []string{
-				string(configv1.TLSGroupSecP256r1),
-				string(configv1.TLSGroupSecP384r1),
-				string(configv1.TLSGroupSecP521r1),
-			}
+			tlsGroupList = append(tlsGroupList, fipsApprovedTLSGroups...)
 		}
 	}
 	env = append(env, corev1.EnvVar{

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -3397,8 +3397,8 @@ func TestDesiredRouterDeploymentTLSGroups(t *testing.T) {
 				configv1.TLSGroupX25519,
 			},
 			expectedEnv: []envData{
-				// Entire list is non-FIPS; must fall back to secp256r1:secp384r1:secp521r1.
-				{"ROUTER_CURVES", true, "secp256r1:secp384r1:secp521r1"},
+				// Entire list is non-FIPS; must fall back to secp256r1:secp384r1:secp521r1:SecP256r1MLKEM768:SecP384r1MLKEM1024.
+				{"ROUTER_CURVES", true, "secp256r1:secp384r1:secp521r1:SecP256r1MLKEM768:SecP384r1MLKEM1024"},
 			},
 		},
 		// ── Feature-gate disabled (Groups field absent) ──────────────────────

--- a/pkg/operator/controller/tls.go
+++ b/pkg/operator/controller/tls.go
@@ -24,11 +24,13 @@ func copyTLSSpec(in *configv1.TLSProfileSpec) *configv1.TLSProfileSpec {
 // tlsGroupToCurveID maps a configv1.TLSGroup to a crypto/tls CurveID.
 // Groups not supported by the Go runtime are returned with ok=false.
 var tlsGroupToCurveID = map[configv1.TLSGroup]tls.CurveID{
-	configv1.TLSGroupX25519:         tls.X25519,
-	configv1.TLSGroupSecP256r1:      tls.CurveP256,
-	configv1.TLSGroupSecP384r1:      tls.CurveP384,
-	configv1.TLSGroupSecP521r1:      tls.CurveP521,
-	configv1.TLSGroupX25519MLKEM768: tls.X25519MLKEM768,
+	configv1.TLSGroupX25519:             tls.X25519,
+	configv1.TLSGroupSecP256r1:          tls.CurveP256,
+	configv1.TLSGroupSecP384r1:          tls.CurveP384,
+	configv1.TLSGroupSecP521r1:          tls.CurveP521,
+	configv1.TLSGroupX25519MLKEM768:     tls.X25519MLKEM768,
+	configv1.TLSGroupSecP256r1MLKEM768:  tls.SecP256r1MLKEM768,
+	configv1.TLSGroupSecP384r1MLKEM1024: tls.SecP384r1MLKEM1024,
 }
 
 // TLSGroupToCurveID converts a configv1.TLSGroup name to its crypto/tls

--- a/pkg/operator/controller/tls_test.go
+++ b/pkg/operator/controller/tls_test.go
@@ -43,8 +43,8 @@ func TestTLSGroupToCurveID(t *testing.T) {
 		{configv1.TLSGroupSecP384r1, tls.CurveP384, true},
 		{configv1.TLSGroupSecP521r1, tls.CurveP521, true},
 		{configv1.TLSGroupX25519MLKEM768, tls.X25519MLKEM768, true},
-		{configv1.TLSGroupSecP256r1MLKEM768, 0, false},
-		{configv1.TLSGroupSecP384r1MLKEM1024, 0, false},
+		{configv1.TLSGroupSecP256r1MLKEM768, tls.SecP256r1MLKEM768, true},
+		{configv1.TLSGroupSecP384r1MLKEM1024, tls.SecP384r1MLKEM1024, true},
 		{configv1.TLSGroup("unknown"), 0, false},
 	}
 
@@ -101,7 +101,7 @@ func TestTLSConfigFromProfile(t *testing.T) {
 	t.Run("unsupported groups are skipped", func(t *testing.T) {
 		spec := &configv1.TLSProfileSpec{
 			Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
-			Groups:        []configv1.TLSGroup{configv1.TLSGroupSecP256r1MLKEM768, configv1.TLSGroupSecP256r1},
+			Groups:        []configv1.TLSGroup{configv1.TLSGroup("unknown"), configv1.TLSGroupSecP256r1},
 			MinTLSVersion: configv1.VersionTLS12,
 		}
 		cfg, err := TLSConfigFromProfile(log, spec)


### PR DESCRIPTION
Add support for NIST P-curve ML-KEM post-quantum hybrid groups (SecP256r1MLKEM768, SecP384r1MLKEM1024) that became available in Go 1.26 via crypto/tls.

Key changes:

-  Register SecP256r1MLKEM768 and SecP384r1MLKEM1024 in the tlsGroupToCurveID map so TLSGroupToCurveID resolves them to the corresponding crypto/tls CurveID constants.

-  Add fipsApprovedTLSGroups and nonFIPSGroups package-level variables to centralize the FIPS filtering logic. On FIPS-enabled clusters, X25519-based groups (X25519, X25519MLKEM768) are stripped because Curve25519 is excluded from the FIPS 140-3 approved list (NIST SP 800-56Ar3, Appendix D). The P-curve ML-KEM hybrids are FIPS-approved and remain in the list.
 
-  Use an explicit []string with deliberate ordering for the FIPS fallback group list (classical ECDH first, then PQ hybrids) instead of sets.NewString().List(), which produced an accidental ordering based on ASCII sort of the group names.

-  Update the FIPS fallback to include the PQ hybrid groups so that FIPS clusters using default settings still get post-quantum key exchange protection.