### PR TITLE
OCPBUGS-104205, OCPBUGS-100424: Harden DNS duplicate-domain ownership checks

### DIFF
--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -428,7 +428,10 @@ func recordIsAlreadyPublishedToZone(record *iov1.DNSRecord, zoneToPublish *confi
 // and block publishing (same DNS name may only have one owner). Records that
 // are being deleted are ignored. When creation timestamps are equal, the
 // lexicographically earlier namespace wins, then name (Gateway API-style
-// tie-break).
+// tie-break). A subject with a zero CreationTimestamp always yields to any
+// non-deleted peer (it is still being created and must not win). An empty
+// index result is treated as an error so the caller requeues with an
+// InternalError condition rather than publishing under cache lag.
 func isOldestRecordForDomain(ctx context.Context, cache cache.Cache, record *iov1.DNSRecord) (bool, error) {
 	records := iov1.DNSRecordList{}
 	if err := cache.List(ctx, &records, client.MatchingFields{dnsRecordIndexFieldName: record.Spec.DNSName}); err != nil {
@@ -453,8 +456,13 @@ func isOldestRecordForDomain(ctx context.Context, cache cache.Cache, record *iov
 		if !existingRecord.DeletionTimestamp.IsZero() {
 			continue
 		}
-		// If this record is currently in the creation process, then any
-		// existing record must be older.
+		// Skip peers that are still being created; a zero timestamp would
+		// otherwise look older than any real CreationTimestamp.
+		if existingRecord.CreationTimestamp.IsZero() {
+			continue
+		}
+		// A record still being created (zero CreationTimestamp) always yields
+		// to any existing non-deleted peer, even a newer one.
 		if record.CreationTimestamp.IsZero() {
 			return false, nil
 		}
@@ -700,6 +708,11 @@ func (r *reconciler) mapOnRecordDelete(ctx context.Context, o client.Object) []r
 		}
 		// Exclude records that are marked for deletion.
 		if !existingRecord.DeletionTimestamp.IsZero() {
+			continue
+		}
+		// Skip survivors still being created; a zero timestamp would otherwise
+		// look older than any real CreationTimestamp via dnsRecordIsPreferred.
+		if existingRecord.CreationTimestamp.IsZero() {
 			continue
 		}
 		// Exclude unmanaged DNS records.

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -424,23 +424,33 @@ func recordIsAlreadyPublishedToZone(record *iov1.DNSRecord, zoneToPublish *confi
 }
 
 // isOldestRecordForDomain returns true if the provided DNSRecord is the oldest
-// record claiming its domain name.
+// record claiming its domain name. Unmanaged records are treated as claimants
+// and block publishing (same DNS name may only have one owner). Records that
+// are being deleted are ignored. When creation timestamps are equal, the
+// lexicographically earlier namespace wins, then name (Gateway API-style
+// tie-break).
 func isOldestRecordForDomain(ctx context.Context, cache cache.Cache, record *iov1.DNSRecord) (bool, error) {
 	records := iov1.DNSRecordList{}
 	if err := cache.List(ctx, &records, client.MatchingFields{dnsRecordIndexFieldName: record.Spec.DNSName}); err != nil {
 		return false, err
 	}
 
-	// If there are no other records claiming this domain name, this record must
-	// be the oldest record.
+	// The record being reconciled should appear in the index. An empty result
+	// indicates the index is not yet consistent; requeue rather than risk
+	// publishing a duplicate while another record for the same name is racing.
 	if len(records.Items) == 0 {
-		return true, nil
+		return false, fmt.Errorf("DNS name %q not found in DNSRecord index", record.Spec.DNSName)
 	}
 
-	// Look for any older DNS records.
-	for _, existingRecord := range records.Items {
+	// Look for any older (or tie-break preferred) DNS records.
+	for i := range records.Items {
+		existingRecord := &records.Items[i]
 		// This record is, by definition, not older than itself.
 		if record.UID == existingRecord.UID {
+			continue
+		}
+		// Ignore records that are already marked for deletion.
+		if !existingRecord.DeletionTimestamp.IsZero() {
 			continue
 		}
 		// If this record is currently in the creation process, then any
@@ -448,13 +458,27 @@ func isOldestRecordForDomain(ctx context.Context, cache cache.Cache, record *iov
 		if record.CreationTimestamp.IsZero() {
 			return false, nil
 		}
-		// After considering all special cases, compare the creation timestamps
-		// to determine which record is older.
-		if existingRecord.CreationTimestamp.Before(&record.CreationTimestamp) {
+		if dnsRecordIsPreferred(existingRecord, record) {
 			return false, nil
 		}
 	}
 	return true, nil
+}
+
+// dnsRecordIsPreferred reports whether a is preferred over b for ownership of
+// the same DNS name. Preference is older CreationTimestamp; when timestamps
+// are equal, the lexicographically earlier namespace wins, then name.
+func dnsRecordIsPreferred(a, b *iov1.DNSRecord) bool {
+	if a.CreationTimestamp.Before(&b.CreationTimestamp) {
+		return true
+	}
+	if b.CreationTimestamp.Before(&a.CreationTimestamp) {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	return a.Name < b.Name
 }
 
 func (r *reconciler) delete(record *iov1.DNSRecord) error {
@@ -665,8 +689,9 @@ func (r *reconciler) mapOnRecordDelete(ctx context.Context, o client.Object) []r
 		// Nothing to do.
 		return []reconcile.Request{}
 	}
-	oldestExistingRecord := iov1.DNSRecord{}
-	for _, existingRecord := range otherRecords.Items {
+	var oldestExistingRecord *iov1.DNSRecord
+	for i := range otherRecords.Items {
+		existingRecord := &otherRecords.Items[i]
 		// mapOnRecordDelete should be called after the deleted record is
 		// actually removed from the cache, but just in case, filter out the
 		// deleted record.
@@ -681,13 +706,13 @@ func (r *reconciler) mapOnRecordDelete(ctx context.Context, o client.Object) []r
 		if existingRecord.Spec.DNSManagementPolicy == iov1.UnmanagedDNS {
 			continue
 		}
-		if oldestExistingRecord.CreationTimestamp.IsZero() || existingRecord.CreationTimestamp.Before(&oldestExistingRecord.CreationTimestamp) {
+		if oldestExistingRecord == nil || dnsRecordIsPreferred(existingRecord, oldestExistingRecord) {
 			oldestExistingRecord = existingRecord
 		}
 	}
 	// If there is no existing record that can be published, don't return a
 	// request.
-	if oldestExistingRecord.Name == "" {
+	if oldestExistingRecord == nil {
 		return []reconcile.Request{}
 	}
 	return []reconcile.Request{

--- a/pkg/operator/controller/dns/controller_test.go
+++ b/pkg/operator/controller/dns/controller_test.go
@@ -12,6 +12,7 @@ import (
 	iov1 "github.com/openshift/api/operatoringress/v1"
 	"github.com/openshift/cluster-ingress-operator/pkg/dns"
 	testutil "github.com/openshift/cluster-ingress-operator/pkg/operator/controller/test/util"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1094,6 +1095,33 @@ func Test_isOldestRecordForDomain(t *testing.T) {
 			expectOldest: true,
 		},
 		{
+			name:   "zero creation timestamp yields to live peer",
+			record: dnsRecordWithZeroCreationTimestamp("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, later),
+				dnsRecordWithZeroCreationTimestamp("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS),
+			},
+			expectOldest: false,
+		},
+		{
+			name:   "zero creation timestamp wins when all peers are deleting",
+			record: dnsRecordWithZeroCreationTimestamp("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS),
+			existingObjects: []runtime.Object{
+				deletingDNSRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier, deleting),
+				dnsRecordWithZeroCreationTimestamp("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS),
+			},
+			expectOldest: true,
+		},
+		{
+			name:   "zero creation timestamp peer is ignored",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecordWithZeroCreationTimestamp("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: true,
+		},
+		{
 			name:   "older unmanaged record still blocks",
 			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
 			existingObjects: []runtime.Object{
@@ -1132,6 +1160,148 @@ func Test_isOldestRecordForDomain(t *testing.T) {
 	}
 }
 
+func Test_dnsRecordIsPreferred(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+
+	a := dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now)
+	older := dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier)
+	newer := dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now)
+	earlierNS := dnsRecord("foo.com", "ns-a", "zzz", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now)
+	laterNS := dnsRecord("foo.com", "ns-b", "aaa", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now)
+	earlierName := dnsRecord("foo.com", "ns-a", "aaa", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now)
+	laterName := dnsRecord("foo.com", "ns-a", "zzz", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now)
+
+	tests := []struct {
+		name     string
+		a, b     *iov1.DNSRecord
+		expected bool
+	}{
+		{
+			name:     "identical record is not preferred over itself",
+			a:        a,
+			b:        a,
+			expected: false,
+		},
+		{
+			name:     "older timestamp is preferred",
+			a:        older,
+			b:        newer,
+			expected: true,
+		},
+		{
+			name:     "newer timestamp is not preferred",
+			a:        newer,
+			b:        older,
+			expected: false,
+		},
+		{
+			name:     "earlier namespace wins on equal timestamps",
+			a:        earlierNS,
+			b:        laterNS,
+			expected: true,
+		},
+		{
+			name:     "earlier name wins on equal timestamps and namespace",
+			a:        earlierName,
+			b:        laterName,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, dnsRecordIsPreferred(test.a, test.b))
+		})
+	}
+}
+
+func Test_mapOnRecordDelete(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	deleting := metav1.NewTime(now.Add(-time.Second))
+
+	onlyDeleted := dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier)
+
+	tests := []struct {
+		name           string
+		deleted        *iov1.DNSRecord
+		existing       []runtime.Object
+		expectRequests []string // "namespace/name"
+	}{
+		{
+			name:           "empty index returns no requests",
+			deleted:        dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+			existing:       []runtime.Object{},
+			expectRequests: nil,
+		},
+		{
+			name:           "only deleted record in index returns no requests",
+			deleted:        onlyDeleted,
+			existing:       []runtime.Object{onlyDeleted},
+			expectRequests: nil,
+		},
+		{
+			name:    "requeues preferred equal-timestamp survivor when earlier-name peer is deleted",
+			deleted: dnsRecord("foo.com", "ns", "aaa", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			existing: []runtime.Object{
+				dnsRecord("foo.com", "ns", "zzz", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectRequests: []string{"ns/zzz"},
+		},
+		{
+			name:    "requeues lexicographically earlier survivor among equal-timestamp peers",
+			deleted: dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+			existing: []runtime.Object{
+				dnsRecord("foo.com", "ns", "zzz", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "ns", "aaa", iov1.ARecordType, "3.3.3.3", iov1.ManagedDNS, now),
+			},
+			expectRequests: []string{"ns/aaa"},
+		},
+		{
+			name:    "skips deleting survivors when choosing next owner",
+			deleted: dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+			existing: []runtime.Object{
+				deletingDNSRecord("foo.com", "ns", "aaa", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now, deleting),
+				dnsRecord("foo.com", "ns", "zzz", iov1.ARecordType, "3.3.3.3", iov1.ManagedDNS, now),
+			},
+			expectRequests: []string{"ns/zzz"},
+		},
+		{
+			name:    "skips unmanaged survivors when choosing next owner",
+			deleted: dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+			existing: []runtime.Object{
+				dnsRecord("foo.com", "ns", "aaa", iov1.ARecordType, "2.2.2.2", iov1.UnmanagedDNS, now),
+				dnsRecord("foo.com", "ns", "zzz", iov1.ARecordType, "3.3.3.3", iov1.ManagedDNS, now),
+			},
+			expectRequests: []string{"ns/zzz"},
+		},
+		{
+			name:    "skips zero creation timestamp survivors when choosing next owner",
+			deleted: dnsRecord("foo.com", "ns", "deleted", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+			existing: []runtime.Object{
+				dnsRecordWithZeroCreationTimestamp("foo.com", "ns", "aaa", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS),
+				dnsRecord("foo.com", "ns", "zzz", iov1.ARecordType, "3.3.3.3", iov1.ManagedDNS, now),
+			},
+			expectRequests: []string{"ns/zzz"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &reconciler{cache: buildFakeCache(t, test.existing)}
+			got := r.mapOnRecordDelete(context.TODO(), test.deleted)
+			var gotNames []string
+			for _, req := range got {
+				gotNames = append(gotNames, req.Namespace+"/"+req.Name)
+			}
+			if diff := cmp.Diff(test.expectRequests, gotNames); diff != "" {
+				t.Fatalf("unexpected requests (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func dnsRecord(dnsName, namespace, name string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy, created metav1.Time) *iov1.DNSRecord {
 	return &iov1.DNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1147,6 +1317,12 @@ func dnsRecord(dnsName, namespace, name string, recordType iov1.DNSRecordType, t
 			DNSManagementPolicy: managed,
 		},
 	}
+}
+
+func dnsRecordWithZeroCreationTimestamp(dnsName, namespace, name string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy) *iov1.DNSRecord {
+	record := dnsRecord(dnsName, namespace, name, recordType, target, managed, metav1.Time{})
+	record.CreationTimestamp = metav1.Time{}
+	return record
 }
 
 func deletingDNSRecord(dnsName, namespace, name string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy, created, deletion metav1.Time) *iov1.DNSRecord {

--- a/pkg/operator/controller/dns/controller_test.go
+++ b/pkg/operator/controller/dns/controller_test.go
@@ -2,8 +2,8 @@ package dns
 
 import (
 	"context"
-	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -110,6 +110,12 @@ func Test_publishRecordToZones(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			record := &iov1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-record",
+					Namespace:         "test-ns",
+					UID:               uuid.NewUUID(),
+					CreationTimestamp: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
+				},
 				Spec: iov1.DNSRecordSpec{
 					DNSName:             "subdomain.dnszone.io.",
 					RecordType:          iov1.ARecordType,
@@ -123,7 +129,7 @@ func Test_publishRecordToZones(t *testing.T) {
 			r := &reconciler{
 				// TODO To write a fake provider that can return errors and add more test cases.
 				dnsProvider: &dns.FakeProvider{},
-				cache:       buildFakeCache(t, nil),
+				cache:       buildFakeCache(t, []runtime.Object{record.DeepCopy()}),
 			}
 
 			_, actual := r.publishRecordToZones(context.TODO(), test.zones, record)
@@ -217,14 +223,21 @@ func Test_publishRecordToZonesMergesStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			record := &iov1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-record",
+					Namespace:         "test-ns",
+					UID:               uuid.NewUUID(),
+					CreationTimestamp: metav1.NewTime(time.Now().UTC().Truncate(time.Second)),
+				},
 				Spec: iov1.DNSRecordSpec{
+					DNSName:             "subdomain.dnszone.io.",
 					DNSManagementPolicy: iov1.ManagedDNS,
 				},
 				Status: iov1.DNSRecordStatus{Zones: tc.oldZoneStatuses},
 			}
 			r := &reconciler{
 				dnsProvider: &dns.FakeProvider{},
-				cache:       buildFakeCache(t, nil),
+				cache:       buildFakeCache(t, []runtime.Object{record.DeepCopy()}),
 			}
 			zone := []configv1.DNSZone{{ID: "zone2"}}
 			oldStatuses := record.Status.DeepCopy().Zones
@@ -852,6 +865,9 @@ func Test_customCABundle(t *testing.T) {
 }
 
 func TestConflictingDNSRecords(t *testing.T) {
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+
 	tests := []struct {
 		name            string
 		recordName      string
@@ -886,7 +902,7 @@ func TestConflictingDNSRecords(t *testing.T) {
 			recordName: "foo.com",
 			recordType: iov1.ARecordType,
 			existingObjects: []runtime.Object{
-				dnsRecord("foo.com", "foo", iov1.ARecordType, "111.22.33.44", iov1.ManagedDNS),
+				dnsRecord("foo.com", "foo", "record-foo.com", iov1.ARecordType, "111.22.33.44", iov1.ManagedDNS, earlier),
 			},
 			zones: []configv1.DNSZone{
 				{ID: "foobar"},
@@ -908,7 +924,7 @@ func TestConflictingDNSRecords(t *testing.T) {
 			recordName: "foo.com",
 			recordType: iov1.ARecordType,
 			existingObjects: []runtime.Object{
-				dnsRecord("bar.com", "foo", iov1.ARecordType, "111.22.33.44", iov1.ManagedDNS),
+				dnsRecord("bar.com", "foo", "record-bar.com", iov1.ARecordType, "111.22.33.44", iov1.ManagedDNS, earlier),
 			},
 			zones: []configv1.DNSZone{
 				{ID: "foobar"},
@@ -930,7 +946,7 @@ func TestConflictingDNSRecords(t *testing.T) {
 			recordName: "foo.com",
 			recordType: iov1.ARecordType,
 			existingObjects: []runtime.Object{
-				dnsRecord("foo.com", "foo", iov1.ARecordType, "111.22.33.44", iov1.UnmanagedDNS),
+				dnsRecord("foo.com", "foo", "record-foo.com", iov1.ARecordType, "111.22.33.44", iov1.UnmanagedDNS, earlier),
 			},
 			zones: []configv1.DNSZone{
 				{ID: "foobar"},
@@ -951,6 +967,12 @@ func TestConflictingDNSRecords(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			record := &iov1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "subject",
+					Namespace:         "test-ns",
+					UID:               uuid.NewUUID(),
+					CreationTimestamp: now,
+				},
 				Spec: iov1.DNSRecordSpec{
 					DNSName:             test.recordName,
 					RecordType:          test.recordType,
@@ -961,10 +983,11 @@ func TestConflictingDNSRecords(t *testing.T) {
 			if test.unmanagedDNS {
 				record.Spec.DNSManagementPolicy = iov1.UnmanagedDNS
 			}
+			existing := append([]runtime.Object{record.DeepCopy()}, test.existingObjects...)
 			r := &reconciler{
 				// TODO To write a fake provider that can return errors and add more test cases.
 				dnsProvider: &dns.FakeProvider{},
-				cache:       buildFakeCache(t, test.existingObjects),
+				cache:       buildFakeCache(t, existing),
 			}
 
 			_, actual := r.publishRecordToZones(context.TODO(), test.zones, record)
@@ -976,20 +999,161 @@ func TestConflictingDNSRecords(t *testing.T) {
 	}
 }
 
-func dnsRecord(name, namespace string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy) *iov1.DNSRecord {
+func Test_isOldestRecordForDomain(t *testing.T) {
+	// Kubernetes stores CreationTimestamp at second precision; use truncated
+	// times so subject and cached objects compare consistently in unit tests.
+	now := metav1.NewTime(time.Now().UTC().Truncate(time.Second))
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	later := metav1.NewTime(now.Add(time.Minute))
+	deleting := metav1.NewTime(now.Add(-time.Second))
+
+	tests := []struct {
+		name            string
+		record          *iov1.DNSRecord
+		existingObjects []runtime.Object
+		expectOldest    bool
+		expectErr       bool
+	}{
+		{
+			name:   "only self in index is oldest",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			},
+			expectOldest: true,
+		},
+		{
+			name:            "empty index returns error",
+			record:          dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{},
+			expectErr:       true,
+		},
+		{
+			name:   "older existing record wins",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: false,
+		},
+		{
+			name:   "newer existing record loses to self",
+			record: dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, later),
+			},
+			expectOldest: true,
+		},
+		{
+			name:   "equal timestamp prefers lexicographically earlier namespace",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: false,
+		},
+		{
+			name:   "equal timestamp self wins when earlier namespace",
+			record: dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: true,
+		},
+		{
+			// Namespace-then-name (not "ns/name" string compare): foo beats
+			// foo-bar even though "foo-bar/a" < "foo/zzz" as a single string.
+			name:   "equal timestamp prefers shorter namespace over prefix sibling",
+			record: dnsRecord("foo.com", "foo-bar", "a", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "foo", "zzz", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "foo-bar", "a", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: false,
+		},
+		{
+			name:   "equal timestamp same namespace prefers earlier name",
+			record: dnsRecord("foo.com", "ns-a", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, now),
+				dnsRecord("foo.com", "ns-a", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: false,
+		},
+		{
+			name:   "deleting older record is ignored",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				deletingDNSRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.ManagedDNS, earlier, deleting),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: true,
+		},
+		{
+			name:   "older unmanaged record still blocks",
+			record: dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			existingObjects: []runtime.Object{
+				dnsRecord("foo.com", "ns-a", "record-a", iov1.ARecordType, "1.1.1.1", iov1.UnmanagedDNS, earlier),
+				dnsRecord("foo.com", "ns-b", "record-b", iov1.ARecordType, "2.2.2.2", iov1.ManagedDNS, now),
+			},
+			expectOldest: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Ensure the subject shares UID with its cache copy when present.
+			for _, obj := range test.existingObjects {
+				if existing, ok := obj.(*iov1.DNSRecord); ok &&
+					existing.Namespace == test.record.Namespace &&
+					existing.Name == test.record.Name {
+					test.record.UID = existing.UID
+				}
+			}
+			cache := buildFakeCache(t, test.existingObjects)
+			oldest, err := isOldestRecordForDomain(context.TODO(), cache, test.record)
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got oldest=%v", oldest)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if oldest != test.expectOldest {
+				t.Fatalf("expected oldest=%v, got %v", test.expectOldest, oldest)
+			}
+		})
+	}
+}
+
+func dnsRecord(dnsName, namespace, name string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy, created metav1.Time) *iov1.DNSRecord {
 	return &iov1.DNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("record-%s", name),
-			Namespace: namespace,
-			UID:       uuid.NewUUID(),
+			Name:              name,
+			Namespace:         namespace,
+			UID:               uuid.NewUUID(),
+			CreationTimestamp: created,
 		},
 		Spec: iov1.DNSRecordSpec{
-			DNSName:             name,
+			DNSName:             dnsName,
 			RecordType:          recordType,
 			Targets:             []string{target},
 			DNSManagementPolicy: managed,
 		},
 	}
+}
+
+func deletingDNSRecord(dnsName, namespace, name string, recordType iov1.DNSRecordType, target string, managed iov1.DNSManagementPolicy, created, deletion metav1.Time) *iov1.DNSRecord {
+	record := dnsRecord(dnsName, namespace, name, recordType, target, managed, created)
+	record.Finalizers = []string{"test.finalizer"}
+	record.DeletionTimestamp = &deletion
+	return record
 }
 
 // buildFakeCache returns a fake cache, with the necessary schema and index function(s) to mimic the parts of the cache

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -583,9 +583,11 @@ func testGatewayAPIDNS(t *testing.T) {
 		name                       string
 		createGateways             []testGateway
 		expectedListenerConditions []metav1.Condition
-		expectedDNSRecords         map[expectedDnsRecord]bool
+		expectedDNSRecords         map[expectedDnsRecord]dnsRecordExpectation
 	}{
-		// TODO: In this case Gateway Listeners should be reported as conflicted. To be fixed in the future release.
+		// Only the oldest DNSRecord for a DNS name is published (#1229).
+		// gw1 is created first (and wins ns/name tie-break), so gw2 is blocked.
+		// TODO: Gateway Listeners should eventually be reported as Conflicted.
 		{
 			name: "multipleGatewaysSameListenerHostname",
 			createGateways: []testGateway{
@@ -613,12 +615,14 @@ func testGatewayAPIDNS(t *testing.T) {
 				{Type: "Programmed", Status: metav1.ConditionTrue},
 				{Type: "ResolvedRefs", Status: metav1.ConditionTrue},
 			},
-			expectedDNSRecords: map[expectedDnsRecord]bool{
-				{dnsName: "abc." + domain + ".", gatewayName: "gw1"}: true,
-				{dnsName: "abc." + domain + ".", gatewayName: "gw2"}: true,
+			expectedDNSRecords: map[expectedDnsRecord]dnsRecordExpectation{
+				{dnsName: "abc." + domain + ".", gatewayName: "gw1"}: expectDNSRecordPublished(),
+				{dnsName: "abc." + domain + ".", gatewayName: "gw2"}: expectDNSRecordUnpublished("DomainAlreadyInUse"),
 			},
 		},
 		{
+			// Use a dedicated subdomain so this case does not collide with the
+			// suite-scoped test-gateway (*.gws.<basedomain>) from testGatewayAPIObjects.
 			name: "gatewayListenersWithOverlappingHostname",
 			createGateways: []testGateway{
 				{gatewayName: "gw3",
@@ -626,7 +630,7 @@ func testGatewayAPIDNS(t *testing.T) {
 					listeners: []testListener{
 						{
 							name:     "http",
-							hostname: ptr.To("qwe." + domain)},
+							hostname: ptr.To("qwe.overlap-gws." + dnsConfig.Spec.BaseDomain)},
 					},
 				},
 				{gatewayName: "gw4",
@@ -634,7 +638,7 @@ func testGatewayAPIDNS(t *testing.T) {
 					listeners: []testListener{
 						{
 							name:     "http",
-							hostname: ptr.To("*." + domain),
+							hostname: ptr.To("*.overlap-gws." + dnsConfig.Spec.BaseDomain),
 						},
 					},
 				},
@@ -645,9 +649,9 @@ func testGatewayAPIDNS(t *testing.T) {
 				{Type: "Programmed", Status: metav1.ConditionTrue},
 				{Type: "ResolvedRefs", Status: metav1.ConditionTrue},
 			},
-			expectedDNSRecords: map[expectedDnsRecord]bool{
-				{dnsName: "qwe." + domain + ".", gatewayName: "gw3"}: true,
-				{dnsName: "*." + domain + ".", gatewayName: "gw4"}:   true,
+			expectedDNSRecords: map[expectedDnsRecord]dnsRecordExpectation{
+				{dnsName: "qwe.overlap-gws." + dnsConfig.Spec.BaseDomain + ".", gatewayName: "gw3"}: expectDNSRecordPublished(),
+				{dnsName: "*.overlap-gws." + dnsConfig.Spec.BaseDomain + ".", gatewayName: "gw4"}:   expectDNSRecordPublished(),
 			},
 		},
 	}
@@ -817,8 +821,8 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		gateway, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, name)
 		require.NoError(t, err, "failed waiting gateway to be ready")
 
-		err = assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-			{dnsName: "*." + testDomain + ".", gatewayName: name}: true})
+		err = assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+			{dnsName: "*." + testDomain + ".", gatewayName: name}: expectDNSRecordPublished()})
 
 		require.NoError(t, err, "dnsrecord never got ready")
 
@@ -1039,61 +1043,57 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 			assert.Equal(t, originalListenerAcceptedCondition.LastTransitionTime, currentListenerAcceptedCondition.LastTransitionTime, "the Accepted condition LastTransitionTime should not change")
 		})
 
-		// This test verifies if creating a 2nd Gateway using the same domain of the 1st one returns
-		// all of the conditions as Ready.
-		// This test should be changed and fixed once https://github.com/openshift/cluster-ingress-operator/pull/1229
-		// is merged, as this will become an unsupported scenario (2 gateways with a conflicting DNS)
-		t.Run("should not conflict with a second Gateway created with the same domain", func(t *testing.T) {
-			t.Skip("skipping while the PR for duplicate DNS is not merged")
+		// Creating a second Gateway with the same domain is unsupported after
+		// #1229: only the oldest DNSRecord is published; the duplicate is blocked.
+		t.Run("should report DNS conflict when a second Gateway uses the same domain", func(t *testing.T) {
 			dupName := gateway.GetName() + "-dup"
 			dupGateway, err := createGateway(t, gatewayClass, dupName, operatorcontroller.DefaultOperandNamespace, testDomain)
-			require.NoError(t, err, "failed to create gateway", "name", name)
+			require.NoError(t, err, "failed to create duplicate gateway", "name", dupName)
 			t.Cleanup(func() {
 				if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), dupGateway)); err != nil {
-					t.Errorf("failed to clean duplicated test gateway %q: %v", name, err)
+					t.Errorf("failed to clean duplicated test gateway %q: %v", dupName, err)
 				}
 			})
-			assert.Eventually(t, func() bool {
-				current := &gatewayapiv1.Gateway{}
+
+			_, err = assertGatewaySuccessful(t, operatorcontroller.DefaultOperandNamespace, dupName)
+			require.NoError(t, err, "failed waiting for duplicate gateway to be Accepted/Programmed")
+
+			require.NoError(t, assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+				{dnsName: "*." + testDomain + ".", gatewayName: name}:    expectDNSRecordPublished(),
+				{dnsName: "*." + testDomain + ".", gatewayName: dupName}: expectDNSRecordUnpublished("DomainAlreadyInUse"),
+			}), "expected original DNSRecord published and duplicate blocked")
+
+			assert.Eventuallyf(t, func() bool {
+				original := &gatewayapiv1.Gateway{}
 				nsName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: name}
-
-				if err := kclient.Get(context.Background(), nsName, current); err != nil {
-					t.Logf("Failed to get current gateway %v: %v; retrying...", nsName, err)
+				if err := kclient.Get(context.Background(), nsName, original); err != nil {
+					t.Logf("Failed to get original gateway %v: %v; retrying...", nsName, err)
 					return false
 				}
-				lsIndex := -1
-				for i, ls := range current.Status.Listeners {
-					if ls.Name == gatewayapiv1.SectionName("http") {
-						lsIndex = i
-					}
-				}
-				if lsIndex < 0 {
-					t.Logf("matching listener not found yet")
-					return false
-				}
-				if !condutils.IsStatusConditionTrue(current.Status.Conditions, "DNSReady") ||
-					!condutils.IsStatusConditionTrue(current.Status.Conditions, "LoadBalancerReady") {
-					t.Logf("current gateway %v does not have the right conditions yet %v; retrying...", nsName, err)
-					return false
-				}
-
 				duplicate := &gatewayapiv1.Gateway{}
-				duplicate.SetName(dupName)
-				duplicate.SetNamespace(dupGateway.Namespace)
-				if err := kclient.Get(context.Background(), client.ObjectKeyFromObject(duplicate), duplicate); err != nil {
-					t.Logf("Failed to get current gateway %v: %v; retrying...", nsName, err)
+				dupNSName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: dupName}
+				if err := kclient.Get(context.Background(), dupNSName, duplicate); err != nil {
+					t.Logf("Failed to get duplicate gateway %v: %v; retrying...", dupNSName, err)
 					return false
 				}
 
-				// This should be false once the duplicate DNSRecord PR is merged
-				if !condutils.IsStatusConditionTrue(current.Status.Conditions, "DNSReady") ||
-					!condutils.IsStatusConditionTrue(current.Status.Conditions, "LoadBalancerReady") {
-					t.Logf("duplicate gateway %v does not have the right conditions yet %v; retrying...", nsName, err)
+				if !condutils.IsStatusConditionTrue(original.Status.Conditions, "DNSReady") ||
+					!condutils.IsStatusConditionTrue(original.Status.Conditions, "LoadBalancerReady") {
+					t.Logf("original gateway conditions not ready yet: %v; retrying...", original.Status.Conditions)
 					return false
 				}
-
+				if !condutils.IsStatusConditionFalse(duplicate.Status.Conditions, "DNSReady") ||
+					!condutils.IsStatusConditionTrue(duplicate.Status.Conditions, "LoadBalancerReady") {
+					t.Logf("duplicate gateway conditions not conflicted yet: %v; retrying...", duplicate.Status.Conditions)
+					return false
+				}
+				dnsReady := condutils.FindStatusCondition(duplicate.Status.Conditions, "DNSReady")
+				if dnsReady == nil || dnsReady.Reason != "FailedZones" {
+					t.Logf("duplicate DNSReady reason want FailedZones, got %#v; retrying...", dnsReady)
+					return false
+				}
 				return true
-			}, 3*time.Minute, 3*time.Second)
+			}, 3*time.Minute, 3*time.Second, "expected original DNSReady=True and duplicate DNSReady=False/FailedZones")
 		})
 
 	})
@@ -1134,8 +1134,8 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		t.Fatalf("failed to accept/program gateway test-gateway-update: %v", err)
 	}
 
-	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-		{dnsName: "foo." + domain + ".", gatewayName: "test-gateway-update"}: true,
+	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+		{dnsName: "foo." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordPublished(),
 	}); err != nil {
 		t.Fatalf("DNSRecord %s expectations not met: %v", "foo."+domain+".", err)
 	}
@@ -1151,10 +1151,10 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 	}
 	t.Logf("Modified gateway %s's listener hostname from %s to: %s", gateway.Name, "foo."+domain+".", "baz."+domain+".")
 
-	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-		{dnsName: "foo." + domain + ".", gatewayName: "test-gateway-update"}: false,
-		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: true,
-		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: true,
+	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+		{dnsName: "foo." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordAbsent(),
+		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordPublished(),
+		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordPublished(),
 	}); err != nil {
 		t.Fatalf("DNSRecord %s expectations not met: %v", "baz."+domain+".", err)
 	}
@@ -1168,9 +1168,9 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 	t.Logf("Deleted listener %s from gateway %s.", "http-listener2", gateway.Name)
 
 	t.Logf("Checking that the dnsRecord for %s gets removed after removing the listener.", "bar."+domain+".")
-	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: true,
-		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: false,
+	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordPublished(),
+		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordAbsent(),
 	}); err != nil {
 		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
 	}
@@ -1178,8 +1178,8 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 	deleteWithRetryOnError(t, context.TODO(), gateway, DefaultRetryTimeout)
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
-	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: false,
+	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordAbsent(),
 	}); err != nil {
 		t.Fatalf("expected baz.%s. to be deleted, but it was not", domain)
 	}

--- a/test/e2e/gateway_api_test.go
+++ b/test/e2e/gateway_api_test.go
@@ -584,12 +584,20 @@ func testGatewayAPIDNS(t *testing.T) {
 		createGateways             []testGateway
 		expectedListenerConditions []metav1.Condition
 		expectedDNSRecords         map[expectedDnsRecord]dnsRecordExpectation
+		// establishDNSOwnershipFirst waits for each gateway (except the last)
+		// to have its DNSRecords published before creating the next gateway.
+		// Required for same-hostname conflict cases: ownership is based on
+		// DNSRecord CreationTimestamp, not Gateway create order, and Istio may
+		// provision Services/DNSRecords out of Gateway creation order.
+		establishDNSOwnershipFirst bool
 	}{
 		// Only the oldest DNSRecord for a DNS name is published (#1229).
-		// gw1 is created first (and wins ns/name tie-break), so gw2 is blocked.
+		// Serialize ownership: publish gw1's DNSRecord before creating gw2 so
+		// gw1 is guaranteed to be the oldest claimant.
 		// TODO: Gateway Listeners should eventually be reported as Conflicted.
 		{
-			name: "multipleGatewaysSameListenerHostname",
+			name:                       "multipleGatewaysSameListenerHostname",
+			establishDNSOwnershipFirst: true,
 			createGateways: []testGateway{
 				{gatewayName: "gw1",
 					namespace: operatorcontroller.DefaultOperandNamespace,
@@ -660,13 +668,19 @@ func testGatewayAPIDNS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var gateways []*gatewayapiv1.Gateway
 
-			// Create gateways
-			for _, gateway := range tc.createGateways {
+			for i, gateway := range tc.createGateways {
 				createdGateway, err := createGatewayWithListeners(t, gatewayClass, gateway.gatewayName, gateway.namespace, gateway.listeners)
 				if err != nil {
 					t.Fatalf("failed to create gateway %s: %v", gateway.gatewayName, err)
 				}
 				gateways = append(gateways, createdGateway)
+
+				if tc.establishDNSOwnershipFirst && i < len(tc.createGateways)-1 {
+					_, err := assertGatewaySuccessful(t, gateway.namespace, gateway.gatewayName)
+					require.NoErrorf(t, err, "failed to accept/program gateway %s before creating the next gateway", gateway.gatewayName)
+					err = assertExpectedDNSRecords(t, publishedDNSRecordExpectations(gateway))
+					require.NoErrorf(t, err, "failed to establish DNS ownership for gateway %s before creating the next gateway", gateway.gatewayName)
+				}
 			}
 
 			t.Cleanup(func() {
@@ -1048,9 +1062,11 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 		t.Run("should report DNS conflict when a second Gateway uses the same domain", func(t *testing.T) {
 			dupName := gateway.GetName() + "-dup"
 			dupGateway, err := createGateway(t, gatewayClass, dupName, operatorcontroller.DefaultOperandNamespace, testDomain)
-			require.NoError(t, err, "failed to create duplicate gateway", "name", dupName)
+			require.NoErrorf(t, err, "failed to create duplicate gateway %q", dupName)
 			t.Cleanup(func() {
-				if err := client.IgnoreNotFound(kclient.Delete(context.TODO(), dupGateway)); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), DefaultRetryTimeout)
+				defer cancel()
+				if err := client.IgnoreNotFound(kclient.Delete(ctx, dupGateway)); err != nil {
 					t.Errorf("failed to clean duplicated test gateway %q: %v", dupName, err)
 				}
 			})
@@ -1066,13 +1082,17 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 			assert.Eventuallyf(t, func() bool {
 				original := &gatewayapiv1.Gateway{}
 				nsName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: name}
-				if err := kclient.Get(context.Background(), nsName, original); err != nil {
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				if err := kclient.Get(ctx, nsName, original); err != nil {
 					t.Logf("Failed to get original gateway %v: %v; retrying...", nsName, err)
 					return false
 				}
 				duplicate := &gatewayapiv1.Gateway{}
 				dupNSName := types.NamespacedName{Namespace: operatorcontroller.DefaultOperandNamespace, Name: dupName}
-				if err := kclient.Get(context.Background(), dupNSName, duplicate); err != nil {
+				ctx, cancel = context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				if err := kclient.Get(ctx, dupNSName, duplicate); err != nil {
 					t.Logf("Failed to get duplicate gateway %v: %v; retrying...", dupNSName, err)
 					return false
 				}
@@ -1087,13 +1107,31 @@ func testGatewayOpenshiftConditions(t *testing.T) {
 					t.Logf("duplicate gateway conditions not conflicted yet: %v; retrying...", duplicate.Status.Conditions)
 					return false
 				}
+				// Gateway-level DNSReady aggregates listener DNS failures as
+				// SomeListenersNotReady; FailedZones is reported on the listener.
 				dnsReady := condutils.FindStatusCondition(duplicate.Status.Conditions, "DNSReady")
-				if dnsReady == nil || dnsReady.Reason != "FailedZones" {
-					t.Logf("duplicate DNSReady reason want FailedZones, got %#v; retrying...", dnsReady)
+				if dnsReady == nil || dnsReady.Reason != "SomeListenersNotReady" {
+					t.Logf("duplicate gateway DNSReady reason want SomeListenersNotReady, got %#v; retrying...", dnsReady)
+					return false
+				}
+				lsIndex := -1
+				for i, ls := range duplicate.Status.Listeners {
+					if ls.Name == gatewayapiv1.SectionName("http") {
+						lsIndex = i
+						break
+					}
+				}
+				if lsIndex < 0 {
+					t.Logf("duplicate gateway http listener status not found yet; retrying...")
+					return false
+				}
+				listenerDNSReady := condutils.FindStatusCondition(duplicate.Status.Listeners[lsIndex].Conditions, "DNSReady")
+				if listenerDNSReady == nil || listenerDNSReady.Status != metav1.ConditionFalse || listenerDNSReady.Reason != "FailedZones" {
+					t.Logf("duplicate listener DNSReady want False/FailedZones, got %#v; retrying...", listenerDNSReady)
 					return false
 				}
 				return true
-			}, 3*time.Minute, 3*time.Second, "expected original DNSReady=True and duplicate DNSReady=False/FailedZones")
+			}, 3*time.Minute, 3*time.Second, "expected original DNSReady=True and duplicate DNSReady=False/SomeListenersNotReady with listener FailedZones")
 		})
 
 	})
@@ -1172,16 +1210,20 @@ func testGatewayAPIDNSListenerUpdate(t *testing.T) {
 		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordPublished(),
 		{dnsName: "bar." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordAbsent(),
 	}); err != nil {
-		t.Fatalf("expected bar.%s. to be deleted, but it was not", domain)
+		t.Fatalf("expected bar.%s. to be deleted, but it was not: %v", domain, err)
 	}
 
-	deleteWithRetryOnError(t, context.TODO(), gateway, DefaultRetryTimeout)
+	{
+		ctx, cancel := context.WithTimeout(t.Context(), DefaultRetryTimeout)
+		defer cancel()
+		deleteWithRetryOnError(t, ctx, gateway, DefaultRetryTimeout)
+	}
 
 	t.Logf("Checking the remaining DNSRecord %s gets deleted after gateway deletion.", "baz."+domain+".")
 	if err := assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
 		{dnsName: "baz." + domain + ".", gatewayName: "test-gateway-update"}: expectDNSRecordAbsent(),
 	}); err != nil {
-		t.Fatalf("expected baz.%s. to be deleted, but it was not", domain)
+		t.Fatalf("expected baz.%s. to be deleted, but it was not: %v", domain, err)
 	}
 	t.Logf("Confirmed DNSRecord removed after gateway deletion.")
 }

--- a/test/e2e/gateway_api_tls_scanner_setup_test.go
+++ b/test/e2e/gateway_api_tls_scanner_setup_test.go
@@ -93,8 +93,8 @@ func TestGatewayAPITLSScannerSetup(t *testing.T) {
 	})
 	require.NoError(t, err, "Gateway infrastructure labels were not propagated to Envoy pods")
 
-	err = assertExpectedDNSRecords(t, map[expectedDnsRecord]bool{
-		{dnsName: hostname + ".", gatewayName: gateway.Name}: true,
+	err = assertExpectedDNSRecords(t, map[expectedDnsRecord]dnsRecordExpectation{
+		{dnsName: hostname + ".", gatewayName: gateway.Name}: expectDNSRecordPublished(),
 	})
 	require.NoError(t, err, "DNSRecord never got ready")
 

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -930,10 +930,31 @@ func gatewayListenerConditionMap(conditions ...metav1.Condition) map[string]stri
 	return conds
 }
 
-// expectedDnsRecord is used to represent a DNSRecord expectation.
+// expectedDnsRecord is used to represent a DNSRecord expectation key.
 type expectedDnsRecord struct {
 	dnsName     string
 	gatewayName string
+}
+
+// dnsRecordExpectation describes the desired presence and publish state of a DNSRecord.
+type dnsRecordExpectation struct {
+	present   bool
+	published bool
+	// reason, when non-empty and published is false, must match the Published
+	// condition Reason on at least one zone.
+	reason string
+}
+
+func expectDNSRecordPublished() dnsRecordExpectation {
+	return dnsRecordExpectation{present: true, published: true}
+}
+
+func expectDNSRecordAbsent() dnsRecordExpectation {
+	return dnsRecordExpectation{present: false}
+}
+
+func expectDNSRecordUnpublished(reason string) dnsRecordExpectation {
+	return dnsRecordExpectation{present: true, published: false, reason: reason}
 }
 
 type testGateway struct {
@@ -948,16 +969,15 @@ type testListener struct {
 }
 
 // assertExpectedDNSRecords polls until the DNSRecords in the default operand namespace match the given expectations.
-// The expectations parameter is a map where keys are expectations for DNSRecord and values indicate whether a DNSRecord should be present.
-func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]bool) error {
+func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]dnsRecordExpectation) error {
 	t.Helper()
 
 	var expectationsMet bool
 
 	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
 		haveExpectNotPresent := false
-		// expectationsMet starts true and gets set to false when some expectation is not met.
-		expectationsMet = true
+		// Only mark met after a successful evaluation of all expectations.
+		expectationsMet = false
 
 		dnsRecords := &v1.DNSRecordList{}
 		if err := kclient.List(ctx, dnsRecords, client.InNamespace(operatorcontroller.DefaultOperandNamespace)); err != nil {
@@ -965,57 +985,70 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]b
 			return false, nil
 		}
 
-		// Iterate over all expectations.
-		for exp, shouldBePresent := range expectations {
-			if !shouldBePresent {
+		for exp, want := range expectations {
+			if !want.present {
 				haveExpectNotPresent = true
 			}
 
-			// Reset the found and foundReady flags for each expectation.
 			found := false
-			foundReady := false
 			// Look for a DNSRecord that matches the expected gateway and DNS name.
 			for _, record := range dnsRecords.Items {
-				if record.Labels["gateway.networking.k8s.io/gateway-name"] == exp.gatewayName &&
-					record.Spec.DNSName == exp.dnsName {
+				if record.Labels["gateway.networking.k8s.io/gateway-name"] != exp.gatewayName ||
+					record.Spec.DNSName != exp.dnsName {
+					continue
+				}
+				found = true
 
-					if !shouldBePresent {
-						expectationsMet = false
-						found = true
-						t.Logf("DNSRecord %q (%s) found but should not be present.", record.Name, exp.dnsName)
-						return false, nil
-					}
-					found = true
-					// DNSRecord found and should be present, check if it is published
-					for _, zone := range record.Status.Zones {
-						for _, condition := range zone.Conditions {
-							if condition.Type == v1.DNSRecordPublishedConditionType && condition.Status == string(metav1.ConditionTrue) {
-								t.Logf("Found DNSRecord %q (%s) %s=%s as expected", record.Name, exp.dnsName, condition.Type, condition.Status)
-								foundReady = true
+				if !want.present {
+					t.Logf("DNSRecord %q (%s) found but should not be present.", record.Name, exp.dnsName)
+					return false, nil
+				}
+
+				publishedTrue, publishedFalseMatchingReason := false, false
+				for _, zone := range record.Status.Zones {
+					for _, condition := range zone.Conditions {
+						if condition.Type != v1.DNSRecordPublishedConditionType {
+							continue
+						}
+						t.Logf("Found DNSRecord %q (%s) %s=%s reason=%s", record.Name, exp.dnsName, condition.Type, condition.Status, condition.Reason)
+						switch condition.Status {
+						case string(metav1.ConditionTrue):
+							publishedTrue = true
+						case string(metav1.ConditionFalse):
+							if want.reason == "" || condition.Reason == want.reason {
+								publishedFalseMatchingReason = true
 							}
 						}
 					}
-					if !foundReady {
-						t.Logf("Found DNSRecord %v but could not determine its readiness; retrying...", record.Name)
-						expectationsMet = false
+				}
+
+				if want.published {
+					if !publishedTrue {
+						t.Logf("DNSRecord %q (%s) is expected to be published but is not; retrying...", record.Name, exp.dnsName)
+						return false, nil
+					}
+				} else {
+					if publishedTrue {
+						t.Logf("DNSRecord %q (%s) is published but expected not to be; retrying...", record.Name, exp.dnsName)
+						return false, nil
+					}
+					if !publishedFalseMatchingReason {
+						t.Logf("DNSRecord %q (%s) is expected unpublished (reason=%q) but matching condition not found; retrying...", record.Name, exp.dnsName, want.reason)
 						return false, nil
 					}
 				}
 			}
 
-			// If the record is expected but not found, return false to continue polling.
-			if shouldBePresent && !found {
+			if want.present && !found {
 				t.Logf("DNSRecord for hostname %q (gateway: %s) is expected to be present but was not found; retrying...", exp.dnsName, exp.gatewayName)
-				expectationsMet = false
 				return false, nil
 			}
-			// If the record is not expected but was found, return false to continue polling.
-			if !shouldBePresent && found {
+			if !want.present && found {
 				t.Logf("DNSRecord for hostname %q (gateway: %s) is present but was expected to be absent; retrying...", exp.dnsName, exp.gatewayName)
-				expectationsMet = false
 				return false, nil
 			}
 		}
+		expectationsMet = true
 		if haveExpectNotPresent {
 			t.Logf("Continuing polling to ensure non-expected DNSRecords do not exist...")
 		}

--- a/test/e2e/util_gatewayapi_test.go
+++ b/test/e2e/util_gatewayapi_test.go
@@ -957,6 +957,23 @@ func expectDNSRecordUnpublished(reason string) dnsRecordExpectation {
 	return dnsRecordExpectation{present: true, published: false, reason: reason}
 }
 
+// publishedDNSRecordExpectations builds Published=True expectations for every
+// listener hostname on the given gateway.
+func publishedDNSRecordExpectations(gateway testGateway) map[expectedDnsRecord]dnsRecordExpectation {
+	expectations := make(map[expectedDnsRecord]dnsRecordExpectation, len(gateway.listeners))
+	for _, listener := range gateway.listeners {
+		if listener.hostname == nil || len(*listener.hostname) == 0 {
+			continue
+		}
+		dnsName := *listener.hostname
+		if !strings.HasSuffix(dnsName, ".") {
+			dnsName += "."
+		}
+		expectations[expectedDnsRecord{dnsName: dnsName, gatewayName: gateway.gatewayName}] = expectDNSRecordPublished()
+	}
+	return expectations
+}
+
 type testGateway struct {
 	gatewayName string
 	namespace   string
@@ -975,7 +992,6 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]d
 	var expectationsMet bool
 
 	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultRetryTimeout, false, func(ctx context.Context) (bool, error) {
-		haveExpectNotPresent := false
 		// Only mark met after a successful evaluation of all expectations.
 		expectationsMet = false
 
@@ -986,14 +1002,10 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]d
 		}
 
 		for exp, want := range expectations {
-			if !want.present {
-				haveExpectNotPresent = true
-			}
-
 			found := false
 			// Look for a DNSRecord that matches the expected gateway and DNS name.
 			for _, record := range dnsRecords.Items {
-				if record.Labels["gateway.networking.k8s.io/gateway-name"] != exp.gatewayName ||
+				if record.Labels[operatorcontroller.GatewayNameLabelKey] != exp.gatewayName ||
 					record.Spec.DNSName != exp.dnsName {
 					continue
 				}
@@ -1048,11 +1060,11 @@ func assertExpectedDNSRecords(t *testing.T, expectations map[expectedDnsRecord]d
 				return false, nil
 			}
 		}
+		// All expectations (including absences) are satisfied; succeed immediately
+		// rather than burning the full timeout, which races a final List against a
+		// cancelled poll context and can falsely fail.
 		expectationsMet = true
-		if haveExpectNotPresent {
-			t.Logf("Continuing polling to ensure non-expected DNSRecords do not exist...")
-		}
-		return !haveExpectNotPresent, nil
+		return true, nil
 	})
 
 	if !expectationsMet {


### PR DESCRIPTION
## What

Hardens oldest-wins DNS publishing for duplicate Gateway API domain names and aligns the Gateway API DNS e2e tests with that policy so testGatewayAPIDNS stops flaking after #1229.

## Why

After [#1229](https://github.com/openshift/cluster-ingress-operator/pull/1229), only the oldest DNSRecord for a given DNS name is published. CI still failed or falsely passed because:

* Equal-second CreationTimestamps (and empty informer index results) could let both conflicting records publish.
* E2e expectations still required dual Published=True for the same hostname, and one subtest collided with the suite-scoped test-gateway wildcard.
* assertExpectedDNSRecords could report success after a failed List when the poll timed out.

## Changes

* Prefer older CreationTimestamp; on ties, compare namespace then name (Gateway API-style).
* Skip records with DeletionTimestamp when choosing the owner.
* Treat an empty DNS-name index as an error and requeue (InternalError) instead of publishing under cache lag.
* Share the same preference helper in mapOnRecordDelete when promoting the next owner.
* Unit-test tie-breaks, deleting/unmanaged survivors, zero-timestamp subjects, and delete-mapper selection.
* Fix assertExpectedDNSRecords false positives; support published / unpublished (DomainAlreadyInUse) / absent expectations.
* Update multipleGatewaysSameListenerHostname to assert conflict (gw1 published, gw2 blocked).
* Move overlapping-hostname coverage to *.overlap-gws.<basedomain> so it does not collide with suite test-gateway.
* Unskip/rewrite the OpenshiftConditions duplicate-domain case for DNSReady=False / FailedZones.

## Additional change: 
Empty-index / pre-sync races that previously attempted publish now surface transient Published=False with reason InternalError until the index catches up.