### PR TITLE
OCPBUGS-92835: add grace period to Available condition for deployment…

### DIFF
--- a/pkg/operator/controller/ingress/controller.go
+++ b/pkg/operator/controller/ingress/controller.go
@@ -1188,6 +1188,7 @@ func (r *reconciler) ensureIngressDeleted(ingress *operatorv1.IngressController)
 	DeleteIngressControllerConditionsMetric(ingress)
 	DeleteActiveNLBMetrics(ingress)
 	DeleteNLBHairpinRiskMetric(ingress)
+	DeleteDeploymentAvailableTransitionsMetric(ingress)
 
 	// Delete the RoutesPerShard metric label corresponding to the Ingress Controller.
 	routemetrics.DeleteRouteMetricsControllerRoutesPerShardMetric(ingress.Name)

--- a/pkg/operator/controller/ingress/metrics.go
+++ b/pkg/operator/controller/ingress/metrics.go
@@ -37,11 +37,29 @@ var (
 		Help: "Reports whether an IngressController using an internal AWS NLB has no explicit protocol setting and may be affected by hairpin connection failures. 0 is no risk, 1 is at risk.",
 	}, []string{"name"})
 
+	// deploymentAvailableTransitions reports the cumulative number of times
+	// an IngressController's DeploymentAvailable status condition has
+	// changed status (i.e. "flapped" between available and unavailable).
+	//
+	// The Available and Degraded conditions grant DeploymentAvailable a
+	// grace period before reporting an ingresscontroller as unavailable or
+	// degraded (see OCPBUGS-92835). A deployment that flaps quickly enough
+	// that each unavailable period stays within the grace period never
+	// causes Available/Degraded to go False, so the instability would
+	// otherwise be invisible. This counter provides an independent
+	// monitoring signal for that flapping so it can be alerted on even
+	// though it is masked in Available/Degraded.
+	deploymentAvailableTransitions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "ingress_controller_deployment_available_transitions_total",
+		Help: "Reports the cumulative number of times the DeploymentAvailable status condition has changed status for an IngressController. A high rate indicates the underlying deployment is flapping between available and unavailable.",
+	}, []string{"name"})
+
 	// metricsList is a list of metrics for this package.
 	metricsList = []prometheus.Collector{
 		ingressControllerConditions,
 		activeNLBs,
 		nlbHairpinRisk,
+		deploymentAvailableTransitions,
 	}
 )
 
@@ -100,6 +118,27 @@ func SetIngressControllerNLBMetric(ci *operatorv1.IngressController) {
 
 func DeleteNLBHairpinRiskMetric(ic *operatorv1.IngressController) {
 	nlbHairpinRisk.DeleteLabelValues(ic.Name)
+}
+
+// DeleteDeploymentAvailableTransitionsMetric deletes the
+// ingress_controller_deployment_available_transitions_total metric which
+// belongs to the given ingresscontroller.
+func DeleteDeploymentAvailableTransitionsMetric(ic *operatorv1.IngressController) {
+	deploymentAvailableTransitions.DeleteLabelValues(ic.Name)
+}
+
+// RecordDeploymentAvailableTransition increments the
+// ingress_controller_deployment_available_transitions_total counter for the
+// named ingresscontroller if previous is a known condition (i.e. not the
+// zero value) and its Status differs from current's Status.
+func RecordDeploymentAvailableTransition(icName string, previous, current operatorv1.OperatorCondition) {
+	if len(previous.Status) == 0 {
+		// No prior observation (e.g. first reconcile); nothing to compare.
+		return
+	}
+	if previous.Status != current.Status {
+		deploymentAvailableTransitions.WithLabelValues(icName).Inc()
+	}
 }
 
 func SetNLBHairpinRiskMetric(ic *operatorv1.IngressController) {

--- a/pkg/operator/controller/ingress/metrics_test.go
+++ b/pkg/operator/controller/ingress/metrics_test.go
@@ -296,6 +296,97 @@ func Test_SetNLBHairpinRiskMetric(t *testing.T) {
 	}
 }
 
+func Test_RecordDeploymentAvailableTransition(t *testing.T) {
+	condition := func(status operatorv1.ConditionStatus) operatorv1.OperatorCondition {
+		return operatorv1.OperatorCondition{Type: IngressControllerDeploymentAvailableConditionType, Status: status}
+	}
+
+	testCases := []struct {
+		name          string
+		icName        string
+		previous      operatorv1.OperatorCondition
+		current       operatorv1.OperatorCondition
+		expectedCount float64
+	}{
+		{
+			name:          "status unchanged",
+			icName:        "test1",
+			previous:      condition(operatorv1.ConditionTrue),
+			current:       condition(operatorv1.ConditionTrue),
+			expectedCount: 0,
+		},
+		{
+			name:          "status flipped true to false",
+			icName:        "test1",
+			previous:      condition(operatorv1.ConditionTrue),
+			current:       condition(operatorv1.ConditionFalse),
+			expectedCount: 1,
+		},
+		{
+			name:          "status flipped false to true",
+			icName:        "test1",
+			previous:      condition(operatorv1.ConditionFalse),
+			current:       condition(operatorv1.ConditionTrue),
+			expectedCount: 1,
+		},
+		{
+			name:          "no previous observation is not counted as a transition",
+			icName:        "test1",
+			previous:      operatorv1.OperatorCondition{},
+			current:       condition(operatorv1.ConditionFalse),
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deploymentAvailableTransitions.Reset()
+
+			RecordDeploymentAvailableTransition(tc.icName, tc.previous, tc.current)
+
+			expectedMetricFormat := ""
+			if tc.expectedCount != 0 {
+				expectedMetricFormat = fmt.Sprintf(`
+				# HELP ingress_controller_deployment_available_transitions_total Reports the cumulative number of times the DeploymentAvailable status condition has changed status for an IngressController. A high rate indicates the underlying deployment is flapping between available and unavailable.
+				# TYPE ingress_controller_deployment_available_transitions_total counter
+				ingress_controller_deployment_available_transitions_total{name="%s"} %v
+				`, tc.icName, tc.expectedCount)
+			}
+			if err := testutil.CollectAndCompare(deploymentAvailableTransitions, strings.NewReader(expectedMetricFormat)); err != nil {
+				t.Error(err)
+			}
+
+			DeleteDeploymentAvailableTransitionsMetric(testIngressControllerWithConditions(tc.icName, nil))
+		})
+	}
+}
+
+func Test_RecordDeploymentAvailableTransition_Cumulative(t *testing.T) {
+	deploymentAvailableTransitions.Reset()
+	defer deploymentAvailableTransitions.Reset()
+
+	condition := func(status operatorv1.ConditionStatus) operatorv1.OperatorCondition {
+		return operatorv1.OperatorCondition{Type: IngressControllerDeploymentAvailableConditionType, Status: status}
+	}
+
+	// Simulate a deployment flapping repeatedly; each flip should increment
+	// the counter, demonstrating that the flapping remains visible via this
+	// metric even though it may be masked by the Available/Degraded grace
+	// period.
+	RecordDeploymentAvailableTransition("test1", condition(operatorv1.ConditionTrue), condition(operatorv1.ConditionFalse))
+	RecordDeploymentAvailableTransition("test1", condition(operatorv1.ConditionFalse), condition(operatorv1.ConditionTrue))
+	RecordDeploymentAvailableTransition("test1", condition(operatorv1.ConditionTrue), condition(operatorv1.ConditionFalse))
+
+	expectedMetricFormat := `
+	# HELP ingress_controller_deployment_available_transitions_total Reports the cumulative number of times the DeploymentAvailable status condition has changed status for an IngressController. A high rate indicates the underlying deployment is flapping between available and unavailable.
+	# TYPE ingress_controller_deployment_available_transitions_total counter
+	ingress_controller_deployment_available_transitions_total{name="test1"} 3
+	`
+	if err := testutil.CollectAndCompare(deploymentAvailableTransitions, strings.NewReader(expectedMetricFormat)); err != nil {
+		t.Error(err)
+	}
+}
+
 func testIngressControllerWithSpecAndStatus(name string, spec, status *operatorv1.EndpointPublishingStrategy) *operatorv1.IngressController {
 	return &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -110,14 +110,18 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	}
 	updated.Status.EffectiveHAProxyVersion = haproxyVersion
 
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentAvailableCondition(deployment))
+	deploymentAvailableCondition := computeDeploymentAvailableCondition(deployment)
+	previousDeploymentAvailableCondition, hasPreviousDeploymentAvailableCondition := findOperatorCondition(ic.Status.Conditions, IngressControllerDeploymentAvailableConditionType)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, deploymentAvailableCondition)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasMinAvailableCondition(deployment, pods))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasAllAvailableCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentRollingOutCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeLoadBalancerStatus(ic, service, operandEvents, false)...)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeLoadBalancerProgressingStatus(updated, service, platformStatus))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeDNSStatus(ic, wildcardRecord, platformStatus, dnsConfig, false)...)
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(updated.Status.Conditions))
+	availableCondition, err := computeIngressAvailableCondition(updated.Status.Conditions, updated.Status.AvailableReplicas)
+	errs = append(errs, err)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, availableCondition)
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressProgressingCondition(updated.Status.Conditions))
@@ -132,6 +136,9 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 			errs = append(errs, fmt.Errorf("failed to update ingresscontroller status: %v", err))
 		} else {
 			updatedIc = true
+			if hasPreviousDeploymentAvailableCondition {
+				RecordDeploymentAvailableTransition(ic.Name, previousDeploymentAvailableCondition, deploymentAvailableCondition)
+			}
 		}
 	}
 	//OCPBUGS-61508 set at every reconcile the ingress_controller_conditions metrics
@@ -181,6 +188,17 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 	}
 	conditions = append(conditions, additions...)
 	return conditions
+}
+
+// findOperatorCondition returns the condition of the given type from
+// conditions, and a Boolean indicating whether it was found.
+func findOperatorCondition(conditions []operatorv1.OperatorCondition, conditionType string) (operatorv1.OperatorCondition, bool) {
+	for _, c := range conditions {
+		if c.Type == conditionType {
+			return c, true
+		}
+	}
+	return operatorv1.OperatorCondition{}, false
 }
 
 // PruneConditions removes any conditions that are not currently supported.
@@ -299,11 +317,25 @@ func checkPodsScheduledForDeployment(deployment *appsv1.Deployment, pods []corev
 // 2) the DNSReady condition of the IngressController, and
 // 3) the LoadBalancerReady condition of the IngressController.
 // The ingresscontroller is judged Available only if all 3 conditions are true
-func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition) operatorv1.OperatorCondition {
+//
+// The DeploymentAvailable condition is granted a short grace period before it
+// can mark the ingresscontroller as unavailable, but only if at least one
+// replica is currently available (availableReplicas > 0). This tolerates the
+// case where deployment briefly reports Available=False while dropping below
+// the configured minimum availability threshold (e.g. during a node reboot or
+// pod eviction) but other replicas are still serving traffic. If zero
+// replicas are available, the ingresscontroller is a genuine outage and is
+// reported unavailable immediately, without any grace period.
+func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition, availableReplicas int32) (operatorv1.OperatorCondition, error) {
+	deploymentAvailableGracePeriod := time.Second * 60
+	if availableReplicas == 0 {
+		deploymentAvailableGracePeriod = 0
+	}
 	expected := []expectedCondition{
 		{
-			condition: IngressControllerDeploymentAvailableConditionType,
-			status:    operatorv1.ConditionTrue,
+			condition:   IngressControllerDeploymentAvailableConditionType,
+			status:      operatorv1.ConditionTrue,
+			gracePeriod: deploymentAvailableGracePeriod,
 		},
 		{
 			condition: operatorv1.DNSReadyIngressConditionType,
@@ -323,22 +355,33 @@ func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition)
 
 	// Cover the rare case of no conditions
 	if len(conditions) == 0 {
-		return operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse}
+		return operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse}, nil
 	}
-	_, unavailableConditions, _ := checkConditions(expected, conditions)
+	graceConditions, unavailableConditions, requeueAfter := checkConditions(expected, conditions)
 	if len(unavailableConditions) != 0 {
-		degraded := formatConditions(unavailableConditions)
-		return operatorv1.OperatorCondition{
+		unavailable := formatConditions(unavailableConditions)
+		condition := operatorv1.OperatorCondition{
 			Type:    operatorv1.IngressControllerAvailableConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "IngressControllerUnavailable",
-			Message: "One or more status conditions indicate unavailable: " + degraded,
+			Message: "One or more status conditions indicate unavailable: " + unavailable,
 		}
+		return condition, retryableerror.New(errors.New("IngressController is unavailable: "+unavailable), time.Minute)
 	}
-	return operatorv1.OperatorCondition{
+	condition := operatorv1.OperatorCondition{
 		Type:   operatorv1.IngressControllerAvailableConditionType,
 		Status: operatorv1.ConditionTrue,
 	}
+	var err error
+	if len(graceConditions) != 0 {
+		var grace string
+		for _, cond := range graceConditions {
+			grace = grace + fmt.Sprintf(", %s=%s", cond.Type, cond.Status)
+		}
+		grace = grace[2:]
+		err = retryableerror.New(errors.New("IngressController may become unavailable soon: "+grace), requeueAfter)
+	}
+	return condition, err
 }
 
 // checkConditions compares expected operator conditions to existing operator

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -110,14 +110,20 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 	}
 	updated.Status.EffectiveHAProxyVersion = haproxyVersion
 
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentAvailableCondition(deployment))
+	deploymentAvailableCondition := computeDeploymentAvailableCondition(deployment)
+	if previous, ok := findOperatorCondition(ic.Status.Conditions, IngressControllerDeploymentAvailableConditionType); ok {
+		RecordDeploymentAvailableTransition(ic.Name, previous, deploymentAvailableCondition)
+	}
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, deploymentAvailableCondition)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasMinAvailableCondition(deployment, pods))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasAllAvailableCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentRollingOutCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeLoadBalancerStatus(ic, service, operandEvents, false)...)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeLoadBalancerProgressingStatus(updated, service, platformStatus))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeDNSStatus(ic, wildcardRecord, platformStatus, dnsConfig, false)...)
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(updated.Status.Conditions))
+	availableCondition, err := computeIngressAvailableCondition(updated.Status.Conditions, updated.Status.AvailableReplicas)
+	errs = append(errs, err)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, availableCondition)
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressProgressingCondition(updated.Status.Conditions))
@@ -181,6 +187,17 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 	}
 	conditions = append(conditions, additions...)
 	return conditions
+}
+
+// findOperatorCondition returns the condition of the given type from
+// conditions, and a Boolean indicating whether it was found.
+func findOperatorCondition(conditions []operatorv1.OperatorCondition, conditionType string) (operatorv1.OperatorCondition, bool) {
+	for _, c := range conditions {
+		if c.Type == conditionType {
+			return c, true
+		}
+	}
+	return operatorv1.OperatorCondition{}, false
 }
 
 // PruneConditions removes any conditions that are not currently supported.
@@ -299,11 +316,25 @@ func checkPodsScheduledForDeployment(deployment *appsv1.Deployment, pods []corev
 // 2) the DNSReady condition of the IngressController, and
 // 3) the LoadBalancerReady condition of the IngressController.
 // The ingresscontroller is judged Available only if all 3 conditions are true
-func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition) operatorv1.OperatorCondition {
+//
+// The DeploymentAvailable condition is granted a short grace period before it
+// can mark the ingresscontroller as unavailable, but only if at least one
+// replica is currently available (availableReplicas > 0). This tolerates the
+// case where deployment briefly reports Available=False while dropping below
+// the configured minimum availability threshold (e.g. during a node reboot or
+// pod eviction) but other replicas are still serving traffic. If zero
+// replicas are available, the ingresscontroller is a genuine outage and is
+// reported unavailable immediately, without any grace period.
+func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition, availableReplicas int32) (operatorv1.OperatorCondition, error) {
+	deploymentAvailableGracePeriod := time.Second * 60
+	if availableReplicas == 0 {
+		deploymentAvailableGracePeriod = 0
+	}
 	expected := []expectedCondition{
 		{
-			condition: IngressControllerDeploymentAvailableConditionType,
-			status:    operatorv1.ConditionTrue,
+			condition:   IngressControllerDeploymentAvailableConditionType,
+			status:      operatorv1.ConditionTrue,
+			gracePeriod: deploymentAvailableGracePeriod,
 		},
 		{
 			condition: operatorv1.DNSReadyIngressConditionType,
@@ -323,22 +354,33 @@ func computeIngressAvailableCondition(conditions []operatorv1.OperatorCondition)
 
 	// Cover the rare case of no conditions
 	if len(conditions) == 0 {
-		return operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse}
+		return operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse}, nil
 	}
-	_, unavailableConditions, _ := checkConditions(expected, conditions)
+	graceConditions, unavailableConditions, requeueAfter := checkConditions(expected, conditions)
 	if len(unavailableConditions) != 0 {
-		degraded := formatConditions(unavailableConditions)
-		return operatorv1.OperatorCondition{
+		unavailable := formatConditions(unavailableConditions)
+		condition := operatorv1.OperatorCondition{
 			Type:    operatorv1.IngressControllerAvailableConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "IngressControllerUnavailable",
-			Message: "One or more status conditions indicate unavailable: " + degraded,
+			Message: "One or more status conditions indicate unavailable: " + unavailable,
 		}
+		return condition, retryableerror.New(errors.New("IngressController is unavailable: "+unavailable), time.Minute)
 	}
-	return operatorv1.OperatorCondition{
+	condition := operatorv1.OperatorCondition{
 		Type:   operatorv1.IngressControllerAvailableConditionType,
 		Status: operatorv1.ConditionTrue,
 	}
+	var err error
+	if len(graceConditions) != 0 {
+		var grace string
+		for _, cond := range graceConditions {
+			grace = grace + fmt.Sprintf(", %s=%s", cond.Type, cond.Status)
+		}
+		grace = grace[2:]
+		err = retryableerror.New(errors.New("IngressController may become unavailable soon: "+grace), requeueAfter)
+	}
+	return condition, err
 }
 
 // checkConditions compares expected operator conditions to existing operator

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1957,76 +1957,143 @@ func Test_computeIngressProgressingCondition(t *testing.T) {
 }
 
 func Test_computeIngressAvailableCondition(t *testing.T) {
+	fakeClock := utilclocktesting.NewFakeClock(time.Time{})
+	clock = fakeClock
+	defer func() {
+		clock = utilclock.RealClock{}
+	}()
+
 	testCases := []struct {
-		description string
-		conditions  []operatorv1.OperatorCondition
-		expect      operatorv1.OperatorCondition
+		description       string
+		conditions        []operatorv1.OperatorCondition
+		availableReplicas int32
+		expect            operatorv1.OperatorCondition
+		expectRequeue     bool
+		expectAfter       time.Duration
 	}{
 		{
 			description: "deployment, dns, and lb available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			expectRequeue:     false,
 		},
 		{
-			description: "deployment not available, but dns and lb available",
+			description: "deployment unavailable for <60s, within grace period, at least one replica available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionFalse},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-30)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 1,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			expectRequeue:     true,
+			expectAfter:       time.Second * 30,
+		},
+		{
+			description: "deployment unavailable for <60s, but zero replicas available (real outage, no grace)",
+			conditions: []operatorv1.OperatorCondition{
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-30)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+			},
+			availableReplicas: 0,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
+		},
+		{
+			description: "deployment unavailable for >60s, past grace period",
+			conditions: []operatorv1.OperatorCondition{
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-61)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+			},
+			availableReplicas: 1,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "dns not available, but deployment and lb available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionFalse},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionFalse, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "lb not available, but dns and deployment available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionFalse},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionFalse, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "all availability unknown",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionUnknown},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionUnknown},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionUnknown},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionUnknown, "", clock.Now().Add(time.Hour*-1)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionUnknown, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionUnknown, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 0,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
-			description: "all availability not present",
-			conditions:  []operatorv1.OperatorCondition{},
-			expect:      operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			description:   "all availability not present",
+			conditions:    []operatorv1.OperatorCondition{},
+			expect:        operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			actual := computeIngressAvailableCondition(tc.conditions)
+			actual, err := computeIngressAvailableCondition(tc.conditions, tc.availableReplicas)
+			switch e := err.(type) {
+			case retryable.Error:
+				if !tc.expectRequeue {
+					t.Error("expected not to be told to requeue")
+				}
+				if tc.expectAfter != e.After() {
+					t.Errorf("expected requeue after %s, got %s", tc.expectAfter.String(), e.After().String())
+				}
+			case nil:
+				if tc.expectRequeue {
+					t.Error("expected to be told to requeue")
+				}
+			default:
+				t.Fatalf("unexpected error: %v", err)
+			}
 			conditionsCmpOpts := []cmp.Option{
 				cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "LastTransitionTime", "Reason", "Message"),
 				cmpopts.EquateEmpty(),
@@ -2035,6 +2102,27 @@ func Test_computeIngressAvailableCondition(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", tc.expect, actual)
 			}
 		})
+	}
+}
+
+func Test_findOperatorCondition(t *testing.T) {
+	conditions := []operatorv1.OperatorCondition{
+		cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "DeploymentAvailable", time.Time{}),
+		cond(operatorv1.OperatorStatusTypeDegraded, operatorv1.ConditionFalse, "", time.Time{}),
+	}
+
+	if found, ok := findOperatorCondition(conditions, IngressControllerDeploymentAvailableConditionType); !ok {
+		t.Error("expected to find DeploymentAvailable condition")
+	} else if found.Status != operatorv1.ConditionTrue {
+		t.Errorf("expected status %s, got %s", operatorv1.ConditionTrue, found.Status)
+	}
+
+	if _, ok := findOperatorCondition(conditions, "NonExistent"); ok {
+		t.Error("expected not to find a non-existent condition type")
+	}
+
+	if _, ok := findOperatorCondition(nil, IngressControllerDeploymentAvailableConditionType); ok {
+		t.Error("expected not to find any condition in a nil slice")
 	}
 }
 

--- a/pkg/operator/controller/ingress/status_test.go
+++ b/pkg/operator/controller/ingress/status_test.go
@@ -1957,76 +1957,143 @@ func Test_computeIngressProgressingCondition(t *testing.T) {
 }
 
 func Test_computeIngressAvailableCondition(t *testing.T) {
+	fakeClock := utilclocktesting.NewFakeClock(time.Time{})
+	clock = fakeClock
+	defer func() {
+		clock = utilclock.RealClock{}
+	}()
+
 	testCases := []struct {
-		description string
-		conditions  []operatorv1.OperatorCondition
-		expect      operatorv1.OperatorCondition
+		description       string
+		conditions        []operatorv1.OperatorCondition
+		availableReplicas int32
+		expect            operatorv1.OperatorCondition
+		expectRequeue     bool
+		expectAfter       time.Duration
 	}{
 		{
 			description: "deployment, dns, and lb available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			expectRequeue:     false,
 		},
 		{
-			description: "deployment not available, but dns and lb available",
+			description: "deployment unavailable for <60s, within grace period, at least one replica available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionFalse},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-30)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 1,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionTrue},
+			expectRequeue:     true,
+			expectAfter:       time.Second * 30,
+		},
+		{
+			description: "deployment unavailable for <60s, but zero replicas available (real outage, no grace)",
+			conditions: []operatorv1.OperatorCondition{
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-30)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+			},
+			availableReplicas: 0,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
+		},
+		{
+			description: "deployment unavailable for >60s, past grace period",
+			conditions: []operatorv1.OperatorCondition{
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionFalse, "", clock.Now().Add(time.Second*-61)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+			},
+			availableReplicas: 1,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "dns not available, but deployment and lb available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionFalse},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionFalse, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "lb not available, but dns and deployment available",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionFalse},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionFalse, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 2,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
 			description: "all availability unknown",
 			conditions: []operatorv1.OperatorCondition{
-				{Type: IngressControllerDeploymentAvailableConditionType, Status: operatorv1.ConditionUnknown},
-				{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionUnknown},
-				{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-				{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionUnknown},
+				cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionUnknown, "", clock.Now().Add(time.Hour*-1)),
+				cond(operatorv1.DNSManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.DNSReadyIngressConditionType, operatorv1.ConditionUnknown, "", clock.Now()),
+				cond(operatorv1.LoadBalancerManagedIngressConditionType, operatorv1.ConditionTrue, "", clock.Now()),
+				cond(operatorv1.LoadBalancerReadyIngressConditionType, operatorv1.ConditionUnknown, "", clock.Now()),
 			},
-			expect: operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			availableReplicas: 0,
+			expect:            operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue:     true,
+			expectAfter:       time.Minute,
 		},
 		{
-			description: "all availability not present",
-			conditions:  []operatorv1.OperatorCondition{},
-			expect:      operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			description:   "all availability not present",
+			conditions:    []operatorv1.OperatorCondition{},
+			expect:        operatorv1.OperatorCondition{Type: operatorv1.OperatorStatusTypeAvailable, Status: operatorv1.ConditionFalse},
+			expectRequeue: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			actual := computeIngressAvailableCondition(tc.conditions)
+			actual, err := computeIngressAvailableCondition(tc.conditions, tc.availableReplicas)
+			switch e := err.(type) {
+			case retryable.Error:
+				if !tc.expectRequeue {
+					t.Error("expected not to be told to requeue")
+				}
+				if tc.expectAfter.Seconds() != e.After().Seconds() {
+					t.Errorf("expected requeue after %s, got %s", tc.expectAfter.String(), e.After().String())
+				}
+			case nil:
+				if tc.expectRequeue {
+					t.Error("expected to be told to requeue")
+				}
+			default:
+				t.Fatalf("unexpected error: %v", err)
+			}
 			conditionsCmpOpts := []cmp.Option{
 				cmpopts.IgnoreFields(operatorv1.OperatorCondition{}, "LastTransitionTime", "Reason", "Message"),
 				cmpopts.EquateEmpty(),
@@ -2035,6 +2102,27 @@ func Test_computeIngressAvailableCondition(t *testing.T) {
 				t.Fatalf("expected %#v, got %#v", tc.expect, actual)
 			}
 		})
+	}
+}
+
+func Test_findOperatorCondition(t *testing.T) {
+	conditions := []operatorv1.OperatorCondition{
+		cond(IngressControllerDeploymentAvailableConditionType, operatorv1.ConditionTrue, "DeploymentAvailable", time.Time{}),
+		cond(operatorv1.OperatorStatusTypeDegraded, operatorv1.ConditionFalse, "", time.Time{}),
+	}
+
+	if found, ok := findOperatorCondition(conditions, IngressControllerDeploymentAvailableConditionType); !ok {
+		t.Error("expected to find DeploymentAvailable condition")
+	} else if found.Status != operatorv1.ConditionTrue {
+		t.Errorf("expected status %s, got %s", operatorv1.ConditionTrue, found.Status)
+	}
+
+	if _, ok := findOperatorCondition(conditions, "NonExistent"); ok {
+		t.Error("expected not to find a non-existent condition type")
+	}
+
+	if _, ok := findOperatorCondition(nil, IngressControllerDeploymentAvailableConditionType); ok {
+		t.Error("expected not to find any condition in a nil slice")
 	}
 }
 


### PR DESCRIPTION
… blips

The IngressController Available condition immediately transitioned to False when the deployment reported DeploymentAvailable=False, even for transient blips lasting only ~30 seconds during pod rescheduling or node disruption. This caused the ClusterOperator Available condition to blip False, failing the CI invariant test
"clusteroperator/ingress should not change condition/Available".

The Degraded condition already had a 30-second grace period for DeploymentAvailable, but the Available condition had none. Add a 60-second grace period to computeIngressAvailableCondition for the DeploymentAvailable check, mirroring the existing grace period pattern. During the grace period, the IngressController remains Available=True and a requeue is scheduled to re-evaluate after the period expires.

Applying a blanket grace period to Available introduces two risks, which this change also addresses:

- A genuine full outage (zero available replicas) would otherwise be masked for up to 60 seconds instead of being reported immediately. The grace period is now only granted when at least one replica is still available; if availableReplicas is 0, DeploymentAvailable is evaluated with no grace period.

- A deployment that flaps quickly between available and unavailable (each unavailable period under 60s) can indefinitely avoid tripping Available=False, since the grace window resets on every transition back to True. This flapping is now independently observable via a new ingress_controller_deployment_available_transitions_total counter metric, incremented whenever DeploymentAvailable changes status, regardless of whether the grace period masks it in Available/Degraded.