### PR TITLE
coderabbit: add AGENTS_LEARNING signal to review instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 language: en-US
+inheritance: true
 reviews:
   profile: chill
   high_level_summary: false
@@ -20,3 +21,16 @@ reviews:
   - "!**/vendor/**"
   - "!vendor/**"
 
+instructions: |
+  While reviewing, if you encounter a pattern, constraint, naming convention,
+  or architectural rule that is non-obvious and not already documented in
+  AGENTS.md or the .agents/ directory, append a section at the end of your
+  review summary in this exact format:
+
+  <!-- AGENTS_LEARNING
+  file: .agents/<context|architecture|controllers|dns|testing|rules|building>.md
+  learning: <one concise sentence describing what should be added>
+  -->
+
+  Only emit this block when the learning is specific and non-obvious —
+  not for things a Go developer would infer from reading the code.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,19 @@ language: en-US
 inheritance: true
 reviews:
   profile: chill
-  high_level_summary: false
+  high_level_summary: true
+  high_level_summary_instructions: |
+    At the end of your summary, if you encountered any non-obvious pattern,
+    constraint, naming convention, or architectural rule that is missing from
+    AGENTS.md or the .agents/ directory, append this exact block:
+
+    <!-- AGENTS_LEARNING
+    file: .agents/<context|architecture|controllers|dns|testing|rules|building>.md
+    learning: <one concise sentence describing what should be added>
+    -->
+
+    Only emit this block when the learning is specific and non-obvious —
+    not for things a Go developer would infer from reading the code.
   review_status: true
   commit_status: true
   collapse_walkthrough: true
@@ -20,17 +32,3 @@ reviews:
   path_filters:
   - "!**/vendor/**"
   - "!vendor/**"
-
-instructions: |
-  While reviewing, if you encounter a pattern, constraint, naming convention,
-  or architectural rule that is non-obvious and not already documented in
-  AGENTS.md or the .agents/ directory, append a section at the end of your
-  review summary in this exact format:
-
-  <!-- AGENTS_LEARNING
-  file: .agents/<context|architecture|controllers|dns|testing|rules|building>.md
-  learning: <one concise sentence describing what should be added>
-  -->
-
-  Only emit this block when the learning is specific and non-obvious —
-  not for things a Go developer would infer from reading the code.

--- a/pkg/operator/controller/ingress/status.go
+++ b/pkg/operator/controller/ingress/status.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	"github.com/openshift/cluster-ingress-operator/pkg/resources/status"
 	"github.com/openshift/cluster-ingress-operator/pkg/util/retryableerror"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -47,11 +49,28 @@ type expectedCondition struct {
 	// or else the condition is not checked.
 	ifConditionsTrue []string
 	gracePeriod      time.Duration
+	// ignoreReasons specifies condition reasons that should be ignored when
+	// determining if the expected condition is met. This allows distinguishing
+	// between significant state changes (configuration rollouts) and transient
+	// infrastructure events (node reboots, pod restarts).
+	// ignoreReasons are only consulted when the condition exists and its Status
+	// differs from expected.status; they are not consulted if the condition is
+	// entirely missing.
+	ignoreReasons []string
 }
+
+const (
+	ReasonDeploymentRollingOut = "DeploymentRollingOut"
+	ReasonNotRollingOut        = "DeploymentNotRollingOut"
+	ReasonPodsStarting         = "PodsStarting"
+	ReasonReplicasStabilizing  = "ReplicasStabilizing"
+
+	deploymentNewRSAvailableReason = "NewReplicaSetAvailable"
+)
 
 // syncIngressControllerStatus computes the current status of ic and
 // updates status upon any changes since last sync.
-func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, deploymentRef metav1.OwnerReference, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS, platformStatus *configv1.PlatformStatus) (error, bool) {
+func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressController, deployment *appsv1.Deployment, deploymentRef metav1.OwnerReference, pods []corev1.Pod, service *corev1.Service, operandEvents []corev1.Event, wildcardRecord *iov1.DNSRecord, dnsConfig *configv1.DNS, platformStatus *configv1.PlatformStatus, ingressConfig *configv1.Ingress) (error, bool) {
 	updatedIc := false
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
@@ -84,22 +103,28 @@ func (r *reconciler) syncIngressControllerStatus(ic *operatorv1.IngressControlle
 		updateIngressControllerFloatingIPOpenStackStatus(updated, service)
 	}
 
+	haproxyVersion, _, err := getEffectiveHAProxyVersionAndImage(ic, &r.config, ingressConfig)
+	if err != nil {
+		errs = append(errs, err)
+		haproxyVersion = ""
+	}
+	updated.Status.EffectiveHAProxyVersion = haproxyVersion
+
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentAvailableCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasMinAvailableCondition(deployment, pods))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentReplicasAllAvailableCondition(deployment))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDeploymentRollingOutCondition(deployment))
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeLoadBalancerStatus(ic, service, operandEvents)...)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeLoadBalancerStatus(ic, service, operandEvents, false)...)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeLoadBalancerProgressingStatus(updated, service, platformStatus))
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeDNSStatus(ic, wildcardRecord, platformStatus, dnsConfig)...)
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, status.ComputeDNSStatus(ic, wildcardRecord, platformStatus, dnsConfig, false)...)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressAvailableCondition(updated.Status.Conditions))
 	degradedCondition, err := computeIngressDegradedCondition(updated.Status.Conditions, updated.Name)
 	errs = append(errs, err)
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressProgressingCondition(updated.Status.Conditions))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, degradedCondition)
-	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressUpgradeableCondition(ic, deploymentRef, service, platformStatus, secret))
+	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressUpgradeableCondition(updated, r.config, deploymentRef, service, platformStatus, secret))
 	updated.Status.Conditions = MergeConditions(updated.Status.Conditions, computeIngressEvaluationConditionsDetectedCondition(ic, service))
 
-	updated.Status.Conditions = PruneConditions(updated.Status.Conditions)
 
 	if !IngressStatusesEqual(updated.Status, ic.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {
@@ -157,18 +182,6 @@ func MergeConditions(conditions []operatorv1.OperatorCondition, updates ...opera
 	return conditions
 }
 
-// PruneConditions removes any conditions that are not currently supported.
-// Returns the updated condition array.
-func PruneConditions(conditions []operatorv1.OperatorCondition) []operatorv1.OperatorCondition {
-	for i, condition := range conditions {
-		// PodsScheduled was removed in 4.13.0.
-		// TODO: Remove this fix-up logic in 4.14.
-		if condition.Type == "PodsScheduled" {
-			conditions = append(conditions[:i], conditions[i+1:]...)
-		}
-	}
-	return conditions
-}
 
 // computeIngressTLSProfile computes the ingresscontroller's current TLS
 // profile.  If the deployment is ready, then the TLS profile is inferred from
@@ -332,7 +345,7 @@ func checkConditions(expectedConds []expectedCondition, conditions []operatorv1.
 		if !haveCondition {
 			continue
 		}
-		if condition.Status == expected.status {
+		if condition.Status == expected.status || slices.Contains(expected.ignoreReasons, condition.Reason) {
 			continue
 		}
 		failedPredicates := false
@@ -505,12 +518,13 @@ func computeDeploymentReplicasAllAvailableCondition(deployment *appsv1.Deploymen
 // of expected or available replicas.
 // See Reference: https://github.com/kubernetes/kubectl/blob/master/pkg/polymorphichelpers/rollout_status.go
 func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operatorv1.OperatorCondition {
-	// If have replicas is less than want replicas, then we are waiting for replicas to be updated.
+	// If updated replicas is less than desired replicas, then we are waiting for updated replicas to be created.
 	if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d out of %d new replica(s) have been updated...\n",
 				deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas),
@@ -518,10 +532,11 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	}
 	// If have replicas greater than updated replicas, then we are waiting for old replicas to terminate.
 	if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d old replica(s) are pending termination...\n",
 				deployment.Status.Replicas-deployment.Status.UpdatedReplicas),
@@ -529,10 +544,11 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	}
 	// If available replicas less than updated replicas, then we are waiting for updated replicas to become available.
 	if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+		reason := computeDeploymentRollingOutReason(deployment)
 		return operatorv1.OperatorCondition{
 			Type:   IngressControllerDeploymentRollingOutConditionType,
 			Status: operatorv1.ConditionTrue,
-			Reason: "DeploymentRollingOut",
+			Reason: reason,
 			Message: fmt.Sprintf(
 				"Waiting for router deployment rollout to finish: %d of %d updated replica(s) are available...\n",
 				deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas),
@@ -542,9 +558,58 @@ func computeDeploymentRollingOutCondition(deployment *appsv1.Deployment) operato
 	return operatorv1.OperatorCondition{
 		Type:    IngressControllerDeploymentRollingOutConditionType,
 		Status:  operatorv1.ConditionFalse,
-		Reason:  "DeploymentNotRollingOut",
+		Reason:  ReasonNotRollingOut,
 		Message: "Deployment is not actively rolling out",
 	}
+}
+
+// computeDeploymentRollingOutReason computes the Reason for the DeploymentRollingOut
+// condition by checking the deployment's "NewReplicaSetAvailable" condition, pod
+// replica counts, and generation metadata to distinguish between an ingress
+// controller configuration rollout and an infrastructure-driven change (e.g.
+// node reboot, scale up/down).
+func computeDeploymentRollingOutReason(deployment *appsv1.Deployment) string {
+	// Check if the deployment has the "NewReplicaSetAvailable" condition.
+	// This indicates that Kubernetes has successfully completed a rollout.
+	hasNewReplicaSetAvailable := false
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == appsv1.DeploymentProgressing &&
+			cond.Status == corev1.ConditionTrue &&
+			cond.Reason == deploymentNewRSAvailableReason {
+			hasNewReplicaSetAvailable = true
+			break
+		}
+	}
+
+	var (
+		wantReplicas      = int32(1)
+		haveReplicas      = deployment.Status.Replicas
+		updatedReplicas   = deployment.Status.UpdatedReplicas
+		availableReplicas = deployment.Status.AvailableReplicas
+	)
+
+	if deployment.Spec.Replicas != nil {
+		wantReplicas = *deployment.Spec.Replicas
+	}
+
+	currentGen := deployment.Generation
+	observedGen := deployment.Status.ObservedGeneration
+	if hasNewReplicaSetAvailable && currentGen == observedGen && updatedReplicas == wantReplicas {
+		if haveReplicas != wantReplicas {
+			return ReasonReplicasStabilizing
+		}
+	}
+
+	// If rollout was previously completed and now only availability is lagging,
+	// treat it as infrastructure-driven pod startup.
+	if hasNewReplicaSetAvailable &&
+		currentGen == observedGen &&
+		updatedReplicas == wantReplicas &&
+		haveReplicas == wantReplicas &&
+		availableReplicas < wantReplicas {
+		return ReasonPodsStarting
+	}
+	return ReasonDeploymentRollingOut
 }
 
 // computeIngressDegradedCondition computes the ingresscontroller's "Degraded"
@@ -595,12 +660,7 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition, 
 	// Only check the default ingress controller for the canary
 	// success status condition.
 	if icName == manifests.DefaultIngressControllerName {
-		canaryCond := struct {
-			condition        string
-			status           operatorv1.ConditionStatus
-			ifConditionsTrue []string
-			gracePeriod      time.Duration
-		}{
+		canaryCond := expectedCondition{
 			condition:   IngressControllerCanaryCheckSuccessConditionType,
 			status:      operatorv1.ConditionTrue,
 			gracePeriod: time.Second * 60,
@@ -646,10 +706,12 @@ func computeIngressDegradedCondition(conditions []operatorv1.OperatorCondition, 
 }
 
 // computeIngressUpgradeableCondition computes the IngressController's "Upgradeable" status condition.
-func computeIngressUpgradeableCondition(ic *operatorv1.IngressController, deploymentRef metav1.OwnerReference, service *corev1.Service, platform *configv1.PlatformStatus, secret *corev1.Secret) operatorv1.OperatorCondition {
+func computeIngressUpgradeableCondition(ic *operatorv1.IngressController, config Config, deploymentRef metav1.OwnerReference, service *corev1.Service, platform *configv1.PlatformStatus, secret *corev1.Secret) operatorv1.OperatorCondition {
 	var errs []error
 
 	errs = append(errs, checkDefaultCertificate(secret, "*."+ic.Status.Domain))
+
+	errs = append(errs, checkDeprecatedHAProxyVersion(ic, config.DeprecatedHAProxyVersion))
 
 	if service != nil {
 		errs = append(errs, loadBalancerServiceIsUpgradeable(ic, deploymentRef, service, platform))
@@ -739,6 +801,15 @@ func checkDefaultCertificate(secret *corev1.Secret, domain string) error {
 	return nil
 }
 
+// checkDeprecatedHAProxyVersion returns an error if the provided IngressController
+// resource references a HAProxy version unsupported in the next release.
+func checkDeprecatedHAProxyVersion(ic *operatorv1.IngressController, deprecatedHAProxyVersion []string) error {
+	if version := string(ic.Status.EffectiveHAProxyVersion); slices.Contains(deprecatedHAProxyVersion, version) {
+		return fmt.Errorf("haproxy %q is being removed in the next release; update or unset spec.haproxyVersion before upgrading", version)
+	}
+	return nil
+}
+
 func formatConditions(conditions []*operatorv1.OperatorCondition) string {
 	var formatted string
 	if len(conditions) == 0 {
@@ -767,6 +838,12 @@ func computeIngressProgressingCondition(conditions []operatorv1.OperatorConditio
 		{
 			condition: IngressControllerDeploymentRollingOutConditionType,
 			status:    operatorv1.ConditionFalse,
+			// Ignore infrastructure-driven deployment rollouts when computing
+			// the IngressController's Progressing condition.
+			ignoreReasons: []string{
+				ReasonReplicasStabilizing, // Node reboots, pod evictions
+				ReasonPodsStarting,        // Pods restarting after infrastructure events
+			},
 		},
 	}
 
@@ -855,6 +932,12 @@ func IngressStatusesEqual(a, b operatorv1.IngressControllerStatus) bool {
 		return false
 	}
 	if getOpenStackFloatingIPInEPS(a.EndpointPublishingStrategy) != getOpenStackFloatingIPInEPS(b.EndpointPublishingStrategy) {
+		return false
+	}
+	if a.EffectiveHAProxyVersion != b.EffectiveHAProxyVersion {
+		return false
+	}
+	if getAWSNLBProtocol(a.EndpointPublishingStrategy) != getAWSNLBProtocol(b.EndpointPublishingStrategy) {
 		return false
 	}
 
@@ -974,74 +1057,6 @@ func conditionsEqual(a, b []operatorv1.OperatorCondition) bool {
 	return cmp.Equal(a, b, conditionCmpOpts...)
 }
 
-// computeLoadBalancerStatus returns the set of current
-// LoadBalancer-prefixed conditions for the given ingress controller, which are
-// used later to determine the ingress controller's Degraded or Available status.
-func computeLoadBalancerStatus(ic *operatorv1.IngressController, service *corev1.Service, operandEvents []corev1.Event) []operatorv1.OperatorCondition {
-	// Compute the LoadBalancerManagedIngressConditionType condition
-	if ic.Status.EndpointPublishingStrategy == nil ||
-		ic.Status.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    operatorv1.LoadBalancerManagedIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "EndpointPublishingStrategyExcludesManagedLoadBalancer",
-				Message: "The configured endpoint publishing strategy does not include a managed load balancer",
-			},
-		}
-	}
-
-	conditions := []operatorv1.OperatorCondition{}
-
-	conditions = append(conditions, operatorv1.OperatorCondition{
-		Type:    operatorv1.LoadBalancerManagedIngressConditionType,
-		Status:  operatorv1.ConditionTrue,
-		Reason:  "WantedByEndpointPublishingStrategy",
-		Message: "The endpoint publishing strategy supports a managed load balancer",
-	})
-
-	// Compute the LoadBalancerReadyIngressConditionType condition
-	switch {
-	case service == nil:
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  "ServiceNotFound",
-			Message: "The LoadBalancer service resource is missing",
-		})
-	case isProvisioned(service):
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "LoadBalancerProvisioned",
-			Message: "The LoadBalancer service is provisioned",
-		})
-	case isPending(service):
-		reason := "LoadBalancerPending"
-		message := "The LoadBalancer service is pending"
-
-		// Try and find a more specific reason for for the pending status.
-		createFailedReason := "SyncLoadBalancerFailed"
-		failedLoadBalancerEvents := getEventsByReason(operandEvents, "service-controller", createFailedReason)
-		for _, event := range failedLoadBalancerEvents {
-			involved := event.InvolvedObject
-			if involved.Kind == "Service" && involved.Namespace == service.Namespace && involved.Name == service.Name && involved.UID == service.UID {
-				reason = "SyncLoadBalancerFailed"
-				message = fmt.Sprintf("The %s component is reporting SyncLoadBalancerFailed events like: %s\n%s",
-					event.Source.Component, event.Message, "The cloud-controller-manager logs may contain more details.")
-				break
-			}
-		}
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.LoadBalancerReadyIngressConditionType,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  reason,
-			Message: message,
-		})
-	}
-	return conditions
-}
-
 // computeLoadBalancerProgressingStatus returns the LoadBalancerProgressing
 // conditions for the given ingress controller. These conditions subsequently determine
 // the ingress controller's Progressing status.
@@ -1153,139 +1168,6 @@ func updateIngressControllerFloatingIPOpenStackStatus(ic *operatorv1.IngressCont
 		ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.OpenStack != nil {
 		ic.Status.EndpointPublishingStrategy.LoadBalancer.ProviderParameters.OpenStack.FloatingIP = getLoadBalancerIPFromService(service)
 	}
-}
-
-func isProvisioned(service *corev1.Service) bool {
-	ingresses := service.Status.LoadBalancer.Ingress
-	return len(ingresses) > 0 && (len(ingresses[0].Hostname) > 0 || len(ingresses[0].IP) > 0)
-}
-
-func isPending(service *corev1.Service) bool {
-	return !isProvisioned(service)
-}
-
-func getEventsByReason(events []corev1.Event, component, reason string) []corev1.Event {
-	var filtered []corev1.Event
-	for i := range events {
-		event := events[i]
-		if event.Source.Component == component && event.Reason == reason {
-			filtered = append(filtered, event)
-		}
-	}
-	return filtered
-}
-
-func computeDNSStatus(ic *operatorv1.IngressController, wildcardRecord *iov1.DNSRecord, status *configv1.PlatformStatus, dnsConfig *configv1.DNS) []operatorv1.OperatorCondition {
-	if dnsConfig.Spec.PublicZone == nil && dnsConfig.Spec.PrivateZone == nil {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    operatorv1.DNSManagedIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "NoDNSZones",
-				Message: "No DNS zones are defined in the cluster dns config.",
-			},
-		}
-	}
-
-	if ic.Status.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
-		return []operatorv1.OperatorCondition{
-			{
-				Type:    operatorv1.DNSManagedIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "UnsupportedEndpointPublishingStrategy",
-				Message: "The endpoint publishing strategy doesn't support DNS management.",
-			},
-		}
-	}
-	var conditions []operatorv1.OperatorCondition
-	// The default value for DNSManagementPolicy is "Managed".
-	if lb := ic.Status.EndpointPublishingStrategy.LoadBalancer; lb != nil && lb.DNSManagementPolicy == operatorv1.UnmanagedLoadBalancerDNS {
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.DNSManagedIngressConditionType,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  "UnmanagedLoadBalancerDNS",
-			Message: "The DNS management policy is set to Unmanaged.",
-		})
-	} else {
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.DNSManagedIngressConditionType,
-			Status:  operatorv1.ConditionTrue,
-			Reason:  "Normal",
-			Message: "DNS management is supported and zones are specified in the cluster DNS config.",
-		})
-	}
-
-	switch {
-	case wildcardRecord == nil:
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.DNSReadyIngressConditionType,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  "RecordNotFound",
-			Message: "The wildcard record resource was not found.",
-		})
-	case wildcardRecord.Spec.DNSManagementPolicy == iov1.UnmanagedDNS:
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.DNSReadyIngressConditionType,
-			Status:  operatorv1.ConditionUnknown,
-			Reason:  "UnmanagedDNS",
-			Message: "The DNS management policy is set to Unmanaged.",
-		})
-	case len(wildcardRecord.Status.Zones) == 0:
-		conditions = append(conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.DNSReadyIngressConditionType,
-			Status:  operatorv1.ConditionFalse,
-			Reason:  "NoZones",
-			Message: "The record isn't present in any zones.",
-		})
-	case len(wildcardRecord.Status.Zones) > 0:
-		var failedZones []configv1.DNSZone
-		var unknownZones []configv1.DNSZone
-		for _, zone := range wildcardRecord.Status.Zones {
-			for _, cond := range zone.Conditions {
-				if cond.Type != iov1.DNSRecordPublishedConditionType {
-					continue
-				}
-				if !checkZoneInConfig(dnsConfig, zone.DNSZone) {
-					continue
-				}
-				switch cond.Status {
-				case string(operatorv1.ConditionFalse):
-					// check to see if the zone is in the dnsConfig.Spec
-					// fix:BZ1942657 - relates to status changes when updating DNS PrivateZone config
-					failedZones = append(failedZones, zone.DNSZone)
-				case string(operatorv1.ConditionUnknown):
-					unknownZones = append(unknownZones, zone.DNSZone)
-				}
-			}
-		}
-		if len(failedZones) != 0 {
-			// TODO: Add failed condition reasons
-			conditions = append(conditions, operatorv1.OperatorCondition{
-				Type:    operatorv1.DNSReadyIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "FailedZones",
-				Message: fmt.Sprintf("The record failed to provision in some zones: %v", failedZones),
-			})
-		} else if len(unknownZones) != 0 {
-			// This condition is an edge case where DNSManaged=True but
-			// there was an internal error during publishing record.
-			conditions = append(conditions, operatorv1.OperatorCondition{
-				Type:    operatorv1.DNSReadyIngressConditionType,
-				Status:  operatorv1.ConditionFalse,
-				Reason:  "UnknownZones",
-				Message: fmt.Sprintf("Provisioning of the record is in an unknown state in some zones: %v", unknownZones),
-			})
-		} else {
-			conditions = append(conditions, operatorv1.OperatorCondition{
-				Type:    operatorv1.DNSReadyIngressConditionType,
-				Status:  operatorv1.ConditionTrue,
-				Reason:  "NoFailedZones",
-				Message: "The record is provisioned in all reported zones.",
-			})
-		}
-	}
-
-	return conditions
 }
 
 // checkZoneInConfig - private utility to check for a zone in the current config


### PR DESCRIPTION
## Summary

- Adds a custom `instructions` block to `.coderabbit.yaml` asking CodeRabbit to emit an `<!-- AGENTS_LEARNING -->` signal when it encounters non-obvious patterns or rules during PR review that are missing from `AGENTS.md` / `.agents/`
- The signal is invisible in the GitHub UI but parseable by future automation
- Only fires for specific, non-obvious learnings — not general Go conventions

## Why

Our `AGENTS.md` is currently a static, manually-maintained document. The goal is to make it a living document that improves reactively based on what CodeRabbit actually catches in reviews, rather than trying to anticipate everything upfront (per the emerging team consensus from the agentic SDLC discussion).

## Test plan

- [ ] Comment `@coderabbitai review` on this PR to verify CodeRabbit follows the new instructions
- [ ] Confirm the `<!-- AGENTS_LEARNING -->` block appears in the review summary when applicable
- [ ] If signal is consistent, wire up automation to open AGENTS.md PRs from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enable configuration inheritance and high-level summaries in `.coderabbit.yaml`.
- Instruct CodeRabbit to emit hidden `<!-- AGENTS_LEARNING -->` blocks for specific, non-obvious project guidance that is missing from `AGENTS.md` or `.agents/`.
- Update ingress status reconciliation to use ingress configuration and shared load balancer and DNS helpers.
- Record the effective HAProxy version and AWS NLB protocol in status comparisons.
- Distinguish deployment configuration rollouts from replica stabilization and pod startup.
- Ignore infrastructure rollout reasons when evaluating `Progressing` status.
- Check deprecated HAProxy versions when evaluating upgradeability.
- Add exported rollout reason constants and update status function signatures.

## Testing

- Trigger CodeRabbit reviews.
- Verify that the signal appears when applicable.
- Evaluate automation for updating `AGENTS.md` from the signal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->