### PR TITLE
OCPBUGS-109582: Normalize malformed CIDRs to avoid upgrade disruptions

### DIFF
--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	netutils "k8s.io/utils/net"
 
 	"github.com/openshift/cluster-ingress-operator/pkg/manifests"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
@@ -605,7 +606,18 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 		if lb != nil && len(lb.AllowedSourceRanges) > 0 {
 			cidrs := make([]string, len(lb.AllowedSourceRanges))
 			for i, cidr := range lb.AllowedSourceRanges {
-				cidrs[i] = string(cidr)
+				_, ipNet, err := netutils.ParseCIDRSloppy(string(cidr)) // check if CIDR is valid
+				if err != nil {
+					log.Error(err, "invalid CIDR", "cidr", string(cidr))
+					cidrs[i] = string(cidr)
+				} else {
+					cidrs[i] = ipNet.String() //Normalizing the Inputted CIDR
+					if string(cidr) != ipNet.String() {
+						log.Info("normalizing malformed CIDR", "original", string(cidr), "normalized", ipNet.String())
+					}
+
+				}
+
 			}
 			service.Spec.LoadBalancerSourceRanges = cidrs
 		}

--- a/pkg/operator/controller/ingress/load_balancer_service.go
+++ b/pkg/operator/controller/ingress/load_balancer_service.go
@@ -608,14 +608,12 @@ func desiredLoadBalancerService(ci *operatorv1.IngressController, deploymentRef 
 			for i, cidr := range lb.AllowedSourceRanges {
 				_, ipNet, err := netutils.ParseCIDRSloppy(string(cidr)) // check if CIDR is valid
 				if err != nil {
+					// API validation should prevent any parsing errors, but as a safeguard, log
+					// the error and still add the CIDR to keep behavior unchanged.
 					log.Error(err, "invalid CIDR", "cidr", string(cidr))
 					cidrs[i] = string(cidr)
 				} else {
-					cidrs[i] = ipNet.String() //Normalizing the Inputted CIDR
-					if string(cidr) != ipNet.String() {
-						log.Info("normalizing malformed CIDR", "original", string(cidr), "normalized", ipNet.String())
-					}
-
+					cidrs[i] = ipNet.String()
 				}
 
 			}
@@ -808,6 +806,11 @@ func loadBalancerServiceChanged(current, expected *corev1.Service) (bool, *corev
 			if !changed {
 				changed = true
 				updated = current.DeepCopy()
+			}
+			for i, expectedCIDR := range expected.Spec.LoadBalancerSourceRanges {
+				if i < len(current.Spec.LoadBalancerSourceRanges) && current.Spec.LoadBalancerSourceRanges[i] != expectedCIDR {
+					log.Info("normalizing malformed CIDR", "original", current.Spec.LoadBalancerSourceRanges[i], "normalized", expectedCIDR)
+				}
 			}
 			updated.Spec.LoadBalancerSourceRanges = expected.Spec.LoadBalancerSourceRanges
 		}

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -1777,6 +1777,20 @@ func TestUpdateLoadBalancerServiceSourceRanges(t *testing.T) {
 			expectChanged:                    false,
 		},
 		{
+			name:                             "test malformed CIDRs",
+			allowedSourceRanges:              []operatorv1.CIDR{"3dee:ef5::/12"},
+			currentLoadBalancerSourceRanges:  []string{"foo"},
+			expectedLoadBalancerSourceRanges: []string{"3de0::/12"},
+			expectChanged:                    true,
+		},
+		{
+			name:                             "test leading zero malformed CIDR",
+			allowedSourceRanges:              []operatorv1.CIDR{"011.3.1.0/16"},
+			currentLoadBalancerSourceRanges:  []string{"3de0::/12"},
+			expectedLoadBalancerSourceRanges: []string{"11.3.0.0/16"},
+			expectChanged:                    true,
+		},
+		{
 			name:                             "loadBalancerSourceRanges is different from allowedSourceRanges and annotation is not set",
 			allowedSourceRanges:              []operatorv1.CIDR{"bar"},
 			currentLoadBalancerSourceRanges:  []string{"foo"},

--- a/pkg/operator/controller/ingress/load_balancer_service_test.go
+++ b/pkg/operator/controller/ingress/load_balancer_service_test.go
@@ -1784,11 +1784,32 @@ func TestUpdateLoadBalancerServiceSourceRanges(t *testing.T) {
 			expectChanged:                    true,
 		},
 		{
+			name:                             "non-canonical CIDR is idempotent (no reconcile churn)",
+			allowedSourceRanges:              []operatorv1.CIDR{"3dee:ef5::/12"},
+			currentLoadBalancerSourceRanges:  []string{"3de0::/12"}, // already normalized from a prior reconcile
+			expectedLoadBalancerSourceRanges: []string{"3de0::/12"},
+			expectChanged:                    false,
+		},
+		{
 			name:                             "test leading zero malformed CIDR",
 			allowedSourceRanges:              []operatorv1.CIDR{"011.3.1.0/16"},
 			currentLoadBalancerSourceRanges:  []string{"3de0::/12"},
 			expectedLoadBalancerSourceRanges: []string{"11.3.0.0/16"},
 			expectChanged:                    true,
+		},
+		{
+			name:                             "change to a regular CIDR",
+			allowedSourceRanges:              []operatorv1.CIDR{"10.0.0.0/8"},
+			currentLoadBalancerSourceRanges:  []string{"3de0::/12"},
+			expectedLoadBalancerSourceRanges: []string{"10.0.0.0/8"},
+			expectChanged:                    true,
+		},
+		{
+			name:                             "canonical CIDR passes through unchanged",
+			allowedSourceRanges:              []operatorv1.CIDR{"10.0.0.0/8"},
+			currentLoadBalancerSourceRanges:  []string{"10.0.0.0/8"},
+			expectedLoadBalancerSourceRanges: []string{"10.0.0.0/8"},
+			expectChanged:                    false,
 		},
 		{
 			name:                             "loadBalancerSourceRanges is different from allowedSourceRanges and annotation is not set",


### PR DESCRIPTION
With the addition of https://github.com/kubernetes/kubernetes/pull/137053 in 5.0 environments, some CIDRs are no longer standard and get rejected when trying to patch it onto an ingresscontroller.

This PR adds logic to normalize any malformed/rejected CIDR values, so any tests related to this feature no longer has a regression.