### PR TITLE
NE-2856: Fix staticcheck warnings across multiple packages

### DIFF
--- a/pkg/dns/azure/client/client.go
+++ b/pkg/dns/azure/client/client.go
@@ -73,6 +73,9 @@ type dnsClient struct {
 // New returns an authenticated DNSClient
 func New(config Config) (DNSClient, error) {
 	credential, err := getAzureCredentials(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get azure credentials")
+	}
 	rsc, err := newRecordSetClient(config, credential)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create recordSetClient")

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -55,9 +55,8 @@ type Config struct {
 }
 
 type provider struct {
-	config       Config
-	client       client.DNSClient
-	clientConfig client.Config
+	config Config
+	client client.DNSClient
 }
 
 // NewProvider creates a new dns.Provider for Azure. It only supports DNSRecords with

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -22,6 +22,6 @@ var _ Provider = &FakeProvider{}
 
 type FakeProvider struct{}
 
-func (_ *FakeProvider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
-func (_ *FakeProvider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
-func (_ *FakeProvider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error { return nil }
+func (*FakeProvider) Ensure(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
+func (*FakeProvider) Delete(record *iov1.DNSRecord, zone configv1.DNSZone) error  { return nil }
+func (*FakeProvider) Replace(record *iov1.DNSRecord, zone configv1.DNSZone) error { return nil }

--- a/pkg/operator/controller/configurable-route/controller.go
+++ b/pkg/operator/controller/configurable-route/controller.go
@@ -291,7 +291,7 @@ func (r *reconciler) deleteOrphanedRoles(componentRoutes []aggregatedComponentRo
 	for _, item := range roleList.Items {
 		expectedHash, ok := item.GetLabels()[componentRouteHashLabelKey]
 		if !ok {
-			errors = append(errors, fmt.Errorf("Unable to find componentRoute hash label on role %s/%s", item.GetNamespace(), item.GetName()))
+			errors = append(errors, fmt.Errorf("unable to find componentRoute hash label on role %s/%s", item.GetNamespace(), item.GetName()))
 			continue
 		}
 

--- a/pkg/operator/controller/gateway-labeler/controller.go
+++ b/pkg/operator/controller/gateway-labeler/controller.go
@@ -98,11 +98,7 @@ func NewUnmanaged(mgr manager.Manager) (controller.Controller, error) {
 		CreateFunc: func(e event.CreateEvent) bool {
 			gatewayClass := e.Object.(*gatewayapiv1.GatewayClass)
 
-			if gatewayClass.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName {
-				return true
-			}
-
-			return false
+			return gatewayClass.Spec.ControllerName == operatorcontroller.OpenShiftGatewayClassControllerName
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Don't reconcile gateways when the gatewayclass is

--- a/pkg/operator/controller/sync-http-error-code-configmap/controller.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/controller.go
@@ -162,10 +162,6 @@ func (r *reconciler) ingressControllersWithConfigMap(ctx context.Context, config
 	if err := r.cache.List(ctx, controllers, client.MatchingFields{"spec.httpErrorCodePages.name": configmapName}); err != nil {
 		return nil, err
 	}
-	names := []string{}
-	for _, ic := range controllers.Items {
-		names = append(names, ic.Name)
-	}
 	return controllers.Items, nil
 }
 

--- a/pkg/operator/controller/sync-http-error-code-configmap/httperrorcode_configmap.go
+++ b/pkg/operator/controller/sync-http-error-code-configmap/httperrorcode_configmap.go
@@ -139,8 +139,5 @@ func (r *reconciler) updateHttpErrorCodeConfigMap(current, desired *corev1.Confi
 // the configmaps should be considered equal for the purpose of determining
 // whether an update is necessary, false otherwise.
 func configmapsEqual(a, b *corev1.ConfigMap) bool {
-	if !reflect.DeepEqual(a.Data, b.Data) {
-		return false
-	}
-	return true
+	return reflect.DeepEqual(a.Data, b.Data)
 }


### PR DESCRIPTION
## Summary

This PR fixes several staticcheck warnings across multiple packages:

- **SA4006** (`pkg/dns/azure/client/client.go`): Add missing error check for `getAzureCredentials()` — the error was silently dropped, which could cause issues if credential retrieval fails.
- **U1000** (`pkg/dns/azure/dns.go`): Remove unused `clientConfig` field from the Azure DNS provider struct.
- **ST1006** (`pkg/dns/dns.go`): Fix underscore receiver names on `FakeProvider` methods — omit receiver name when unused per Go conventions.
- **ST1005** (`pkg/operator/controller/configurable-route/controller.go`): Lowercase error string ("Unable" → "unable") per Go error string conventions.
- **S1008** (`pkg/operator/controller/gateway-labeler/controller.go`): Simplify redundant `if-return-true-return-false` to direct boolean return.
- **SA4006** (`pkg/operator/controller/sync-http-error-code-configmap/controller.go`): Remove unused `names` slice that was built but never consumed.
- **S1008** (`pkg/operator/controller/sync-http-error-code-configmap/httperrorcode_configmap.go`): Simplify `if-not-equal-return-false-return-true` to direct `return reflect.DeepEqual(...)`.

All changes are mechanical and pass `go vet` and `go build`.