### PR TITLE
WAF-3: Implement extension provider capability for WAF

### DIFF
--- a/pkg/operator/controller/gatewayclass/controller_test.go
+++ b/pkg/operator/controller/gatewayclass/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
@@ -17,6 +18,9 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -342,6 +346,51 @@ func Test_Reconcile(t *testing.T) {
 		}
 	}
 
+	mutateForWaf := func(options *install.Options, host string, port uint32) *install.Options {
+		// At this moment, these options should be already set
+		if options == nil || options.Values == nil || options.Values.MeshConfig == nil {
+			return options
+		}
+		if len(options.Values.MeshConfig.ExtensionProviders) == 0 {
+			options.Values.MeshConfig.ExtensionProviders = make([]*sailv1.MeshConfigExtensionProvider, 0)
+		}
+		options.Values.MeshConfig.ExtensionProviders = append(options.Values.MeshConfig.ExtensionProviders,
+			&sailv1.MeshConfigExtensionProvider{
+				Name: new("waf-log-collector"),
+				EnvoyOtelAls: &sailv1.MeshConfigExtensionProviderEnvoyOpenTelemetryLogProvider{
+					Service: new(host),
+					Port:    new(uint32(port)),
+					// Define later if we really need it, or if OTEL can do parsing on its side
+					LogFormat: &sailv1.MeshConfigExtensionProviderEnvoyOpenTelemetryLogProviderLogFormat{
+						Labels: map[string]string{
+							"start_time":     "%START_TIME%",
+							"namespace":      "%ENVIRONMENT(POD_NAMESPACE)%",
+							"gateway":        "%ENVIRONMENT(ISTIO_META_WORKLOAD_NAME)%",
+							"pod_name":       "%ENVIRONMENT(POD_NAME)%",
+							"method":         "%REQ(:METHOD)%",
+							"path":           "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+							"response_code":  "%RESPONSE_CODE%",
+							"response_flags": "%RESPONSE_FLAGS%",
+							"route_name":     "%ROUTE_NAME%",
+							"authority":      "%REQ(:AUTHORITY)%",
+							"duration":       "%DURATION%",
+							"client_ip":      "%REQ(X-FORWARDED-FOR)%",
+							"request_id":     "%REQ(X-REQUEST-ID)%",
+							"sni_hostname":   "%REQUESTED_SERVER_NAME%",
+							"waf_event":      "%FILTER_STATE(wasm.io.coraza.waf.event:PLAIN)%",
+							"rule_id":        "%FILTER_STATE(wasm.io.coraza.waf.rule_id:PLAIN)%",
+							"action":         "%FILTER_STATE(wasm.io.coraza.waf.action:PLAIN)%",
+							"phase":          "%FILTER_STATE(wasm.io.coraza.waf.phase:PLAIN)%",
+							"waf_status":     "%FILTER_STATE(wasm.io.coraza.waf.status:PLAIN)%",
+							"severity":       "%FILTER_STATE(wasm.io.coraza.waf.severity:PLAIN)%",
+							"category":       "%FILTER_STATE(wasm.io.coraza.waf.category:PLAIN)%",
+						},
+					},
+				},
+			})
+		return options
+	}
+
 	tests := []struct {
 		name                             string
 		request                          reconcile.Request
@@ -356,6 +405,7 @@ func Test_Reconcile(t *testing.T) {
 		expectError                      string
 		expectedSailLibraryOptions       *install.Options
 		expectSailLibraryUninstallCalled bool
+		expectedLogMessage               string
 	}{
 		{
 			name:            "OLM mode: Missing cluster infrastructure config and nonexistent gatewayclass",
@@ -906,6 +956,165 @@ func Test_Reconcile(t *testing.T) {
 				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
 					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
 		},
+		{
+			name:              "Sail Library/WAF: Set WAF collector when internal annotation is present",
+			fakeSailInstaller: &fakeSailInstaller{},
+			request:           req("openshift-default"),
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:4317",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:4317",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: mutateForWaf(expectedSailLibraryOptions(
+				"v1.24.4",
+				false,
+				nil,
+				gatewayclassesConfig(gatewayclassConfig(2), "openshift-default"),
+				expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+				"some.collector.tld", 4317),
+		},
+		{
+			name:               "Sail Library/WAF: Set WAF collector without a port does not mutate the configuration",
+			fakeSailInstaller:  &fakeSailInstaller{},
+			request:            req("openshift-default"),
+			expectedLogMessage: "invalid value for WAF collector host:port, skipping",
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
+		{
+			name:               "Sail Library/WAF: Set WAF collector with a invalid port does not mutate the configuration",
+			fakeSailInstaller:  &fakeSailInstaller{},
+			request:            req("openshift-default"),
+			expectedLogMessage: "invalid value for WAF collector port, skipping",
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:xxxxx",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:xxxxx",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
+		{
+			name:               "Sail Library/WAF: Set WAF collector with a port 0 does not mutate the configuration",
+			fakeSailInstaller:  &fakeSailInstaller{},
+			request:            req("openshift-default"),
+			expectedLogMessage: "invalid value for WAF collector port, skipping",
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:0",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:0",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
+		{
+			name:               "Sail Library/WAF: Set WAF collector with a port bigger than 65535 does not mutate the configuration",
+			fakeSailInstaller:  &fakeSailInstaller{},
+			request:            req("openshift-default"),
+			expectedLogMessage: "invalid value for WAF collector port, skipping",
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:65536",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": "some.collector.tld:65536",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
+		{
+			name:               "Sail Library/WAF: Set WAF collector with a port and no host does not mutate the configuration",
+			fakeSailInstaller:  &fakeSailInstaller{},
+			request:            req("openshift-default"),
+			expectedLogMessage: "WAF collector value does not contain a host, skipping",
+			existingObjects: []client.Object{
+				infraConfig(configv1.HighlyAvailableTopologyMode),
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": ":65536",
+				}, nil, false),
+				apiserverConfig(&configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				}, configv1.TLSAdherencePolicyStrictAllComponents),
+			},
+			expectCreate: []client.Object{
+				manifests.IstiodAllowNetworkPolicy(),
+			},
+			expectedStatusPatched: []client.Object{
+				gatewayClass("openshift-default", true, map[string]string{
+					"internal.do-not-use.openshift.io/waf-otel-collector": ":65536",
+				}, installedConditions(), false),
+			},
+			expectedSailLibraryOptions: expectedSailLibraryOptions(
+				"v1.24.4", false, nil, gatewayclassesConfig(gatewayclassConfig(2),
+					"openshift-default"), expectedTLSConfig(t, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)),
+		},
 	}
 
 	scheme := runtime.NewScheme()
@@ -924,6 +1133,18 @@ func Test_Reconcile(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+
+			coreLog, recorded := observer.New(zapcore.InfoLevel)
+			testZap := zap.New(coreLog)
+
+			origLogger := log
+			t.Cleanup(func() {
+				log = origLogger
+			})
+
+			// 3. Override global logger for the duration of this test
+			log = zapr.NewLogger(testZap).WithName("operator")
+
 			objects := tc.existingObjects
 			if tc.fakeSailInstaller != nil {
 				objects = append(objects, availableIstiodDeployment())
@@ -977,6 +1198,17 @@ func Test_Reconcile(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.expectError)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			if tc.expectedLogMessage != "" {
+				entries := recorded.All()
+				contains := false
+				for i := range entries {
+					if entries[i].Message == tc.expectedLogMessage {
+						contains = true
+					}
+				}
+				assert.True(t, contains, "the test does not contain the expected log message", entries)
 			}
 
 			assert.Equal(t, tc.expectedResult, res)

--- a/pkg/operator/controller/gatewayclass/istio_sail_installer.go
+++ b/pkg/operator/controller/gatewayclass/istio_sail_installer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
@@ -29,6 +31,8 @@ import (
 const (
 	// subscriptionPrefix is the OLM label prefix indicating subscription ownership.
 	subscriptionPrefix = "operators.coreos.com/"
+
+	wafOtelCollectorAnnotation = "internal.do-not-use.openshift.io/waf-otel-collector"
 )
 
 // overwriteOLMManagedCRDFunc is used as a predicate function by the Sail Library to determine
@@ -276,6 +280,71 @@ func openshiftValues(enableInferenceExtension bool, operandNamespace string, gat
 	} else {
 		val.GatewayClasses = gwClassConfig
 	}
+
+	// (rikatz): This is related to WAF implementation for observability. Once Gateway API
+	// supports TelemetryPolicy + Logging, we can drop this implementation and migrate to
+	// a pure Gateway API approach, that creates a provider per Gateway directly on Istio
+	// outputs
+	// While that, we need a way to signal to sail-installer/Istio that a provider must be
+	// created to ship WAF logs, and this provider is created via this internal annotation
+	for _, gc := range gatewayclasses {
+		if wafOtelval, ok := gc.Annotations[wafOtelCollectorAnnotation]; ok && gc.Name == controller.OpenShiftDefaultGatewayClassName {
+			wafCollectorHost, port, err := net.SplitHostPort(wafOtelval)
+			if err != nil {
+				log.Error(err, "invalid value for WAF collector host:port, skipping", "gatewayclass", gc, "value", wafOtelval)
+				break
+			}
+			if wafCollectorHost == "" {
+				log.Error(err, "WAF collector value does not contain a host, skipping", "gatewayclass", gc, "value", wafOtelval)
+				break
+			}
+			wafCollectorPort, err := strconv.Atoi(port)
+			if err != nil || wafCollectorPort < 1 || wafCollectorPort > 65535 {
+				log.Error(err, "invalid value for WAF collector port, skipping", "gatewayclass", gc, "value", wafOtelval)
+				break
+			}
+
+			if len(val.MeshConfig.ExtensionProviders) == 0 {
+				val.MeshConfig.ExtensionProviders = make([]*sailv1.MeshConfigExtensionProvider, 0)
+			}
+			val.MeshConfig.ExtensionProviders = append(val.MeshConfig.ExtensionProviders, &sailv1.MeshConfigExtensionProvider{
+
+				Name: new("waf-log-collector"),
+				EnvoyOtelAls: &sailv1.MeshConfigExtensionProviderEnvoyOpenTelemetryLogProvider{
+					Service: new(wafCollectorHost),
+					Port:    new(uint32(wafCollectorPort)),
+					// Define later if we really need it, or if OTEL can do parsing on its side
+					LogFormat: &sailv1.MeshConfigExtensionProviderEnvoyOpenTelemetryLogProviderLogFormat{
+						Labels: map[string]string{
+							"start_time":     "%START_TIME%",
+							"namespace":      "%ENVIRONMENT(POD_NAMESPACE)%",
+							"gateway":        "%ENVIRONMENT(ISTIO_META_WORKLOAD_NAME)%",
+							"pod_name":       "%ENVIRONMENT(POD_NAME)%",
+							"method":         "%REQ(:METHOD)%",
+							"path":           "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+							"response_code":  "%RESPONSE_CODE%",
+							"response_flags": "%RESPONSE_FLAGS%",
+							"route_name":     "%ROUTE_NAME%",
+							"authority":      "%REQ(:AUTHORITY)%",
+							"duration":       "%DURATION%",
+							"client_ip":      "%REQ(X-FORWARDED-FOR)%",
+							"request_id":     "%REQ(X-REQUEST-ID)%",
+							"sni_hostname":   "%REQUESTED_SERVER_NAME%",
+							"waf_event":      "%FILTER_STATE(wasm.io.coraza.waf.event:PLAIN)%",
+							"rule_id":        "%FILTER_STATE(wasm.io.coraza.waf.rule_id:PLAIN)%",
+							"action":         "%FILTER_STATE(wasm.io.coraza.waf.action:PLAIN)%",
+							"phase":          "%FILTER_STATE(wasm.io.coraza.waf.phase:PLAIN)%",
+							"waf_status":     "%FILTER_STATE(wasm.io.coraza.waf.status:PLAIN)%",
+							"severity":       "%FILTER_STATE(wasm.io.coraza.waf.severity:PLAIN)%",
+							"category":       "%FILTER_STATE(wasm.io.coraza.waf.category:PLAIN)%",
+						},
+					},
+				},
+			})
+			break
+		}
+	}
+
 	return val, nil
 }
 

--- a/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observer
+
+import "go.uber.org/zap/zapcore"
+
+// A LoggedEntry is an encoding-agnostic representation of a log message.
+// Field availability is context dependent.
+type LoggedEntry struct {
+	zapcore.Entry
+	Context []zapcore.Field
+}
+
+// ContextMap returns a map for all fields in Context.
+func (e LoggedEntry) ContextMap() map[string]interface{} {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, f := range e.Context {
+		f.AddTo(encoder)
+	}
+	return encoder.Fields
+}

--- a/vendor/go.uber.org/zap/zaptest/observer/observer.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/observer.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016-2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package observer provides a zapcore.Core that keeps an in-memory,
+// encoding-agnostic representation of log entries. It's useful for
+// applications that want to unit test their log output without tying their
+// tests to a particular output encoding.
+package observer // import "go.uber.org/zap/zaptest/observer"
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap/internal"
+	"go.uber.org/zap/zapcore"
+)
+
+// ObservedLogs is a concurrency-safe, ordered collection of observed logs.
+type ObservedLogs struct {
+	mu   sync.RWMutex
+	logs []LoggedEntry
+}
+
+// Len returns the number of items in the collection.
+func (o *ObservedLogs) Len() int {
+	o.mu.RLock()
+	n := len(o.logs)
+	o.mu.RUnlock()
+	return n
+}
+
+// All returns a copy of all the observed logs.
+func (o *ObservedLogs) All() []LoggedEntry {
+	o.mu.RLock()
+	ret := make([]LoggedEntry, len(o.logs))
+	copy(ret, o.logs)
+	o.mu.RUnlock()
+	return ret
+}
+
+// TakeAll returns a copy of all the observed logs, and truncates the observed
+// slice.
+func (o *ObservedLogs) TakeAll() []LoggedEntry {
+	o.mu.Lock()
+	ret := o.logs
+	o.logs = nil
+	o.mu.Unlock()
+	return ret
+}
+
+// AllUntimed returns a copy of all the observed logs, but overwrites the
+// observed timestamps with time.Time's zero value. This is useful when making
+// assertions in tests.
+func (o *ObservedLogs) AllUntimed() []LoggedEntry {
+	ret := o.All()
+	for i := range ret {
+		ret[i].Time = time.Time{}
+	}
+	return ret
+}
+
+// FilterLevelExact filters entries to those logged at exactly the given level.
+func (o *ObservedLogs) FilterLevelExact(level zapcore.Level) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Level == level
+	})
+}
+
+// FilterMessage filters entries to those that have the specified message.
+func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Message == msg
+	})
+}
+
+// FilterLoggerName filters entries to those logged through logger with the specified logger name.
+func (o *ObservedLogs) FilterLoggerName(name string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.LoggerName == name
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
+	})
+}
+
+// FilterField filters entries to those that have the specified field.
+func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Equals(field) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// FilterFieldKey filters entries to those that have the specified key.
+func (o *ObservedLogs) FilterFieldKey(key string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Key == key {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// Filter returns a copy of this ObservedLogs containing only those entries
+// for which the provided function returns true.
+func (o *ObservedLogs) Filter(keep func(LoggedEntry) bool) *ObservedLogs {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	var filtered []LoggedEntry
+	for _, entry := range o.logs {
+		if keep(entry) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return &ObservedLogs{logs: filtered}
+}
+
+func (o *ObservedLogs) add(log LoggedEntry) {
+	o.mu.Lock()
+	o.logs = append(o.logs, log)
+	o.mu.Unlock()
+}
+
+// New creates a new Core that buffers logs in memory (without any encoding).
+// It's particularly useful in tests.
+func New(enab zapcore.LevelEnabler) (zapcore.Core, *ObservedLogs) {
+	ol := &ObservedLogs{}
+	return &contextObserver{
+		LevelEnabler: enab,
+		logs:         ol,
+	}, ol
+}
+
+type contextObserver struct {
+	zapcore.LevelEnabler
+	logs    *ObservedLogs
+	context []zapcore.Field
+}
+
+var (
+	_ zapcore.Core            = (*contextObserver)(nil)
+	_ internal.LeveledEnabler = (*contextObserver)(nil)
+)
+
+func (co *contextObserver) Level() zapcore.Level {
+	return zapcore.LevelOf(co.LevelEnabler)
+}
+
+func (co *contextObserver) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if co.Enabled(ent.Level) {
+		return ce.AddCore(ent, co)
+	}
+	return ce
+}
+
+func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
+	return &contextObserver{
+		LevelEnabler: co.LevelEnabler,
+		logs:         co.logs,
+		context:      append(co.context[:len(co.context):len(co.context)], fields...),
+	}
+}
+
+func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	all := make([]zapcore.Field, 0, len(fields)+len(co.context))
+	all = append(all, co.context...)
+	all = append(all, fields...)
+	co.logs.add(LoggedEntry{ent, all})
+	return nil
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1128,6 +1128,7 @@ go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
+go.uber.org/zap/zaptest/observer
 # go.yaml.in/yaml/v2 v2.4.4
 ## explicit; go 1.15
 go.yaml.in/yaml/v2


### PR DESCRIPTION
As part of WAF observability story, Istio must be configured with an extra extension provider that has the capability of capture the state/attributes issued by the WAF engine and ship to an external OTEL collector.

This external OTEL collector will then be responsible to assembling and consolidating the logs into metrics, to be provided later to WAF users.

For Istio, this is mostly a no-op operation. The extensionProvider is configured, but only consumed when a Telemetry resource is created targetting the Gateway and this provider. Additionally, the implementation is kept simple as it will need to be backported, but also it may be removed/migrated once GatewayAPI implements TelemetryPolicy with logging capabilities