### PR TITLE
OCPBUGS-112280: Preserve server-defaulted fields on init containers and volumes

### DIFF
--- a/pkg/operator/controller/ingress/deployment.go
+++ b/pkg/operator/controller/ingress/deployment.go
@@ -1697,23 +1697,7 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 	hashableDeployment.Spec.Template.Spec.NodeSelector = deployment.Spec.Template.Spec.NodeSelector
 	containers := make([]corev1.Container, len(deployment.Spec.Template.Spec.Containers))
 	for i, container := range deployment.Spec.Template.Spec.Containers {
-		env := container.Env
-		sort.Slice(env, func(i, j int) bool {
-			return env[i].Name < env[j].Name
-		})
-		containers[i] = corev1.Container{
-			Command:         container.Command,
-			Env:             env,
-			Image:           container.Image,
-			ImagePullPolicy: container.ImagePullPolicy,
-			Name:            container.Name,
-			LivenessProbe:   hashableProbe(container.LivenessProbe),
-			ReadinessProbe:  hashableProbe(container.ReadinessProbe),
-			StartupProbe:    hashableProbe(container.StartupProbe),
-			Resources:       container.Resources,
-			SecurityContext: container.SecurityContext,
-			Ports:           container.Ports,
-		}
+		containers[i] = hashableContainer(container, false)
 	}
 	sort.Slice(containers, func(i, j int) bool {
 		return containers[i].Name < containers[j].Name
@@ -1721,26 +1705,7 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 	hashableDeployment.Spec.Template.Spec.Containers = containers
 	initContainers := make([]corev1.Container, len(deployment.Spec.Template.Spec.InitContainers))
 	for i, initContainer := range deployment.Spec.Template.Spec.InitContainers {
-		env := initContainer.Env
-		sort.Slice(env, func(i, j int) bool {
-			return env[i].Name < env[j].Name
-		})
-		initContainers[i] = corev1.Container{
-			Args:            initContainer.Args,
-			Command:         initContainer.Command,
-			Env:             env,
-			Image:           initContainer.Image,
-			ImagePullPolicy: initContainer.ImagePullPolicy,
-			Name:            initContainer.Name,
-			LivenessProbe:   hashableProbe(initContainer.LivenessProbe),
-			ReadinessProbe:  hashableProbe(initContainer.ReadinessProbe),
-			StartupProbe:    hashableProbe(initContainer.StartupProbe),
-			SecurityContext: initContainer.SecurityContext,
-			Ports:           initContainer.Ports,
-			Resources:       initContainer.Resources,
-			RestartPolicy:   initContainer.RestartPolicy,
-			VolumeMounts:    initContainer.VolumeMounts,
-		}
+		initContainers[i] = hashableContainer(initContainer, true)
 	}
 	sort.Slice(initContainers, func(i, j int) bool {
 		return initContainers[i].Name < initContainers[j].Name
@@ -1760,6 +1725,26 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 		}
 		if vol.Secret != nil && vol.Secret.DefaultMode != nil && *vol.Secret.DefaultMode == int32(420) {
 			volumes[i].Secret.DefaultMode = nil
+		}
+		if vol.Projected != nil {
+			// 420 is the default value for DefaultMode for Projected volumes.
+			if vol.Projected.DefaultMode != nil && *vol.Projected.DefaultMode == int32(420) {
+				volumes[i].Projected.DefaultMode = nil
+			}
+			for _, source := range volumes[i].Projected.Sources {
+				// "v1" is the default value for FieldRef.APIVersion in DownwardAPI items.
+				if source.DownwardAPI != nil {
+					for _, item := range source.DownwardAPI.Items {
+						if item.FieldRef != nil && item.FieldRef.APIVersion == "v1" {
+							item.FieldRef.APIVersion = ""
+						}
+					}
+				}
+				// 3600 is the default value for ServiceAccountToken.ExpirationSeconds
+				if sat := source.ServiceAccountToken; sat != nil && sat.ExpirationSeconds != nil && *sat.ExpirationSeconds == 3600 {
+					sat.ExpirationSeconds = nil
+				}
+			}
 		}
 	}
 	sort.Slice(volumes, func(i, j int) bool {
@@ -1793,6 +1778,41 @@ func hashableDeployment(deployment *appsv1.Deployment, onlyTemplate bool) *appsv
 	hashableDeployment.Spec.Selector = deployment.Spec.Selector
 
 	return &hashableDeployment
+}
+
+// hashableContainer returns a copy of the given container containing only
+// the fields that should be used for computing the deployment hash. Keep
+// this in sync with copyContainer() — a field present here but missing
+// there is detected as changed but never actually applied.
+//
+// initContainer must be true for init containers: unlike the primary
+// router container, whose Args/Command users are allowed to customize by
+// hand, init containers are fully defined by the manifest, so their
+// Args/Command are also hashed/copied to keep them in sync with it.
+func hashableContainer(container corev1.Container, initContainer bool) corev1.Container {
+	env := container.Env
+	sort.Slice(env, func(i, j int) bool {
+		return env[i].Name < env[j].Name
+	})
+	hashContainer := corev1.Container{
+		Name:            container.Name,
+		Env:             env,
+		Image:           container.Image,
+		ImagePullPolicy: container.ImagePullPolicy,
+		LivenessProbe:   hashableProbe(container.LivenessProbe),
+		Ports:           container.Ports,
+		ReadinessProbe:  hashableProbe(container.ReadinessProbe),
+		Resources:       container.Resources,
+		RestartPolicy:   container.RestartPolicy,
+		SecurityContext: container.SecurityContext,
+		StartupProbe:    hashableProbe(container.StartupProbe),
+		VolumeMounts:    container.VolumeMounts,
+	}
+	if initContainer {
+		hashContainer.Args = container.Args
+		hashContainer.Command = container.Command
+	}
+	return hashContainer
 }
 
 // cmpMatchExpressions is a helper for hashableDeployment.
@@ -1933,7 +1953,17 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 		containers[i+1] = *container.DeepCopy()
 	}
 	updated.Spec.Template.Spec.Containers = containers
-	updated.Spec.Template.Spec.InitContainers = expected.Spec.Template.Spec.InitContainers
+
+	// Only overrides init containers if current does not have the expected size.
+	expectedInitContainersCount := len(expected.Spec.Template.Spec.InitContainers)
+	if len(updated.Spec.Template.Spec.InitContainers) != expectedInitContainersCount {
+		initContainers := make([]corev1.Container, len(expected.Spec.Template.Spec.InitContainers))
+		for i, initContainer := range expected.Spec.Template.Spec.InitContainers {
+			initContainers[i] = *initContainer.DeepCopy()
+		}
+		updated.Spec.Template.Spec.InitContainers = initContainers
+	}
+
 	updated.Spec.Template.Spec.AutomountServiceAccountToken = expected.Spec.Template.Spec.AutomountServiceAccountToken
 	updated.Spec.Template.Spec.ShareProcessNamespace = expected.Spec.Template.Spec.ShareProcessNamespace
 	updated.Spec.Template.Spec.DNSPolicy = expected.Spec.Template.Spec.DNSPolicy
@@ -1960,15 +1990,10 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	}
 	updated.Spec.Template.Spec.Volumes = volumes
 	updated.Spec.Template.Spec.NodeSelector = expected.Spec.Template.Spec.NodeSelector
-	updated.Spec.Template.Spec.Containers[0].SecurityContext = expected.Spec.Template.Spec.Containers[0].SecurityContext
-	updated.Spec.Template.Spec.Containers[0].Env = expected.Spec.Template.Spec.Containers[0].Env
-	updated.Spec.Template.Spec.Containers[0].Image = expected.Spec.Template.Spec.Containers[0].Image
-	copyProbe(expected.Spec.Template.Spec.Containers[0].LivenessProbe, updated.Spec.Template.Spec.Containers[0].LivenessProbe, true)
-	copyProbe(expected.Spec.Template.Spec.Containers[0].ReadinessProbe, updated.Spec.Template.Spec.Containers[0].ReadinessProbe, true)
-	copyProbe(expected.Spec.Template.Spec.Containers[0].StartupProbe, updated.Spec.Template.Spec.Containers[0].StartupProbe, true)
-	updated.Spec.Template.Spec.Containers[0].VolumeMounts = expected.Spec.Template.Spec.Containers[0].VolumeMounts
-	updated.Spec.Template.Spec.Containers[0].Resources = expected.Spec.Template.Spec.Containers[0].Resources
-	updated.Spec.Template.Spec.Containers[0].Ports = expected.Spec.Template.Spec.Containers[0].Ports
+	copyContainer(&updated.Spec.Template.Spec.Containers[0], &expected.Spec.Template.Spec.Containers[0], false)
+	for i := range expectedInitContainersCount {
+		copyContainer(&updated.Spec.Template.Spec.InitContainers[i], &expected.Spec.Template.Spec.InitContainers[i], true)
+	}
 	updated.Spec.Template.Spec.Tolerations = expected.Spec.Template.Spec.Tolerations
 	updated.Spec.Template.Spec.TopologySpreadConstraints = expected.Spec.Template.Spec.TopologySpreadConstraints
 	updated.Spec.Template.Spec.Affinity = expected.Spec.Template.Spec.Affinity
@@ -1979,6 +2004,32 @@ func deploymentConfigChanged(current, expected *appsv1.Deployment) (bool, *appsv
 	updated.Spec.Replicas = &replicas
 	updated.Spec.MinReadySeconds = expected.Spec.MinReadySeconds
 	return true, updated
+}
+
+// copyContainer copies container parameters that the operator manages.
+// Keep this in sync with hashableContainer() — a field present here but
+// missing there will not be detected as a change.
+//
+// initContainer must be true for init containers: unlike the primary
+// router container, whose Args/Command users are allowed to customize by
+// hand, init containers are fully defined by the manifest, so their
+// Args/Command are also hashed/copied to keep them in sync with it.
+func copyContainer(to, from *corev1.Container, initContainer bool) {
+	if initContainer {
+		to.Args = from.Args
+		to.Command = from.Command
+	}
+	to.Env = from.Env
+	to.Image = from.Image
+	to.ImagePullPolicy = from.ImagePullPolicy
+	copyProbe(from.LivenessProbe, to.LivenessProbe, true)
+	to.Ports = from.Ports
+	copyProbe(from.ReadinessProbe, to.ReadinessProbe, true)
+	to.Resources = from.Resources
+	to.RestartPolicy = from.RestartPolicy
+	to.SecurityContext = from.SecurityContext
+	copyProbe(from.StartupProbe, to.StartupProbe, true)
+	to.VolumeMounts = from.VolumeMounts
 }
 
 // copyProbe copies probe parameters that the operator manages from probe a to

--- a/pkg/operator/controller/ingress/deployment_test.go
+++ b/pkg/operator/controller/ingress/deployment_test.go
@@ -2015,6 +2015,38 @@ func TestDeploymentHash(t *testing.T) {
 			expectDeploymentHashChanged: true,
 			expectTemplateHashChanged:   true,
 		},
+		{
+			description: "if volume mounts are changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      "shared",
+					MountPath: "/tmp/shared",
+				}}
+			},
+			expectDeploymentHashChanged: true,
+			expectTemplateHashChanged:   true,
+		},
+		{
+			description: "if projected volume downwardAPI fieldRef.apiVersion is defaulted to v1",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[1].DownwardAPI.Items[0].FieldRef.APIVersion = "v1"
+			},
+		},
+		{
+			description: "if projected volume defaultMode is defaulted to 420",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes[0].Projected.DefaultMode = ptr.To[int32](420)
+			},
+		},
+		{
+			description: "if projected volume serviceAccountToken expirationSeconds is defaulted to 3600",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[0].ServiceAccountToken = &corev1.ServiceAccountTokenProjection{
+					ExpirationSeconds: ptr.To[int64](3600),
+					Path:              "token",
+				}
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2036,6 +2068,34 @@ func TestDeploymentHash(t *testing.T) {
 										{ContainerPort: 80},
 										{ContainerPort: 443},
 										{ContainerPort: 1936},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: routerServiceAccountVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Path: "token",
+													},
+												},
+												{
+													DownwardAPI: &corev1.DownwardAPIProjection{
+														Items: []corev1.DownwardAPIVolumeFile{
+															{
+																Path: "namespace",
+																FieldRef: &corev1.ObjectFieldSelector{
+																	FieldPath: "metadata.namespace",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
 									},
 								},
 							},
@@ -2065,8 +2125,10 @@ func Test_deploymentConfigChanged(t *testing.T) {
 	pointerTo := func(ios intstr.IntOrString) *intstr.IntOrString { return &ios }
 	testCases := []struct {
 		description string
-		mutate      func(*appsv1.Deployment)
+		mutateCurr  func(*appsv1.Deployment) // current, coming from live deployment
+		mutate      func(*appsv1.Deployment) // expected, coming from desired deployment
 		expect      bool
+		assert      func(*testing.T, *appsv1.Deployment)
 	}{
 		{
 			description: "if nothing changes",
@@ -2272,9 +2334,58 @@ func Test_deploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the init container resources is changed",
+			description: "if the container args is changed",
 			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.InitContainers[0].Resources = corev1.ResourceRequirements{
+				deployment.Spec.Template.Spec.Containers[0].Args = []string{"--version"}
+			},
+			expect: false,
+		},
+		{
+			description: "if the container command is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.Containers[0].Command = []string{"bash", "-c", "sleep 1"}
+			},
+			expect: false,
+		},
+		{
+			description: "if the init container args is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Args = []string{"--version"}
+			},
+			expect: true,
+		},
+		{
+			description: "if the init container command is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Command = []string{"bash", "-c", "sleep 1"}
+			},
+			expect: true,
+		},
+		{
+			description: "if the init container restart policy is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].RestartPolicy = ptr.To(corev1.ContainerRestartPolicyNever)
+			},
+			expect: true,
+		},
+		{
+			description: "if the init container image is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Image = "openshift/init:latest"
+			},
+			expect: true,
+		},
+		{
+			description: "if the sidecar container image is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[1].Image = "openshift/haproxy-v28:latest"
+			},
+			expect: true,
+		},
+		{
+			description: "if the sidecar container resources is changed",
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[1].Resources = corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("200m"),
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -2284,11 +2395,60 @@ func Test_deploymentConfigChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the sidecar container image is changed",
-			mutate: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Template.Spec.InitContainers[0].Image = "openshift/haproxy-v28:latest"
+			description: "if the current init container slice is missing from an upgrade",
+			mutateCurr: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers = nil
 			},
 			expect: true,
+			assert: func(t *testing.T, deployment *appsv1.Deployment) {
+				assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 2)
+			},
+		},
+		{
+			description: "if the current init container slice is missing a container",
+			mutateCurr: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers = deployment.Spec.Template.Spec.InitContainers[:1]
+			},
+			expect: true,
+			assert: func(t *testing.T, deployment *appsv1.Deployment) {
+				assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 2)
+			},
+		},
+		{
+			description: "if the current init container slice has a 3rd container",
+			mutateCurr: func(deployment *appsv1.Deployment) {
+				container := corev1.Container{}
+				deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, container)
+			},
+			expect: true,
+			assert: func(t *testing.T, deployment *appsv1.Deployment) {
+				assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 2)
+			},
+		},
+		{
+			description: "if the init container k8s-defaulted fields are preserved during an update",
+			mutateCurr: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePath = "/dev/termination-log"
+				deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+			},
+			mutate: func(deployment *appsv1.Deployment) {
+				deployment.Spec.Template.Spec.InitContainers[0].Image = "openshift/init:latest"
+			},
+			expect: true,
+			assert: func(t *testing.T, deployment *appsv1.Deployment) {
+				assert.Equal(t, "/dev/termination-log", deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePath)
+				assert.Equal(t, corev1.TerminationMessageReadFile, deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePolicy)
+				assert.Equal(t, "openshift/init:latest", deployment.Spec.Template.Spec.InitContainers[0].Image)
+			},
+		},
+		{
+			description: "if the init container k8s-defaulted fields are preserved",
+			mutateCurr: func(deployment *appsv1.Deployment) {
+				// Simulate what k8s injects on save
+				deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePath = "/dev/termination-log"
+				deployment.Spec.Template.Spec.InitContainers[0].TerminationMessagePolicy = corev1.TerminationMessageReadFile
+			},
+			expect: false, // k8s-defaulted fields are not operator-managed, no change expected
 		},
 		{
 			description: "if the volumes change ordering",
@@ -2702,6 +2862,9 @@ func Test_deploymentConfigChanged(t *testing.T) {
 							},
 							InitContainers: []corev1.Container{
 								{
+									Image: "openshift/origin-cluster-ingress-operator-init:v4.0",
+								},
+								{
 									Image: "openshift/haproxy-v28:v4.0",
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
@@ -2797,17 +2960,27 @@ func Test_deploymentConfigChanged(t *testing.T) {
 					Replicas: &nineteen,
 				},
 			}
+			current := original.DeepCopy()
 			mutated := original.DeepCopy()
-			tc.mutate(mutated)
-			if changed, updated := deploymentConfigChanged(&original, mutated); changed != tc.expect {
+			if tc.mutateCurr != nil {
+				tc.mutateCurr(current)
+			}
+			if tc.mutate != nil {
+				tc.mutate(mutated)
+			}
+			changed, updated := deploymentConfigChanged(current, mutated)
+			if changed != tc.expect {
 				t.Errorf("expect deploymentConfigChanged to be %t, got %t", tc.expect, changed)
 			} else if changed {
-				if updatedChanged, _ := deploymentConfigChanged(&original, updated); !updatedChanged {
+				if updatedChanged, _ := deploymentConfigChanged(current, updated); !updatedChanged {
 					t.Error("deploymentConfigChanged reported changes but did not make any update")
 				}
 				if changedAgain, _ := deploymentConfigChanged(mutated, updated); changedAgain {
 					t.Error("deploymentConfigChanged does not behave as a fixed point function")
 				}
+			}
+			if tc.assert != nil {
+				tc.assert(t, updated)
 			}
 		})
 	}


### PR DESCRIPTION
deploymentConfigChanged() replaced InitContainers wholesale with the desired/expected value on every update, which reverts fields the API server defaults on the live object (e.g. TerminationMessagePath) and produces a noisy, misleading diff in the update log on every unrelated change. The primary container already avoided this by copying from current and selectively overlaying only the fields the operator manages; extract that logic into copyContainer() and apply it to every init container as well, syncing by index up to the length of the desired slice so any container beyond the two static ones (init-router, haproxy) still gets synced.

Since current is a live object, its InitContainers slice can differ in length from what's expected (e.g. right after an upgrade, or if it was manually edited). Guard against that by falling back to a verbatim copy of the desired InitContainers whenever the lengths don't match, before doing the selective per-field copy, so a mismatched live deployment self-heals instead of panicking on an out-of-range index.

hashableDeployment() built the hashable Containers and InitContainers independently, and the two had drifted: InitContainers included Args, RestartPolicy and VolumeMounts in the hash while Containers didn't, and neither hashed exactly the set of fields copyContainer() applies. That mismatch is exactly what caused the InitContainers bug above, and it silently allows the same failure to recur one field at a time. Extract the shared logic into hashableContainer(), used for both Containers and InitContainers, with a field list kept in sync with copyContainer() by a comment in each pointing at the other, so a field added to one and not the other fails loudly (detected as changed but never applied) instead of silently.

hashableDeployment() has the same class of issue for the projected service-account-token volume: DefaultMode and the DownwardAPI FieldRef.APIVersion are also defaulted by the API server, and were already handled for ConfigMap/Secret volumes but not for Projected ones, causing spurious hash mismatches. Normalize them the same way.

https://redhat.atlassian.net/browse/OCPBUGS-112280