### PR TITLE
OCPBUGS-91026: Add missing KAS-defaulted fields to ValidatingAdmissionPolicy manifest

### DIFF
--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -14,7 +14,7 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE","DELETE"]
       resources:   ["customresourcedefinitions"]
-      scope: “*”
+      scope: "*"
     matchPolicy: Equivalent
     namespaceSelector: {}
     objectSelector: {}

--- a/manifests/01-validating-admission-policy.yaml
+++ b/manifests/01-validating-admission-policy.yaml
@@ -14,6 +14,10 @@ spec:
       apiVersions: ["v1"]
       operations:  ["CREATE","UPDATE","DELETE"]
       resources:   ["customresourcedefinitions"]
+      scope: “*”
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
   matchConditions:
     # Consider only request to Gateway API CRDs.
     - name: "check-only-gateway-api-crds"


### PR DESCRIPTION
Add matchPolicy, namespaceSelector, objectSelector, and scope to manifests/01-validating-admission-policy.yaml. These fields are injected as defaults by the API server, causing CVO to detect a diff on every reconciliation cycle and update loop indefinitely.