### PR TITLE
OCPBUGS-105398: refactor: remove Azure workload identity feature gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,6 @@ Defined as constants in `pkg/operator/controller/names.go`:
 Controllers check these feature gates (from `github.com/openshift/api/features`):
 - `features.FeatureGateGatewayAPI` — Gateway API support
 - `features.FeatureGateGatewayAPIController` — Gateway API controller
-- `features.FeatureGateAzureWorkloadIdentity` — Azure workload identity
 - `features.FeatureGateIngressControllerDynamicConfigurationManager` — Dynamic configuration management
 - `features.FeatureGateRouteExternalCertificate` — External route certificates (being removed)
 

--- a/pkg/dns/azure/client/auth.go
+++ b/pkg/dns/azure/client/auth.go
@@ -65,7 +65,7 @@ func getAzureCredentials(config Config) (azcore.TokenCredential, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if config.AzureWorkloadIdentityEnabled && strings.TrimSpace(config.ClientSecret) == "" {
+	} else if strings.TrimSpace(config.ClientSecret) == "" {
 		options := azidentity.WorkloadIdentityCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
 				Cloud:     cloudConfig,

--- a/pkg/dns/azure/client/client.go
+++ b/pkg/dns/azure/client/client.go
@@ -40,15 +40,11 @@ type Config struct {
 	// if Azure workload identity is not used.
 	ClientSecret string
 	// FederatedTokenFile is the path to a file containing a workload
-	// identity token.  If FederatedTokenFile is specified and
-	// AzureWorkloadIdentityEnabled is true, then Azure workload identity is
-	// used instead of using a client secret.
+	// identity token. If no client secret is available, Azure workload
+	// identity is used instead.
 	FederatedTokenFile string
 	// TenantID is the Azure tenant ID.
 	TenantID string
-	// AzureWorkloadIdentityEnabled indicates whether the
-	// "AzureWorkloadIdentity" feature gate is enabled.
-	AzureWorkloadIdentityEnabled bool
 }
 
 // ARecord is a DNS A record.

--- a/pkg/dns/azure/dns.go
+++ b/pkg/dns/azure/dns.go
@@ -61,7 +61,7 @@ type provider struct {
 
 // NewProvider creates a new dns.Provider for Azure. It only supports DNSRecords with
 // type A.
-func NewProvider(config Config, AzureWorkloadIdentityEnabled bool) (dns.Provider, error) {
+func NewProvider(config Config) (dns.Provider, error) {
 	var env azure.Environment
 	var err error
 	switch config.Environment {
@@ -74,13 +74,12 @@ func NewProvider(config Config, AzureWorkloadIdentityEnabled bool) (dns.Provider
 		return nil, fmt.Errorf("could not determine cloud environment: %w", err)
 	}
 	c, err := client.New(client.Config{
-		Environment:                  env,
-		SubscriptionID:               config.SubscriptionID,
-		ClientID:                     config.ClientID,
-		ClientSecret:                 config.ClientSecret,
-		FederatedTokenFile:           config.FederatedTokenFile,
-		TenantID:                     config.TenantID,
-		AzureWorkloadIdentityEnabled: AzureWorkloadIdentityEnabled,
+		Environment:        env,
+		SubscriptionID:     config.SubscriptionID,
+		ClientID:           config.ClientID,
+		ClientSecret:       config.ClientSecret,
+		FederatedTokenFile: config.FederatedTokenFile,
+		TenantID:           config.TenantID,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/operator/controller/dns/controller.go
+++ b/pkg/operator/controller/dns/controller.go
@@ -130,10 +130,9 @@ func indexDNSRecords(o client.Object) []string {
 
 // Config holds all the things necessary for the controller to run.
 type Config struct {
-	CredentialsRequestNamespace  string
-	DNSRecordNamespaces          []string
-	OperatorReleaseVersion       string
-	AzureWorkloadIdentityEnabled bool
+	CredentialsRequestNamespace string
+	DNSRecordNamespaces         []string
+	OperatorReleaseVersion      string
 }
 
 type reconciler struct {
@@ -276,7 +275,7 @@ func (r *reconciler) createDNSProviderIfNeeded(dnsConfig *configv1.DNS, record *
 	}
 
 	if needUpdate {
-		dnsProvider, err := r.createDNSProvider(dnsConfig, platformStatus, &infraConfig.Status, creds, r.config.AzureWorkloadIdentityEnabled)
+		dnsProvider, err := r.createDNSProvider(dnsConfig, platformStatus, &infraConfig.Status, creds)
 		if err != nil {
 			return fmt.Errorf("failed to create DNS provider: %v", err)
 		}
@@ -740,7 +739,7 @@ func (r *reconciler) mapOnRecordDelete(ctx context.Context, o client.Object) []r
 
 // createDNSProvider creates a DNS manager compatible with the given cluster
 // configuration.
-func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *configv1.PlatformStatus, infraStatus *configv1.InfrastructureStatus, creds *corev1.Secret, AzureWorkloadIdentityEnabled bool) (dns.Provider, error) {
+func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *configv1.PlatformStatus, infraStatus *configv1.InfrastructureStatus, creds *corev1.Secret) (dns.Provider, error) {
 	// If no DNS configuration is provided, don't try to set up provider clients.
 	// TODO: the provider configuration can be refactored into the provider
 	// implementations themselves, so this part of the code won't need to
@@ -854,7 +853,7 @@ func (r *reconciler) createDNSProvider(dnsConfig *configv1.DNS, platformStatus *
 			ARMEndpoint:    platformStatus.Azure.ARMEndpoint,
 			InfraID:        infraStatus.InfrastructureName,
 			Tags:           azuredns.GetTagList(infraStatus),
-		}, AzureWorkloadIdentityEnabled)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Azure DNS manager: %v", err)
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -138,7 +138,6 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 	if err != nil {
 		return nil, err
 	}
-	azureWorkloadIdentityEnabled := featureGates.Enabled(features.FeatureGateAzureWorkloadIdentity)
 	gatewayAPIWithoutOLMEnabled := featureGates.Enabled(features.FeatureGateGatewayAPIWithoutOLM)
 	ingressControllerDCMEnabled := featureGates.Enabled(features.FeatureGateIngressControllerDynamicConfigurationManager)
 	featureMultiHAProxyEnabled := featureGates.Enabled(features.FeatureGateIngressControllerMultipleHAProxyVersions)
@@ -287,8 +286,7 @@ func New(config operatorconfig.Config, kubeConfig *rest.Config) (*Operator, erro
 			config.Namespace,
 			operatorcontroller.DefaultOperandNamespace,
 		},
-		OperatorReleaseVersion:       config.OperatorReleaseVersion,
-		AzureWorkloadIdentityEnabled: azureWorkloadIdentityEnabled,
+		OperatorReleaseVersion: config.OperatorReleaseVersion,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create dns controller: %v", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Removes the `AzureWorkloadIdentity` feature-gate dependency from the
cluster ingress operator.

The feature is GA and enabled by default, so the previously gated Azure
workload identity behavior is now unconditional when no client secret is
available.

Changes include:
- Removing feature-gate observation and configuration plumbing.
- Removing the Azure DNS provider/client boolean parameter.
- Using workload identity whenever the Azure client secret is empty.

## Why is this needed?

This must merge before `openshift/api#3018`, which removes the feature-gate
definition. Remaining `.Enabled()` consumers would panic once the gate is
removed from the cluster-served feature-gate list.

Related:
- openshift/api#3018
