### PR TITLE
OCPBUGS-114344: Detect unexpected router deployment updates

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -2111,8 +2112,15 @@ func TestNodePortServiceEndpointPublishingStrategy(t *testing.T) {
 	}
 	err := waitForIngressControllerCondition(t, kclient, 5*time.Minute, name, conditions...)
 	if err != nil {
-		t.Errorf("failed to observe expected conditions: %v", err)
+		t.Fatalf("failed to observe expected conditions: %v", err)
 	}
+
+	// Capture the deployment's state now so we can assert the Ingress Controller
+	// deployment wasn't updated during the lifetime of the test. 5s is a heuristic
+	// margin for the ingress controller to react after the last Service update.
+	captured, err := captureObject(context.Background(), &appsv1.Deployment{}, controller.RouterDeploymentName(ing))
+	require.NoError(t, err)
+	defer captured.verifyGeneration(context.Background(), t, 5*time.Second)
 
 	// Make sure the ingresscontroller has a nodeport service
 	// with the expected ports.

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -22,6 +22,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/cluster-ingress-operator/pkg/operator/controller"
+	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -848,6 +849,46 @@ func updateInfrastructureConfigStatusWithRetryOnConflict(t *testing.T, timeout t
 		}
 		return true, nil
 	})
+}
+
+// capturedObject stores the state of an object. The stored state can be
+// verified later against the live one.
+type capturedObject struct {
+	previous client.Object
+}
+
+// captureObject records the current state of an object for a later check.
+func captureObject(ctx context.Context, typ client.Object, name types.NamespacedName) (*capturedObject, error) {
+	obj := typ.DeepCopyObject().(client.Object)
+	if err := kclient.Get(ctx, name, obj); err != nil {
+		return nil, fmt.Errorf("error reading current state: %w", err)
+	}
+	return &capturedObject{
+		previous: obj,
+	}, nil
+}
+
+// verifyGeneration verifies that the object's generation is unchanged. It waits
+// `verifyAfter` before checking, to give asynchronous writers (e.g. a controller
+// reconcile loop) a chance to persist a change.
+//
+// This is a best-effort check: it only detects a change happening within
+// `verifyAfter` of the method call. A write queued behind a longer requeue/backoff
+// will not be caught. Choose `verifyAfter` based on the reconcile path under test
+// (e.g. a multiple of its expected requeue delay), and treat a pass as "no churn
+// observed within N seconds", not "no churn is possible".
+func (g *capturedObject) verifyGeneration(ctx context.Context, t *testing.T, verifyAfter time.Duration) {
+	t.Helper()
+
+	// Allow asynchronous writers to persist their changes before checking.
+	time.Sleep(verifyAfter)
+
+	current := g.previous.DeepCopyObject().(client.Object)
+	err := kclient.Get(ctx, client.ObjectKeyFromObject(g.previous), current)
+	require.NoError(t, err, "error reading object for generation check")
+	require.Equal(t, g.previous.GetGeneration(), current.GetGeneration(),
+		"generation from %T %s/%s unexpectedly changed; previous: %+v; current: %+v",
+		current, current.GetNamespace(), current.GetName(), g.previous, current)
 }
 
 // createWithRetryOnError creates the given object. If there is an error on create


### PR DESCRIPTION
Once an ingresscontroller reports Available, its router deployment should stay untouched unless something explicitly needs to change it. There was no way to catch a regression that causes the operator to needlessly re-trigger a deployment update after readiness, e.g. a spurious rollout in reaction to an unrelated change to a dependent resource, or a misconfigured deployment hash after adding new fields in the deployment manifest.

Add generic captureObject/verifyGeneration helpers in util_test.go: snapshot an object's generation once the ingresscontroller is ready, then, after exercising the scenario under test, wait briefly for any async reconcile to land and assert the generation didn't change. Generation (rather than resource version) is used so status-only updates don't cause false failures.

https://redhat.atlassian.net/browse/OCPBUGS-114344